### PR TITLE
Group H: Mentions adapter for @mention artifact stripping

### DIFF
--- a/ADAPTER_PARITY.md
+++ b/ADAPTER_PARITY.md
@@ -1,0 +1,1 @@
+~/.claude-sneakpeek/claudesp/config/plans/ticklish-Amplifying-music.md

--- a/ADAPTER_PARITY.md
+++ b/ADAPTER_PARITY.md
@@ -1,1 +1,0 @@
-~/.claude-sneakpeek/claudesp/config/plans/ticklish-Amplifying-music.md

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,8 @@ const plugin = {
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     setBasecampRuntime(api.runtime);
+    // Cast required: SDK's registerChannel expects ChannelPlugin<unknown> but
+    // our concrete Probe/Audit type params are contravariant with unknown.
     api.registerChannel({ plugin: basecampChannel as any });
     api.registerHttpRoute({
       path: "/webhooks/basecamp",

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ const plugin = {
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     setBasecampRuntime(api.runtime);
-    api.registerChannel({ plugin: basecampChannel });
+    api.registerChannel({ plugin: basecampChannel as any });
     api.registerHttpRoute({
       path: "/webhooks/basecamp",
       handler: handleBasecampWebhook,

--- a/src/adapters/agent-prompt.ts
+++ b/src/adapters/agent-prompt.ts
@@ -1,0 +1,26 @@
+/**
+ * Basecamp agent prompt adapter — channel-specific context hints for agents.
+ *
+ * Provides Basecamp-specific guidance to agents about peer ID formats,
+ * mention conventions, threading model, surface types, and reactions.
+ */
+
+import type { ChannelPlugin } from "openclaw/plugin-sdk";
+import type { ResolvedBasecampAccount } from "../types.js";
+
+// ChannelAgentPromptAdapter is not exported from the SDK, so extract it from ChannelPlugin.
+type AgentPromptAdapter = NonNullable<ChannelPlugin<ResolvedBasecampAccount>["agentPrompt"]>;
+
+export const basecampAgentPromptAdapter: AgentPromptAdapter = {
+  messageToolHints: () => [
+    "Basecamp peer IDs use the format recording:<id>, bucket:<id>, or ping:<id>.",
+    "To @mention someone in Basecamp, use their bc-attachment SGID tag.",
+    "Basecamp comments are flat per recording — there are no nested threads.",
+    "Basecamp surfaces include: Campfire (real-time chat), Card Table (kanban), " +
+      "Todo List, Check-in (recurring questions), Ping (direct messages), " +
+      "Message Board, and Documents.",
+    "Basecamp supports boost reactions on recordings.",
+    "Campfire messages and Ping messages are delivered as chat lines. " +
+      "All other surfaces receive comments on the recording.",
+  ],
+};

--- a/src/adapters/directory.ts
+++ b/src/adapters/directory.ts
@@ -54,19 +54,18 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
       entries.push({ kind: "user", id, name: undefined });
     }
 
-    // Include all account personIds
+    // Include all account personIds (use Set for O(1) dedup)
+    const seenIds = new Set(entries.map((e) => e.id));
     const accounts = section?.accounts;
     if (accounts) {
       for (const acct of Object.values(accounts)) {
-        if (acct.personId) {
-          const existing = entries.find((e) => e.id === acct.personId);
-          if (!existing) {
-            entries.push({
-              kind: "user",
-              id: acct.personId,
-              name: acct.displayName,
-            });
-          }
+        if (acct.personId && !seenIds.has(acct.personId)) {
+          seenIds.add(acct.personId);
+          entries.push({
+            kind: "user",
+            id: acct.personId,
+            name: acct.displayName,
+          });
         }
       }
     }

--- a/src/adapters/directory.ts
+++ b/src/adapters/directory.ts
@@ -1,0 +1,183 @@
+/**
+ * Basecamp directory adapter — people & project discovery.
+ *
+ * Implements ChannelDirectoryAdapter for `openclaw channels resolve`,
+ * agent targeting, and people/project lookup via bcq.
+ */
+
+import type { ChannelDirectoryAdapter, ChannelDirectoryEntry, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ResolvedBasecampAccount, BasecampPerson, BasecampProject, BasecampChannelConfig } from "../types.js";
+import { resolveBasecampAccount } from "../config.js";
+import { bcqMe, bcqApiGet } from "../bcq.js";
+
+function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
+  return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+}
+
+function bcqOptsForAccount(account: ResolvedBasecampAccount) {
+  return {
+    accountId: account.config.bcqAccountId,
+    profile: account.bcqProfile,
+  };
+}
+
+export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
+  self: async ({ cfg, accountId }) => {
+    const account = resolveBasecampAccount(cfg, accountId);
+    if (!account.bcqProfile && !account.token) return null;
+
+    try {
+      const me = await bcqMe({
+        profile: account.bcqProfile,
+        accountId: account.config.bcqAccountId,
+      });
+      const data = me.data as { id: number; name: string; email_address: string };
+      return {
+        kind: "user" as const,
+        id: String(data.id),
+        name: data.name,
+        handle: data.email_address,
+      };
+    } catch {
+      return null;
+    }
+  },
+
+  listPeers: async ({ cfg }) => {
+    const section = getBasecampSection(cfg);
+    const entries: ChannelDirectoryEntry[] = [];
+
+    // Include allowFrom person IDs as known peers
+    const allowFrom = section?.allowFrom ?? [];
+    for (const entry of allowFrom) {
+      const id = String(entry);
+      entries.push({ kind: "user", id, name: undefined });
+    }
+
+    // Include all account personIds
+    const accounts = section?.accounts;
+    if (accounts) {
+      for (const acct of Object.values(accounts)) {
+        if (acct.personId) {
+          const existing = entries.find((e) => e.id === acct.personId);
+          if (!existing) {
+            entries.push({
+              kind: "user",
+              id: acct.personId,
+              name: acct.displayName,
+            });
+          }
+        }
+      }
+    }
+
+    return entries;
+  },
+
+  listPeersLive: async ({ cfg, accountId, query }) => {
+    const account = resolveBasecampAccount(cfg, accountId);
+    const opts = bcqOptsForAccount(account);
+
+    let people: BasecampPerson[];
+    try {
+      people = await bcqApiGet<BasecampPerson[]>("/people.json", opts.accountId, opts.profile);
+    } catch {
+      return [];
+    }
+
+    if (!Array.isArray(people)) return [];
+
+    let filtered = people;
+    if (query) {
+      const q = query.toLowerCase();
+      filtered = people.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          p.email_address.toLowerCase().includes(q),
+      );
+    }
+
+    return filtered.map((p) => ({
+      kind: "user" as const,
+      id: String(p.id),
+      name: p.name,
+      handle: p.email_address,
+      avatarUrl: p.avatar_url,
+    }));
+  },
+
+  listGroups: async ({ cfg }) => {
+    const section = getBasecampSection(cfg);
+    const entries: ChannelDirectoryEntry[] = [];
+
+    // Include virtual account (project-scope) entries as groups
+    const virtualAccounts = section?.virtualAccounts;
+    if (virtualAccounts) {
+      for (const [key, va] of Object.entries(virtualAccounts)) {
+        entries.push({
+          kind: "group",
+          id: `bucket:${va.bucketId}`,
+          name: key,
+        });
+      }
+    }
+
+    return entries;
+  },
+
+  listGroupsLive: async ({ cfg, accountId, query }) => {
+    const account = resolveBasecampAccount(cfg, accountId);
+    const opts = bcqOptsForAccount(account);
+
+    let projects: BasecampProject[];
+    try {
+      projects = await bcqApiGet<BasecampProject[]>("/projects.json", opts.accountId, opts.profile);
+    } catch {
+      return [];
+    }
+
+    if (!Array.isArray(projects)) return [];
+
+    let filtered = projects;
+    if (query) {
+      const q = query.toLowerCase();
+      filtered = projects.filter((p) => p.name.toLowerCase().includes(q));
+    }
+
+    return filtered.map((p) => ({
+      kind: "group" as const,
+      id: `bucket:${p.id}`,
+      name: p.name,
+    }));
+  },
+
+  listGroupMembers: async ({ cfg, accountId, groupId }) => {
+    const bucketMatch = groupId.match(/^bucket:(\d+)$/);
+    if (!bucketMatch) return [];
+
+    const bucketId = bucketMatch[1];
+    const account = resolveBasecampAccount(cfg, accountId);
+    const opts = bcqOptsForAccount(account);
+
+    let people: BasecampPerson[];
+    try {
+      people = await bcqApiGet<BasecampPerson[]>(
+        `/buckets/${bucketId}/people.json`,
+        opts.accountId,
+        opts.profile,
+      );
+    } catch {
+      return [];
+    }
+
+    if (!Array.isArray(people)) return [];
+
+    return people.map((p) => ({
+      kind: "user" as const,
+      id: String(p.id),
+      name: p.name,
+      handle: p.email_address,
+      avatarUrl: p.avatar_url,
+    }));
+  },
+};

--- a/src/adapters/groups.ts
+++ b/src/adapters/groups.ts
@@ -1,0 +1,64 @@
+/**
+ * Basecamp groups adapter — per-bucket behavior configuration.
+ *
+ * Implements ChannelGroupAdapter for resolving requireMention, tool policies,
+ * and group intro hints on a per-project (bucket) basis.
+ */
+
+import type { ChannelGroupAdapter, ChannelGroupContext } from "openclaw/plugin-sdk";
+import type { BasecampChannelConfig, BasecampBucketConfig } from "../types.js";
+
+function getBasecampSection(cfg: Record<string, unknown>): BasecampChannelConfig | undefined {
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  return channels?.basecamp as BasecampChannelConfig | undefined;
+}
+
+/**
+ * Resolve bucket config: exact bucket ID match, then "*" wildcard fallback.
+ */
+export function resolveBasecampBucketConfig(
+  cfg: Record<string, unknown>,
+  bucketId: string | undefined,
+): BasecampBucketConfig | undefined {
+  const section = getBasecampSection(cfg);
+  const buckets = section?.buckets;
+  if (!buckets) return undefined;
+
+  // Exact match
+  if (bucketId && buckets[bucketId]) {
+    return buckets[bucketId];
+  }
+
+  // Wildcard fallback
+  return buckets["*"];
+}
+
+function extractBucketId(groupId?: string | null): string | undefined {
+  if (!groupId) return undefined;
+  // groupId may be "bucket:123" or just a recording peer — extract bucket from context
+  const match = groupId.match(/^bucket:(\d+)$/);
+  return match ? match[1] : undefined;
+}
+
+export const basecampGroupAdapter: ChannelGroupAdapter = {
+  resolveRequireMention: ({ cfg, groupId }) => {
+    const bucketId = extractBucketId(groupId);
+    const bucketCfg = resolveBasecampBucketConfig(cfg as Record<string, unknown>, bucketId);
+    return bucketCfg?.requireMention;
+  },
+
+  resolveToolPolicy: ({ cfg, groupId }) => {
+    const bucketId = extractBucketId(groupId);
+    const bucketCfg = resolveBasecampBucketConfig(cfg as Record<string, unknown>, bucketId);
+    if (!bucketCfg?.tools) return undefined;
+    return {
+      allow: bucketCfg.tools.allow,
+      deny: bucketCfg.tools.deny,
+    };
+  },
+
+  resolveGroupIntroHint: () =>
+    "This is a Basecamp project. Conversations happen across Campfire chats, " +
+    "card tables, to-do lists, check-ins, message boards, and documents. " +
+    "Use recording:<id>, bucket:<id>, or ping:<id> to reference Basecamp resources.",
+};

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -1,0 +1,184 @@
+/**
+ * Basecamp hatch adapter — interactive wizard for provisioning new service identities.
+ *
+ * Walks the user through selecting a bcq profile, discovering their Basecamp
+ * identity, choosing an account key, and optionally mapping to an agent persona.
+ *
+ * This is not a formal SDK adapter (no ChannelHatchAdapter interface exists);
+ * it's a standalone wizard function called from the onboarding adapter.
+ */
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { normalizeAccountId } from "openclaw/plugin-sdk";
+import type { BasecampChannelConfig } from "../types.js";
+import { bcqMe, bcqProfileList } from "../bcq.js";
+import { listBasecampAccountIds } from "../config.js";
+
+type WizardPrompter = {
+  select: (opts: { message: string; options: Array<{ value: string; label: string }>; initialValue?: string }) => Promise<string>;
+  text: (opts: { message: string; validate?: (value: string | undefined) => string | undefined }) => Promise<string>;
+  note: (message: string, title?: string) => Promise<void>;
+};
+
+function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
+  return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+}
+
+export type HatchResult = {
+  cfg: OpenClawConfig;
+  accountId: string;
+  personId: string;
+  personaMapping?: { agentId: string; accountId: string };
+};
+
+/**
+ * Run the hatch identity wizard.
+ *
+ * Steps:
+ * 1. List bcq profiles — select existing or prompt to create
+ * 2. Call bcqMe — enumerate Basecamp accounts, select one
+ * 3. Resolve identity — personId, name, attachableSgid; confirm with user
+ * 4. Assign account ID key — prompt, validate uniqueness
+ * 5. Optionally map to agent persona
+ * 6. Apply config
+ */
+export async function hatchIdentity(
+  cfg: OpenClawConfig,
+  prompter: WizardPrompter,
+): Promise<HatchResult> {
+  // Step 1: List bcq profiles
+  let profileNames: string[] = [];
+  try {
+    const result = await bcqProfileList();
+    profileNames = result.data;
+  } catch {
+    // bcq not available
+  }
+
+  let selectedProfile: string | undefined;
+  if (profileNames.length > 1) {
+    const choice = await prompter.select({
+      message: "Select bcq profile for the new identity",
+      options: [
+        ...profileNames.map((name) => ({ value: name, label: name })),
+        { value: "__none__", label: "Use default (no profile)" },
+      ],
+    });
+    selectedProfile = choice === "__none__" ? undefined : choice;
+  } else if (profileNames.length === 1) {
+    selectedProfile = profileNames[0];
+  }
+
+  // Step 2: Call bcqMe to get identity
+  type BcqAccount = { id: number; name: string };
+  let meIdentity: { id: number; name: string; email_address: string; attachable_sgid?: string } | undefined;
+  let bcqAccountId: string | undefined;
+
+  try {
+    const meResult = await bcqMe(selectedProfile ? { profile: selectedProfile } : {});
+    const data = meResult.data as unknown as {
+      identity?: { id: number; name: string; email_address: string; attachable_sgid?: string };
+      accounts?: BcqAccount[];
+    };
+    meIdentity = data.identity ?? (meResult.data as any);
+
+    const accounts = data.accounts ?? [];
+    if (accounts.length > 1) {
+      bcqAccountId = await prompter.select({
+        message: "Basecamp account for this identity",
+        options: accounts.map((a) => ({
+          value: String(a.id),
+          label: `${a.name} (${a.id})`,
+        })),
+      });
+    } else if (accounts.length === 1) {
+      bcqAccountId = String(accounts[0]!.id);
+    }
+  } catch {
+    await prompter.note(
+      "Could not fetch identity. Make sure bcq is authenticated.",
+      "Identity error",
+    );
+    // Fall through to manual entry
+  }
+
+  // Step 3: Resolve identity — confirm or prompt
+  let personId: string;
+  if (meIdentity) {
+    await prompter.note(
+      `Identity: ${meIdentity.name} (ID: ${meIdentity.id}, ${meIdentity.email_address})`,
+      "Detected identity",
+    );
+    personId = String(meIdentity.id);
+  } else {
+    personId = await prompter.text({
+      message: "Basecamp person ID for this identity",
+      validate: (v) => (v?.trim() ? undefined : "Required"),
+    });
+    personId = personId.trim();
+  }
+
+  // Step 4: Assign account ID key — validate uniqueness
+  const existingIds = new Set(listBasecampAccountIds(cfg));
+  const accountId = normalizeAccountId(
+    await prompter.text({
+      message: "Account ID key for this identity (e.g. 'security', 'design-bot')",
+      validate: (v) => {
+        if (!v?.trim()) return "Required";
+        if (existingIds.has(normalizeAccountId(v))) return `"${v}" is already in use`;
+        return undefined;
+      },
+    }),
+  );
+
+  // Step 5: Optionally map to agent persona
+  let personaMapping: { agentId: string; accountId: string } | undefined;
+  const mapChoice = await prompter.select({
+    message: "Map this identity to an agent?",
+    options: [
+      { value: "__skip__", label: "Skip — configure later" },
+      { value: "__enter__", label: "Enter agent ID now" },
+    ],
+  });
+
+  if (mapChoice === "__enter__") {
+    const agentId = await prompter.text({
+      message: "Agent ID to use this identity",
+      validate: (v) => (v?.trim() ? undefined : "Required"),
+    });
+    personaMapping = { agentId: agentId.trim(), accountId };
+  }
+
+  // Step 6: Apply config
+  const section = getBasecampSection(cfg) ?? {};
+  const accounts = (section.accounts ?? {}) as Record<string, Record<string, unknown>>;
+  const personas = { ...(section.personas ?? {}) };
+
+  if (personaMapping) {
+    personas[personaMapping.agentId] = personaMapping.accountId;
+  }
+
+  const next: OpenClawConfig = {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      basecamp: {
+        ...section,
+        accounts: {
+          ...accounts,
+          [accountId]: {
+            personId,
+            enabled: true,
+            ...(selectedProfile ? { bcqProfile: selectedProfile } : {}),
+            ...(bcqAccountId ? { bcqAccountId } : {}),
+            ...(meIdentity?.name ? { displayName: meIdentity.name } : {}),
+            ...(meIdentity?.attachable_sgid ? { attachableSgid: meIdentity.attachable_sgid } : {}),
+          },
+        },
+        personas,
+      },
+    },
+  };
+
+  return { cfg: next, accountId, personId, personaMapping };
+}

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -80,7 +80,8 @@ export async function hatchIdentity(
       identity?: { id: number; name: string; email_address: string; attachable_sgid?: string };
       accounts?: BcqAccount[];
     };
-    meIdentity = data.identity ?? (meResult.data as any);
+    // bcqMe may return {id, name, ...} directly or nested under {identity: ...}
+    meIdentity = data.identity ?? (meResult.data as typeof meIdentity);
 
     const accounts = data.accounts ?? [];
     if (accounts.length > 1) {

--- a/src/adapters/heartbeat.ts
+++ b/src/adapters/heartbeat.ts
@@ -45,16 +45,10 @@ export const basecampHeartbeatAdapter: ChannelHeartbeatAdapter = {
       };
     }
 
-    // Map allowFrom entries to ping:<personId> targets
-    const section = getBasecampSection(cfg);
-    const allowFrom = section?.allowFrom;
-    if (allowFrom && allowFrom.length > 0) {
-      return {
-        recipients: allowFrom.map((id) => `ping:${id}`),
-        source: "allowFrom",
-      };
-    }
-
+    // allowFrom contains person IDs, but ping peer IDs require circle bucket
+    // IDs (not person IDs). We cannot map person IDs to ping targets without
+    // an API call to discover the circle. Return empty — heartbeat delivery
+    // for Basecamp requires an explicit --to flag with a valid peer ID.
     return { recipients: [], source: "none" };
   },
 };

--- a/src/adapters/heartbeat.ts
+++ b/src/adapters/heartbeat.ts
@@ -1,0 +1,60 @@
+/**
+ * Basecamp heartbeat adapter — delivery health checks.
+ *
+ * Implements ChannelHeartbeatAdapter for verifying bcq auth readiness
+ * and resolving heartbeat message recipients.
+ */
+
+import type { ChannelHeartbeatAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { BasecampChannelConfig } from "../types.js";
+import { resolveBasecampAccount } from "../config.js";
+import { bcqAuthStatus } from "../bcq.js";
+
+function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
+  return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+}
+
+export const basecampHeartbeatAdapter: ChannelHeartbeatAdapter = {
+  checkReady: async ({ cfg, accountId }) => {
+    const account = resolveBasecampAccount(cfg, accountId);
+
+    if (!account.bcqProfile && !account.token) {
+      return { ok: false, reason: "No bcq profile or token configured" };
+    }
+
+    if (account.bcqProfile) {
+      try {
+        const result = await bcqAuthStatus({ profile: account.bcqProfile });
+        if (!result.data.authenticated) {
+          return { ok: false, reason: `bcq profile "${account.bcqProfile}" is not authenticated` };
+        }
+      } catch (err) {
+        return { ok: false, reason: `bcq auth check failed: ${String(err)}` };
+      }
+    }
+
+    return { ok: true, reason: "Basecamp connection ready" };
+  },
+
+  resolveRecipients: ({ cfg, opts }) => {
+    // Explicit recipients from opts
+    if (opts?.to) {
+      return {
+        recipients: [opts.to],
+        source: "explicit",
+      };
+    }
+
+    // Map allowFrom entries to ping:<personId> targets
+    const section = getBasecampSection(cfg);
+    const allowFrom = section?.allowFrom;
+    if (allowFrom && allowFrom.length > 0) {
+      return {
+        recipients: allowFrom.map((id) => `ping:${id}`),
+        source: "allowFrom",
+      };
+    }
+
+    return { recipients: [], source: "none" };
+  },
+};

--- a/src/adapters/mentions.ts
+++ b/src/adapters/mentions.ts
@@ -11,12 +11,17 @@
 import type { ChannelMentionAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
 import type { BasecampChannelConfig } from "../types.js";
 
+function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
+  return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+}
+
 /**
  * Resolve the agent's display name for a given account.
  * Uses the account config's displayName field.
  */
 function resolveAgentDisplayName(cfg: OpenClawConfig | undefined, accountId?: string): string | undefined {
-  const section = cfg?.channels?.basecamp as BasecampChannelConfig | undefined;
+  if (!cfg) return undefined;
+  const section = getBasecampSection(cfg);
   if (!section?.accounts) return undefined;
 
   // If accountId matches a specific account, use its displayName

--- a/src/adapters/mentions.ts
+++ b/src/adapters/mentions.ts
@@ -1,0 +1,54 @@
+/**
+ * Basecamp mentions adapter — strip @mention artifacts from inbound text.
+ *
+ * Basecamp @mentions use `<bc-attachment sgid="...">Name</bc-attachment>`
+ * HTML tags. The inbound pipeline strips HTML to plain text before the agent
+ * sees it, but the mentioned person's name remains inline. This adapter
+ * strips the agent's own display name when it appears as a mention artifact
+ * at the start of a message.
+ */
+
+import type { ChannelMentionAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { BasecampChannelConfig } from "../types.js";
+
+/**
+ * Resolve the agent's display name for a given account.
+ * Uses the account config's displayName field.
+ */
+function resolveAgentDisplayName(cfg: OpenClawConfig | undefined, accountId?: string): string | undefined {
+  const section = cfg?.channels?.basecamp as BasecampChannelConfig | undefined;
+  if (!section?.accounts) return undefined;
+
+  // If accountId matches a specific account, use its displayName
+  if (accountId && section.accounts[accountId]) {
+    return section.accounts[accountId]!.displayName;
+  }
+
+  // Fall back to first account with a displayName
+  for (const acct of Object.values(section.accounts)) {
+    if (acct.displayName) return acct.displayName;
+  }
+
+  return undefined;
+}
+
+export const basecampMentionAdapter: ChannelMentionAdapter = {
+  stripPatterns: ({ cfg, agentId }) => {
+    const name = resolveAgentDisplayName(cfg, agentId);
+    if (!name) return [];
+    // Match agent's display name at the start of text, followed by
+    // optional punctuation and whitespace (common mention artifact pattern)
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return [`^${escaped}[,:]?\\s*`];
+  },
+
+  stripMentions: ({ text, cfg, agentId }) => {
+    const name = resolveAgentDisplayName(cfg, agentId);
+    if (!name) return text;
+
+    // Strip agent's display name from the start of the message
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`^${escaped}[,:]?\\s*`, "i");
+    return text.replace(pattern, "").trim();
+  },
+};

--- a/src/adapters/messaging.ts
+++ b/src/adapters/messaging.ts
@@ -1,0 +1,59 @@
+/**
+ * Basecamp messaging adapter — target normalization and display formatting.
+ *
+ * Implements ChannelMessagingAdapter for normalizing Basecamp peer IDs
+ * (recording:<id>, bucket:<id>, ping:<id>) and formatting them for display.
+ */
+
+import type { ChannelMessagingAdapter } from "openclaw/plugin-sdk";
+
+const PEER_PATTERN = /^(recording|bucket|ping):\d+$/;
+
+export const basecampMessagingAdapter: ChannelMessagingAdapter = {
+  normalizeTarget: (raw) => {
+    // Already in canonical form
+    if (PEER_PATTERN.test(raw)) return raw;
+
+    // Bare numeric → recording:<id>
+    if (/^\d+$/.test(raw)) return `recording:${raw}`;
+
+    // Strip basecamp: prefix and recurse
+    if (raw.startsWith("basecamp:")) {
+      const stripped = raw.slice("basecamp:".length);
+      if (PEER_PATTERN.test(stripped)) return stripped;
+      if (/^\d+$/.test(stripped)) return `recording:${stripped}`;
+    }
+
+    return undefined;
+  },
+
+  targetResolver: {
+    looksLikeId: (raw) => {
+      if (PEER_PATTERN.test(raw)) return true;
+      if (/^\d+$/.test(raw)) return true;
+      if (raw.startsWith("basecamp:")) {
+        const stripped = raw.slice("basecamp:".length);
+        return PEER_PATTERN.test(stripped) || /^\d+$/.test(stripped);
+      }
+      return false;
+    },
+    hint: "recording:<id> | bucket:<id> | ping:<id>",
+  },
+
+  formatTargetDisplay: ({ target }) => {
+    const match = target.match(/^(recording|bucket|ping):(\d+)$/);
+    if (!match) return target;
+
+    const [, kind, id] = match;
+    switch (kind) {
+      case "recording":
+        return `Recording ${id}`;
+      case "bucket":
+        return `Project ${id}`;
+      case "ping":
+        return `Ping ${id}`;
+      default:
+        return target;
+    }
+  },
+};

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -241,6 +241,30 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
       },
     };
 
+    // Step 8: Offer to add another identity via hatch flow
+    if (authenticated) {
+      const postChoice = await prompter.select({
+        message: "What would you like to do?",
+        options: [
+          { value: "done", label: "Done — use this account" },
+          { value: "hatch", label: "Add another identity" },
+        ],
+      });
+
+      if (postChoice === "hatch") {
+        try {
+          const { hatchIdentity } = await import("./hatch.js");
+          const result = await hatchIdentity(next, prompter);
+          next = result.cfg;
+        } catch {
+          await prompter.note(
+            "Failed to add another identity. You can add more later with `openclaw channels hatch basecamp`.",
+            "Hatch error",
+          );
+        }
+      }
+    }
+
     return { cfg: next, accountId };
   },
 

--- a/src/adapters/resolver.ts
+++ b/src/adapters/resolver.ts
@@ -1,0 +1,125 @@
+/**
+ * Basecamp resolver adapter — batch fuzzy name→ID resolution.
+ *
+ * Implements ChannelResolverAdapter for `openclaw channels resolve`.
+ * Fetches people or projects once, then matches each input by exact ID,
+ * exact name (case-insensitive), partial name, or email prefix.
+ */
+
+import type { ChannelResolverAdapter, ChannelResolveResult } from "openclaw/plugin-sdk";
+import type { BasecampPerson, BasecampProject } from "../types.js";
+import { resolveBasecampAccount } from "../config.js";
+import { bcqApiGet } from "../bcq.js";
+
+function matchPerson(input: string, people: BasecampPerson[]): BasecampPerson | undefined {
+  const lower = input.toLowerCase();
+
+  // Exact ID match
+  const byId = people.find((p) => String(p.id) === input);
+  if (byId) return byId;
+
+  // Exact name match (case-insensitive)
+  const byName = people.find((p) => p.name.toLowerCase() === lower);
+  if (byName) return byName;
+
+  // Partial name match
+  const byPartial = people.find((p) => p.name.toLowerCase().includes(lower));
+  if (byPartial) return byPartial;
+
+  // Email prefix match
+  const byEmail = people.find((p) => p.email_address.toLowerCase().startsWith(lower));
+  if (byEmail) return byEmail;
+
+  return undefined;
+}
+
+function matchProject(input: string, projects: BasecampProject[]): BasecampProject | undefined {
+  const lower = input.toLowerCase();
+
+  // Exact bucket ID match (with or without prefix)
+  const bareId = input.replace(/^bucket:/, "");
+  const byId = projects.find((p) => String(p.id) === bareId);
+  if (byId) return byId;
+
+  // Exact name match (case-insensitive)
+  const byName = projects.find((p) => p.name.toLowerCase() === lower);
+  if (byName) return byName;
+
+  // Partial name match
+  const byPartial = projects.find((p) => p.name.toLowerCase().includes(lower));
+  if (byPartial) return byPartial;
+
+  return undefined;
+}
+
+export const basecampResolverAdapter: ChannelResolverAdapter = {
+  resolveTargets: async ({ cfg, accountId, inputs, kind }) => {
+    const account = resolveBasecampAccount(cfg, accountId);
+    const opts = {
+      accountId: account.config.bcqAccountId,
+      profile: account.bcqProfile,
+    };
+
+    if (kind === "user") {
+      let people: BasecampPerson[];
+      try {
+        people = await bcqApiGet<BasecampPerson[]>("/people.json", opts.accountId, opts.profile);
+      } catch {
+        return inputs.map((input) => ({
+          input,
+          resolved: false,
+          note: "Failed to fetch people list",
+        }));
+      }
+
+      if (!Array.isArray(people)) {
+        return inputs.map((input) => ({ input, resolved: false }));
+      }
+
+      return inputs.map((input): ChannelResolveResult => {
+        const person = matchPerson(input, people);
+        if (person) {
+          return {
+            input,
+            resolved: true,
+            id: String(person.id),
+            name: person.name,
+          };
+        }
+        return { input, resolved: false };
+      });
+    }
+
+    if (kind === "group") {
+      let projects: BasecampProject[];
+      try {
+        projects = await bcqApiGet<BasecampProject[]>("/projects.json", opts.accountId, opts.profile);
+      } catch {
+        return inputs.map((input) => ({
+          input,
+          resolved: false,
+          note: "Failed to fetch projects list",
+        }));
+      }
+
+      if (!Array.isArray(projects)) {
+        return inputs.map((input) => ({ input, resolved: false }));
+      }
+
+      return inputs.map((input): ChannelResolveResult => {
+        const project = matchProject(input, projects);
+        if (project) {
+          return {
+            input,
+            resolved: true,
+            id: `bucket:${project.id}`,
+            name: project.name,
+          };
+        }
+        return { input, resolved: false };
+      });
+    }
+
+    return inputs.map((input) => ({ input, resolved: false }));
+  },
+};

--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -3,21 +3,37 @@
  *
  * Uses bcq to verify authentication and connectivity. Builds the
  * ChannelAccountSnapshot used by `openclaw status` output.
+ * Enhanced with identity resolution, project audit, persona validation,
+ * and status issue collection.
  */
 
-import type { ChannelStatusAdapter, ChannelAccountSnapshot } from "openclaw/plugin-sdk";
+import type { ChannelStatusAdapter, ChannelAccountSnapshot, OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
-import type { ResolvedBasecampAccount } from "../types.js";
-import { bcqAuthStatus } from "../bcq.js";
+import type { ResolvedBasecampAccount, BasecampChannelConfig, BasecampProject } from "../types.js";
+import { bcqAuthStatus, bcqMe, bcqApiGet } from "../bcq.js";
 import type { BcqOptions } from "../bcq.js";
+import { resolveBasecampAccount } from "../config.js";
 
 export type BasecampProbe = {
   ok: boolean;
   authenticated: boolean;
+  personName?: string;
+  accountCount?: number;
   error?: string;
 };
 
-export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount, BasecampProbe> = {
+export type BasecampAudit = {
+  projectsAccessible: number;
+  personasMapped: number;
+  personasValid: number;
+  errors: string[];
+};
+
+function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
+  return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+}
+
+export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   defaultRuntime: {
     accountId: DEFAULT_ACCOUNT_ID,
     running: false,
@@ -31,13 +47,32 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
     if (account.bcqProfile) {
       bcqOpts.profile = account.bcqProfile;
     }
+    if (account.config.bcqAccountId) {
+      bcqOpts.accountId = account.config.bcqAccountId;
+    }
 
     try {
       const result = await bcqAuthStatus(bcqOpts);
-      return {
-        ok: result.data.authenticated,
-        authenticated: result.data.authenticated,
-      };
+      if (!result.data.authenticated) {
+        return { ok: false, authenticated: false };
+      }
+
+      // Also call bcqMe to get identity details
+      let personName: string | undefined;
+      let accountCount: number | undefined;
+      try {
+        const meResult = await bcqMe(bcqOpts);
+        const data = meResult.data as unknown as {
+          name?: string;
+          accounts?: unknown[];
+        };
+        personName = data.name;
+        accountCount = Array.isArray(data.accounts) ? data.accounts.length : undefined;
+      } catch {
+        // Identity fetch is best-effort
+      }
+
+      return { ok: true, authenticated: true, personName, accountCount };
     } catch (err) {
       return {
         ok: false,
@@ -47,7 +82,49 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
     }
   },
 
-  buildAccountSnapshot: ({ account, runtime, probe }) => {
+  auditAccount: async ({ account, cfg, probe }) => {
+    const errors: string[] = [];
+    const opts: BcqOptions = {
+      profile: account.bcqProfile,
+      accountId: account.config.bcqAccountId,
+    };
+
+    // Check project access
+    let projectsAccessible = 0;
+    try {
+      const projects = await bcqApiGet<BasecampProject[]>("/projects.json", opts.accountId, opts.profile);
+      if (Array.isArray(projects)) {
+        projectsAccessible = projects.length;
+      }
+    } catch (err) {
+      errors.push(`Failed to verify project access: ${String(err)}`);
+    }
+
+    // Validate persona mappings
+    const section = getBasecampSection(cfg);
+    const personas = section?.personas ?? {};
+    const accounts = section?.accounts ?? {};
+    let personasMapped = 0;
+    let personasValid = 0;
+
+    for (const [agentId, targetAccountId] of Object.entries(personas)) {
+      personasMapped++;
+      if (accounts[targetAccountId]) {
+        const resolved = resolveBasecampAccount(cfg, targetAccountId);
+        if (resolved.token || resolved.bcqProfile) {
+          personasValid++;
+        } else {
+          errors.push(`Persona "${agentId}" → account "${targetAccountId}": no auth configured`);
+        }
+      } else {
+        errors.push(`Persona "${agentId}" → account "${targetAccountId}": account does not exist`);
+      }
+    }
+
+    return { projectsAccessible, personasMapped, personasValid, errors };
+  },
+
+  buildAccountSnapshot: ({ account, runtime, probe, audit }) => {
     const configured = Boolean(
       account.token?.trim() || account.config.tokenFile || account.bcqProfile,
     );
@@ -62,6 +139,9 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
       lastStopAt: runtime?.lastStopAt ?? null,
       lastError: runtime?.lastError ?? null,
       probe,
+      audit,
+      personName: probe?.personName,
+      accountCount: probe?.accountCount,
     };
   },
 
@@ -74,4 +154,32 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
     lastError: snapshot.lastError ?? null,
     probe: snapshot.probe,
   }),
+
+  logSelfId: ({ account }) => {
+    const name = account.displayName ?? "unknown";
+    console.log(`[basecamp:${account.accountId}] identity: ${name} (personId=${account.personId})`);
+  },
+
+  resolveAccountState: ({ account, configured, enabled }) => {
+    if (!enabled) return "disabled";
+    if (!configured) return "not configured";
+    return "configured";
+  },
+
+  collectStatusIssues: (accounts) => {
+    // Status issues are collected per-channel from the account snapshots.
+    // Return issues for accounts with problems.
+    return accounts
+      .filter((s) => {
+        const probe = s.probe as BasecampProbe | undefined;
+        return probe && !probe.authenticated;
+      })
+      .map((s) => ({
+        channel: "basecamp" as const,
+        accountId: s.accountId,
+        kind: "auth" as const,
+        message: "Account is not authenticated",
+        fix: "Run `bcq auth login` to authenticate",
+      }));
+  },
 };

--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -111,7 +111,7 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
       personasMapped++;
       if (accounts[targetAccountId]) {
         const resolved = resolveBasecampAccount(cfg, targetAccountId);
-        if (resolved.token || resolved.bcqProfile) {
+        if (resolved.token || resolved.bcqProfile || resolved.config.tokenFile) {
           personasValid++;
         } else {
           errors.push(`Persona "${agentId}" → account "${targetAccountId}": no auth configured`);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -23,6 +23,7 @@ import { basecampResolverAdapter } from "./adapters/resolver.js";
 import { basecampHeartbeatAdapter } from "./adapters/heartbeat.js";
 import { basecampGroupAdapter } from "./adapters/groups.js";
 import { basecampAgentPromptAdapter } from "./adapters/agent-prompt.js";
+import { basecampMentionAdapter } from "./adapters/mentions.js";
 
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   id: "basecamp",
@@ -65,6 +66,8 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
   groups: basecampGroupAdapter,
 
   agentPrompt: basecampAgentPromptAdapter,
+
+  mentions: basecampMentionAdapter,
 
   reload: { configPrefixes: ["channels.basecamp"] },
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,6 +1,7 @@
-import type { ChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ChannelPlugin } from "openclaw/plugin-sdk";
 import { buildChannelConfigSchema, DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
 import type { ResolvedBasecampAccount, BasecampInboundMessage } from "./types.js";
+import type { BasecampProbe, BasecampAudit } from "./adapters/status.js";
 import {
   BasecampConfigSchema,
   listBasecampAccountIds,
@@ -16,8 +17,14 @@ import { basecampOnboardingAdapter } from "./adapters/onboarding.js";
 import { basecampSetupAdapter } from "./adapters/setup.js";
 import { basecampStatusAdapter } from "./adapters/status.js";
 import { basecampPairingAdapter } from "./adapters/pairing.js";
+import { basecampDirectoryAdapter } from "./adapters/directory.js";
+import { basecampMessagingAdapter } from "./adapters/messaging.js";
+import { basecampResolverAdapter } from "./adapters/resolver.js";
+import { basecampHeartbeatAdapter } from "./adapters/heartbeat.js";
+import { basecampGroupAdapter } from "./adapters/groups.js";
+import { basecampAgentPromptAdapter } from "./adapters/agent-prompt.js";
 
-export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount> = {
+export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   id: "basecamp",
 
   meta: {
@@ -47,6 +54,18 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount> = {
 
   status: basecampStatusAdapter,
 
+  directory: basecampDirectoryAdapter,
+
+  messaging: basecampMessagingAdapter,
+
+  resolver: basecampResolverAdapter,
+
+  heartbeat: basecampHeartbeatAdapter,
+
+  groups: basecampGroupAdapter,
+
+  agentPrompt: basecampAgentPromptAdapter,
+
   reload: { configPrefixes: ["channels.basecamp"] },
 
   configSchema: buildChannelConfigSchema(BasecampConfigSchema),
@@ -67,7 +86,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount> = {
   },
 
   security: {
-    resolveDmPolicy: ({ cfg, accountId, account }) => {
+    resolveDmPolicy: ({ cfg, accountId }) => {
       const section = cfg.channels?.basecamp as Record<string, unknown> | undefined;
       const dmPolicy = (section?.dmPolicy as string) ?? "pairing";
       const allowFrom = (section?.allowFrom as Array<string | number>) ?? [];

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,7 +97,7 @@ export function listBasecampAccountIds(cfg: OpenClawConfig): string[] {
   if (ids.size === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }
-  return [...ids].sort((a: string, b: string) => a.localeCompare(b));
+  return Array.from(ids).sort();
 }
 
 /**
@@ -158,6 +158,7 @@ export function resolveProjectScope(
 export function resolveBasecampAccount(
   cfg: OpenClawConfig,
   accountId?: string | null,
+  _visited?: Set<string>,
 ): ResolvedBasecampAccount {
   const effectiveId = normalizeAccountId(accountId ?? DEFAULT_ACCOUNT_ID);
   const section = getBasecampSection(cfg);
@@ -165,7 +166,20 @@ export function resolveBasecampAccount(
   // Check if this is a project-scope (virtual account) entry
   const scope = resolveProjectScope(cfg, effectiveId);
   if (scope) {
-    const resolved = resolveBasecampAccount(cfg, scope.accountId);
+    // Cycle detection: virtual accounts must not reference each other
+    const visited = _visited ?? new Set<string>();
+    if (visited.has(effectiveId)) {
+      return {
+        accountId: effectiveId,
+        enabled: false,
+        personId: "",
+        token: "",
+        tokenSource: "none",
+        config: { personId: "" },
+      };
+    }
+    visited.add(effectiveId);
+    const resolved = resolveBasecampAccount(cfg, scope.accountId, visited);
     return {
       ...resolved,
       accountId: effectiveId,

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
 import type {
   BasecampAccountConfig,
   BasecampChannelConfig,
+  BasecampVirtualAccountConfig,
   ResolvedBasecampAccount,
 } from "./types.js";
 
@@ -27,6 +28,15 @@ const BasecampVirtualAccountSchema = z.object({
   bucketId: z.string(),
 });
 
+const BasecampBucketConfigSchema = z.object({
+  requireMention: z.boolean().optional(),
+  tools: z.object({
+    allow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
+  }).optional(),
+  enabled: z.boolean().optional(),
+});
+
 export const BasecampConfigSchema = z.object({
   enabled: z.boolean().optional(),
   accounts: z.record(z.string(), BasecampAccountConfigSchema).optional(),
@@ -34,6 +44,7 @@ export const BasecampConfigSchema = z.object({
   personas: z.record(z.string(), z.string()).optional(),
   dmPolicy: z.enum(["open", "pairing", "closed"]).optional(),
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  buckets: z.record(z.string(), BasecampBucketConfigSchema).optional(),
   polling: z
     .object({
       activityIntervalMs: z.number().positive().optional(),
@@ -67,15 +78,26 @@ function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
 }
 
 /**
- * List all account IDs configured under channels.basecamp.accounts.
+ * List all account IDs configured under channels.basecamp.accounts,
+ * including virtual (project-scoped) account keys.
  * Returns [DEFAULT_ACCOUNT_ID] if none are configured.
  */
 export function listBasecampAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
+  const ids = new Set(listConfiguredAccountIds(cfg));
+
+  // Include virtual account (project-scope) keys
+  const section = getBasecampSection(cfg);
+  const virtualAccounts = section?.virtualAccounts;
+  if (virtualAccounts && typeof virtualAccounts === "object") {
+    for (const key of Object.keys(virtualAccounts)) {
+      if (key) ids.add(normalizeAccountId(key));
+    }
+  }
+
+  if (ids.size === 0) {
     return [DEFAULT_ACCOUNT_ID];
   }
-  return ids.toSorted((a, b) => a.localeCompare(b));
+  return [...ids].sort((a: string, b: string) => a.localeCompare(b));
 }
 
 /**
@@ -112,9 +134,26 @@ async function readTokenFile(filePath: string): Promise<string> {
 }
 
 /**
+ * Resolve a project-scope entry by its key.
+ * Returns the real account ID and scoped bucket ID, or undefined if not found.
+ */
+export function resolveProjectScope(
+  cfg: OpenClawConfig,
+  scopeId: string,
+): { accountId: string; bucketId: string } | undefined {
+  const section = getBasecampSection(cfg);
+  const va = section?.virtualAccounts?.[scopeId] as BasecampVirtualAccountConfig | undefined;
+  if (!va) return undefined;
+  return { accountId: va.accountId, bucketId: va.bucketId };
+}
+
+/**
  * Synchronously resolve a Basecamp account from config.
  * Token loading from file is deferred — use the token field if available,
  * otherwise the gateway startup will load it.
+ *
+ * When accountId matches a virtualAccounts (project-scope) entry, the real
+ * account is resolved and scopedBucketId is set on the result.
  */
 export function resolveBasecampAccount(
   cfg: OpenClawConfig,
@@ -122,6 +161,18 @@ export function resolveBasecampAccount(
 ): ResolvedBasecampAccount {
   const effectiveId = normalizeAccountId(accountId ?? DEFAULT_ACCOUNT_ID);
   const section = getBasecampSection(cfg);
+
+  // Check if this is a project-scope (virtual account) entry
+  const scope = resolveProjectScope(cfg, effectiveId);
+  if (scope) {
+    const resolved = resolveBasecampAccount(cfg, scope.accountId);
+    return {
+      ...resolved,
+      accountId: effectiveId,
+      scopedBucketId: scope.bucketId,
+    };
+  }
+
   const accountCfg = section?.accounts?.[effectiveId] as BasecampAccountConfig | undefined;
 
   if (!accountCfg) {

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -11,7 +11,8 @@
  *    to send the agent's response back to the correct Basecamp surface
  */
 
-import type { BasecampInboundMessage, ResolvedBasecampAccount } from "./types.js";
+import type { BasecampInboundMessage, BasecampChannelConfig, ResolvedBasecampAccount } from "./types.js";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { getBasecampRuntime } from "./runtime.js";
 import { resolvePersonaAccountId, resolveBasecampAccount } from "./config.js";
 import { postReplyToEvent } from "./outbound/send.js";
@@ -45,11 +46,16 @@ export async function dispatchBasecampEvent(
     return false;
   }
 
+  // ----- Project-scope routing override -----
+  // Check if the event's bucketId matches a virtualAccounts entry;
+  // if so, override the accountId to the scope alias so agent bindings match.
+  const effectiveAccountId = resolveProjectScopeAccountId(cfg, msg) ?? msg.accountId;
+
   // ----- Route resolution -----
   const route = runtime.channel.routing.resolveAgentRoute({
     cfg,
     channel: "basecamp",
-    accountId: msg.accountId,
+    accountId: effectiveAccountId,
     peer: msg.peer,
     parentPeer: msg.parentPeer,
   });
@@ -136,6 +142,28 @@ export async function dispatchBasecampEvent(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Check if an inbound message's bucketId matches a virtualAccounts entry.
+ * Returns the virtual account key (scope alias) if matched, undefined otherwise.
+ */
+function resolveProjectScopeAccountId(
+  cfg: OpenClawConfig,
+  msg: BasecampInboundMessage,
+): string | undefined {
+  const section = cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+  const virtualAccounts = section?.virtualAccounts;
+  if (!virtualAccounts) return undefined;
+
+  const bucketId = msg.meta.bucketId;
+  for (const [key, va] of Object.entries(virtualAccounts)) {
+    if (va.bucketId === bucketId) {
+      return key;
+    }
+  }
+
+  return undefined;
+}
 
 /**
  * Build UntrustedContext entries from Basecamp-specific metadata.

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,6 +281,36 @@ export type BasecampWebhookPayload = {
 };
 
 // ---------------------------------------------------------------------------
+// Raw API entity shapes (for directory / resolver adapters)
+// ---------------------------------------------------------------------------
+
+export type BasecampPerson = {
+  id: number;
+  name: string;
+  email_address: string;
+  avatar_url?: string;
+  attachable_sgid?: string;
+};
+
+export type BasecampProject = {
+  id: number;
+  name: string;
+  description?: string;
+  app_url?: string;
+  bookmarked?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Per-bucket config (Group C)
+// ---------------------------------------------------------------------------
+
+export type BasecampBucketConfig = {
+  requireMention?: boolean;
+  tools?: { allow?: string[]; deny?: string[] };
+  enabled?: boolean;
+};
+
+// ---------------------------------------------------------------------------
 // Config types
 // ---------------------------------------------------------------------------
 
@@ -338,6 +368,8 @@ export type BasecampChannelConfig = {
   dmPolicy?: "open" | "pairing" | "closed";
   /** Allowed sender person IDs for DM/pairing. */
   allowFrom?: Array<string | number>;
+  /** Per-bucket behavior overrides. Key is bucket ID or "*" for wildcard. */
+  buckets?: Record<string, BasecampBucketConfig>;
   /** Polling cadence overrides (milliseconds). */
   polling?: {
     activityIntervalMs?: number;
@@ -360,6 +392,8 @@ export type ResolvedBasecampAccount = {
   tokenSource: "tokenFile" | "config" | "bcq" | "none";
   /** bcq profile name (for --profile flag). */
   bcqProfile?: string;
+  /** When this account was resolved via a project-scope entry, the scoped bucket ID. */
+  scopedBucketId?: string;
   config: BasecampAccountConfig;
 };
 

--- a/tests/agent-prompt.test.ts
+++ b/tests/agent-prompt.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { basecampAgentPromptAdapter } from "../src/adapters/agent-prompt.js";
+
+describe("agentPrompt.messageToolHints", () => {
+  it("returns non-empty array of hints", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: {} as any,
+    });
+
+    expect(hints.length).toBeGreaterThan(0);
+  });
+
+  it("contains Basecamp terminology", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: {} as any,
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).toContain("recording:");
+    expect(joined).toContain("bucket:");
+    expect(joined).toContain("ping:");
+    expect(joined).toContain("Campfire");
+    expect(joined).toContain("Ping");
+    expect(joined).toContain("Card Table");
+  });
+
+  it("mentions bc-attachment SGID format", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: {} as any,
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).toContain("bc-attachment");
+    expect(joined).toContain("SGID");
+  });
+
+  it("describes threading model", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: {} as any,
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).toContain("flat");
+    expect(joined).toContain("no nested threads");
+  });
+});

--- a/tests/directory.test.ts
+++ b/tests/directory.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+}));
+
+vi.mock("../src/bcq.js", () => ({
+  bcqMe: vi.fn(),
+  bcqApiGet: vi.fn(),
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(),
+}));
+
+import { basecampDirectoryAdapter } from "../src/adapters/directory.js";
+import { bcqMe, bcqApiGet } from "../src/bcq.js";
+import { resolveBasecampAccount } from "../src/config.js";
+
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+const mockAccount = {
+  accountId: "test",
+  enabled: true,
+  personId: "1",
+  token: "tok",
+  tokenSource: "config" as const,
+  bcqProfile: "default",
+  config: { personId: "1", bcqProfile: "default", bcqAccountId: "99" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolveBasecampAccount).mockReturnValue(mockAccount as any);
+});
+
+// ---------------------------------------------------------------------------
+// self
+// ---------------------------------------------------------------------------
+
+describe("directory.self", () => {
+  it("returns entry from bcqMe", async () => {
+    vi.mocked(bcqMe).mockResolvedValue({
+      data: { id: 42, name: "Jeremy", email_address: "j@example.com" },
+      raw: "",
+    });
+
+    const result = await basecampDirectoryAdapter.self!({
+      cfg: cfg({ accounts: { test: { personId: "1" } } }),
+      accountId: "test",
+      runtime: {} as any,
+    });
+
+    expect(result).toEqual({
+      kind: "user",
+      id: "42",
+      name: "Jeremy",
+      handle: "j@example.com",
+    });
+  });
+
+  it("returns null when bcqMe fails", async () => {
+    vi.mocked(bcqMe).mockRejectedValue(new Error("fail"));
+
+    const result = await basecampDirectoryAdapter.self!({
+      cfg: cfg({ accounts: { test: { personId: "1" } } }),
+      accountId: "test",
+      runtime: {} as any,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when account has no token or profile", async () => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      ...mockAccount,
+      token: "",
+      bcqProfile: undefined,
+    } as any);
+
+    const result = await basecampDirectoryAdapter.self!({
+      cfg: cfg({}),
+      accountId: "test",
+      runtime: {} as any,
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listPeers
+// ---------------------------------------------------------------------------
+
+describe("directory.listPeers", () => {
+  it("returns allowFrom entries and account personIds", async () => {
+    const result = await basecampDirectoryAdapter.listPeers!({
+      cfg: cfg({
+        allowFrom: ["100", "200"],
+        accounts: {
+          primary: { personId: "300", displayName: "Bot" },
+        },
+      }),
+      runtime: {} as any,
+    });
+
+    expect(result).toEqual([
+      { kind: "user", id: "100", name: undefined },
+      { kind: "user", id: "200", name: undefined },
+      { kind: "user", id: "300", name: "Bot" },
+    ]);
+  });
+
+  it("returns empty when no config", async () => {
+    const result = await basecampDirectoryAdapter.listPeers!({
+      cfg: cfg({}),
+      runtime: {} as any,
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listPeersLive
+// ---------------------------------------------------------------------------
+
+describe("directory.listPeersLive", () => {
+  it("returns people from API", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([
+      { id: 1, name: "Alice", email_address: "alice@example.com", avatar_url: "https://a.png" },
+      { id: 2, name: "Bob", email_address: "bob@example.com" },
+    ]);
+
+    const result = await basecampDirectoryAdapter.listPeersLive!({
+      cfg: cfg({ accounts: { test: {} } }),
+      accountId: "test",
+      runtime: {} as any,
+    });
+
+    expect(result).toEqual([
+      { kind: "user", id: "1", name: "Alice", handle: "alice@example.com", avatarUrl: "https://a.png" },
+      { kind: "user", id: "2", name: "Bob", handle: "bob@example.com", avatarUrl: undefined },
+    ]);
+  });
+
+  it("filters by query", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([
+      { id: 1, name: "Alice", email_address: "alice@example.com" },
+      { id: 2, name: "Bob", email_address: "bob@example.com" },
+    ]);
+
+    const result = await basecampDirectoryAdapter.listPeersLive!({
+      cfg: cfg({ accounts: { test: {} } }),
+      accountId: "test",
+      query: "ali",
+      runtime: {} as any,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe("Alice");
+  });
+
+  it("returns empty on API failure", async () => {
+    vi.mocked(bcqApiGet).mockRejectedValue(new Error("fail"));
+
+    const result = await basecampDirectoryAdapter.listPeersLive!({
+      cfg: cfg({ accounts: { test: {} } }),
+      accountId: "test",
+      runtime: {} as any,
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listGroupsLive
+// ---------------------------------------------------------------------------
+
+describe("directory.listGroupsLive", () => {
+  it("returns projects from API with bucket: prefix", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([
+      { id: 100, name: "Design Project" },
+      { id: 200, name: "Engineering" },
+    ]);
+
+    const result = await basecampDirectoryAdapter.listGroupsLive!({
+      cfg: cfg({ accounts: { test: {} } }),
+      accountId: "test",
+      runtime: {} as any,
+    });
+
+    expect(result).toEqual([
+      { kind: "group", id: "bucket:100", name: "Design Project" },
+      { kind: "group", id: "bucket:200", name: "Engineering" },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listGroupMembers
+// ---------------------------------------------------------------------------
+
+describe("directory.listGroupMembers", () => {
+  it("fetches members for bucket:<id> group", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([
+      { id: 5, name: "Carol", email_address: "carol@example.com" },
+    ]);
+
+    const result = await basecampDirectoryAdapter.listGroupMembers!({
+      cfg: cfg({ accounts: { test: {} } }),
+      accountId: "test",
+      groupId: "bucket:123",
+      runtime: {} as any,
+    });
+
+    expect(bcqApiGet).toHaveBeenCalledWith("/buckets/123/people.json", "99", "default");
+    expect(result).toEqual([
+      { kind: "user", id: "5", name: "Carol", handle: "carol@example.com", avatarUrl: undefined },
+    ]);
+  });
+
+  it("returns empty for non-bucket groupId", async () => {
+    const result = await basecampDirectoryAdapter.listGroupMembers!({
+      cfg: cfg({ accounts: { test: {} } }),
+      accountId: "test",
+      groupId: "recording:456",
+      runtime: {} as any,
+    });
+
+    expect(result).toEqual([]);
+    expect(bcqApiGet).not.toHaveBeenCalled();
+  });
+});

--- a/tests/groups.test.ts
+++ b/tests/groups.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { basecampGroupAdapter } from "../src/adapters/groups.js";
+import { resolveBasecampBucketConfig } from "../src/adapters/groups.js";
+
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+// ---------------------------------------------------------------------------
+// resolveBasecampBucketConfig
+// ---------------------------------------------------------------------------
+
+describe("resolveBasecampBucketConfig", () => {
+  it("returns exact match", () => {
+    const result = resolveBasecampBucketConfig(
+      cfg({ buckets: { "123": { requireMention: true } } }),
+      "123",
+    );
+    expect(result).toEqual({ requireMention: true });
+  });
+
+  it("falls back to wildcard", () => {
+    const result = resolveBasecampBucketConfig(
+      cfg({ buckets: { "*": { requireMention: false } } }),
+      "999",
+    );
+    expect(result).toEqual({ requireMention: false });
+  });
+
+  it("prefers exact match over wildcard", () => {
+    const result = resolveBasecampBucketConfig(
+      cfg({
+        buckets: {
+          "123": { requireMention: true },
+          "*": { requireMention: false },
+        },
+      }),
+      "123",
+    );
+    expect(result?.requireMention).toBe(true);
+  });
+
+  it("returns undefined when no buckets configured", () => {
+    const result = resolveBasecampBucketConfig(cfg({}), "123");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when bucketId not found and no wildcard", () => {
+    const result = resolveBasecampBucketConfig(
+      cfg({ buckets: { "456": { requireMention: true } } }),
+      "123",
+    );
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRequireMention
+// ---------------------------------------------------------------------------
+
+describe("groups.resolveRequireMention", () => {
+  it("returns value from exact bucket config", () => {
+    const result = basecampGroupAdapter.resolveRequireMention!({
+      cfg: cfg({ buckets: { "123": { requireMention: true } } }),
+      groupId: "bucket:123",
+    } as any);
+    expect(result).toBe(true);
+  });
+
+  it("returns value from wildcard", () => {
+    const result = basecampGroupAdapter.resolveRequireMention!({
+      cfg: cfg({ buckets: { "*": { requireMention: false } } }),
+      groupId: "bucket:999",
+    } as any);
+    expect(result).toBe(false);
+  });
+
+  it("returns undefined for non-bucket groupId", () => {
+    const result = basecampGroupAdapter.resolveRequireMention!({
+      cfg: cfg({ buckets: { "123": { requireMention: true } } }),
+      groupId: "recording:456",
+    } as any);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when no buckets configured", () => {
+    const result = basecampGroupAdapter.resolveRequireMention!({
+      cfg: cfg({}),
+      groupId: "bucket:123",
+    } as any);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveToolPolicy
+// ---------------------------------------------------------------------------
+
+describe("groups.resolveToolPolicy", () => {
+  it("returns tool policy from bucket config", () => {
+    const result = basecampGroupAdapter.resolveToolPolicy!({
+      cfg: cfg({
+        buckets: {
+          "123": { tools: { allow: ["read"], deny: ["write"] } },
+        },
+      }),
+      groupId: "bucket:123",
+    } as any);
+
+    expect(result).toEqual({ allow: ["read"], deny: ["write"] });
+  });
+
+  it("returns undefined when no tools configured", () => {
+    const result = basecampGroupAdapter.resolveToolPolicy!({
+      cfg: cfg({ buckets: { "123": { requireMention: true } } }),
+      groupId: "bucket:123",
+    } as any);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveGroupIntroHint
+// ---------------------------------------------------------------------------
+
+describe("groups.resolveGroupIntroHint", () => {
+  it("returns non-empty Basecamp context string", () => {
+    const hint = basecampGroupAdapter.resolveGroupIntroHint!({
+      cfg: cfg({}),
+    } as any);
+
+    expect(hint).toBeTruthy();
+    expect(hint).toContain("Basecamp");
+    expect(hint).toContain("Campfire");
+  });
+});

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+}));
+
+vi.mock("../src/bcq.js", () => ({
+  bcqMe: vi.fn(),
+  bcqProfileList: vi.fn(),
+}));
+
+vi.mock("../src/config.js", () => ({
+  listBasecampAccountIds: vi.fn(),
+}));
+
+import { hatchIdentity } from "../src/adapters/hatch.js";
+import { bcqMe, bcqProfileList } from "../src/bcq.js";
+import { listBasecampAccountIds } from "../src/config.js";
+
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+function createMockPrompter(responses: Record<string, string>) {
+  const selectCalls: string[] = [];
+  const textCalls: string[] = [];
+  const noteCalls: string[] = [];
+
+  return {
+    prompter: {
+      select: vi.fn(async ({ message, options }: any) => {
+        selectCalls.push(message);
+        return responses[message] ?? options[0]?.value ?? "";
+      }),
+      text: vi.fn(async ({ message }: any) => {
+        textCalls.push(message);
+        return responses[message] ?? "test-value";
+      }),
+      note: vi.fn(async () => {}),
+    },
+    calls: { selectCalls, textCalls, noteCalls },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(listBasecampAccountIds).mockReturnValue(["default"]);
+});
+
+// ---------------------------------------------------------------------------
+// hatchIdentity
+// ---------------------------------------------------------------------------
+
+describe("hatchIdentity", () => {
+  it("resolves personId from bcqMe and adds account", async () => {
+    vi.mocked(bcqProfileList).mockResolvedValue({
+      data: ["default"],
+      raw: "",
+    });
+    vi.mocked(bcqMe).mockResolvedValue({
+      data: {
+        identity: { id: 42, name: "Jeremy", email_address: "j@example.com", attachable_sgid: "sgid://x" },
+        accounts: [{ id: 99, name: "Acme" }],
+      } as any,
+      raw: "",
+    });
+
+    const { prompter } = createMockPrompter({
+      "Account ID key for this identity (e.g. 'security', 'design-bot')": "security",
+      "Map this identity to an agent?": "__skip__",
+    });
+
+    const result = await hatchIdentity(cfg({}), prompter);
+
+    expect(result.accountId).toBe("security");
+    expect(result.personId).toBe("42");
+    // Config should have the new account
+    const accounts = (result.cfg.channels as any).basecamp.accounts;
+    expect(accounts.security).toBeDefined();
+    expect(accounts.security.personId).toBe("42");
+    expect(accounts.security.displayName).toBe("Jeremy");
+    expect(accounts.security.attachableSgid).toBe("sgid://x");
+  });
+
+  it("adds persona mapping when agent ID provided", async () => {
+    vi.mocked(bcqProfileList).mockResolvedValue({ data: ["default"], raw: "" });
+    vi.mocked(bcqMe).mockResolvedValue({
+      data: {
+        identity: { id: 10, name: "Bot", email_address: "bot@example.com" },
+        accounts: [{ id: 1, name: "Co" }],
+      } as any,
+      raw: "",
+    });
+
+    const { prompter } = createMockPrompter({
+      "Account ID key for this identity (e.g. 'security', 'design-bot')": "bot-acct",
+      "Map this identity to an agent?": "__enter__",
+      "Agent ID to use this identity": "security-agent",
+    });
+
+    const result = await hatchIdentity(cfg({}), prompter);
+
+    expect(result.personaMapping).toEqual({
+      agentId: "security-agent",
+      accountId: "bot-acct",
+    });
+    const personas = (result.cfg.channels as any).basecamp.personas;
+    expect(personas["security-agent"]).toBe("bot-acct");
+  });
+
+  it("validates unique account ID", async () => {
+    vi.mocked(bcqProfileList).mockResolvedValue({ data: ["default"], raw: "" });
+    vi.mocked(bcqMe).mockResolvedValue({
+      data: { identity: { id: 1, name: "X", email_address: "x@x.com" }, accounts: [] } as any,
+      raw: "",
+    });
+    vi.mocked(listBasecampAccountIds).mockReturnValue(["default", "existing"]);
+
+    const { prompter } = createMockPrompter({
+      "Account ID key for this identity (e.g. 'security', 'design-bot')": "new-one",
+      "Map this identity to an agent?": "__skip__",
+    });
+
+    // The text validator should reject "existing" — verify via the validate function
+    const result = await hatchIdentity(cfg({}), prompter);
+    expect(result.accountId).toBe("new-one");
+
+    // Verify the validator was set up correctly
+    const textCall = prompter.text.mock.calls.find(
+      (c: any) => c[0].message.includes("Account ID key"),
+    );
+    expect(textCall).toBeDefined();
+    const validate = textCall![0].validate;
+    expect(validate!("existing")).toContain("already in use");
+    expect(validate!("new-one")).toBeUndefined();
+  });
+
+  it("handles bcqMe failure gracefully", async () => {
+    vi.mocked(bcqProfileList).mockResolvedValue({ data: [], raw: "" });
+    vi.mocked(bcqMe).mockRejectedValue(new Error("fail"));
+
+    const { prompter } = createMockPrompter({
+      "Basecamp person ID for this identity": "99",
+      "Account ID key for this identity (e.g. 'security', 'design-bot')": "manual",
+      "Map this identity to an agent?": "__skip__",
+    });
+
+    const result = await hatchIdentity(cfg({}), prompter);
+
+    expect(result.personId).toBe("99");
+    expect(result.accountId).toBe("manual");
+    // Note should have been shown about error
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("Could not fetch identity"),
+      expect.any(String),
+    );
+  });
+});

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -118,13 +118,15 @@ describe("heartbeat.resolveRecipients", () => {
     expect(result.source).toBe("explicit");
   });
 
-  it("maps allowFrom to ping targets", () => {
+  it("returns empty when only allowFrom is available (person IDs cannot be mapped to ping peers)", () => {
     const result = basecampHeartbeatAdapter.resolveRecipients!({
       cfg: cfg({ allowFrom: ["100", "200"] }),
     });
 
-    expect(result.recipients).toEqual(["ping:100", "ping:200"]);
-    expect(result.source).toBe("allowFrom");
+    // allowFrom contains person IDs, but ping peers require circle bucket IDs.
+    // Without an API call we can't map them, so recipients is empty.
+    expect(result.recipients).toEqual([]);
+    expect(result.source).toBe("none");
   });
 
   it("returns empty when no recipients available", () => {

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+}));
+
+vi.mock("../src/bcq.js", () => ({
+  bcqAuthStatus: vi.fn(),
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(),
+}));
+
+import { basecampHeartbeatAdapter } from "../src/adapters/heartbeat.js";
+import { bcqAuthStatus } from "../src/bcq.js";
+import { resolveBasecampAccount } from "../src/config.js";
+
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+const mockAccount = {
+  accountId: "test",
+  enabled: true,
+  personId: "42",
+  token: "tok",
+  tokenSource: "config" as const,
+  bcqProfile: "default",
+  config: { personId: "42", bcqProfile: "default" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolveBasecampAccount).mockReturnValue(mockAccount as any);
+});
+
+// ---------------------------------------------------------------------------
+// checkReady
+// ---------------------------------------------------------------------------
+
+describe("heartbeat.checkReady", () => {
+  it("returns ok when authenticated", async () => {
+    vi.mocked(bcqAuthStatus).mockResolvedValue({
+      data: { authenticated: true },
+      raw: "",
+    });
+
+    const result = await basecampHeartbeatAdapter.checkReady!({
+      cfg: cfg({}),
+      accountId: "test",
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns not ok when not authenticated", async () => {
+    vi.mocked(bcqAuthStatus).mockResolvedValue({
+      data: { authenticated: false },
+      raw: "",
+    });
+
+    const result = await basecampHeartbeatAdapter.checkReady!({
+      cfg: cfg({}),
+      accountId: "test",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("not authenticated");
+  });
+
+  it("returns not ok when no token or profile", async () => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      ...mockAccount,
+      token: "",
+      bcqProfile: undefined,
+    } as any);
+
+    const result = await basecampHeartbeatAdapter.checkReady!({
+      cfg: cfg({}),
+      accountId: "test",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("No bcq profile or token");
+  });
+
+  it("returns not ok on auth check failure", async () => {
+    vi.mocked(bcqAuthStatus).mockRejectedValue(new Error("timeout"));
+
+    const result = await basecampHeartbeatAdapter.checkReady!({
+      cfg: cfg({}),
+      accountId: "test",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("auth check failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRecipients
+// ---------------------------------------------------------------------------
+
+describe("heartbeat.resolveRecipients", () => {
+  it("returns explicit recipient", () => {
+    const result = basecampHeartbeatAdapter.resolveRecipients!({
+      cfg: cfg({}),
+      opts: { to: "ping:42" },
+    });
+
+    expect(result.recipients).toEqual(["ping:42"]);
+    expect(result.source).toBe("explicit");
+  });
+
+  it("maps allowFrom to ping targets", () => {
+    const result = basecampHeartbeatAdapter.resolveRecipients!({
+      cfg: cfg({ allowFrom: ["100", "200"] }),
+    });
+
+    expect(result.recipients).toEqual(["ping:100", "ping:200"]);
+    expect(result.source).toBe("allowFrom");
+  });
+
+  it("returns empty when no recipients available", () => {
+    const result = basecampHeartbeatAdapter.resolveRecipients!({
+      cfg: cfg({}),
+    });
+
+    expect(result.recipients).toEqual([]);
+    expect(result.source).toBe("none");
+  });
+});

--- a/tests/mentions-adapter.test.ts
+++ b/tests/mentions-adapter.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+}));
+
+import { basecampMentionAdapter } from "../src/adapters/mentions.js";
+
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+const mockCtx = { Body: "test", From: "basecamp:42" } as any;
+
+// ---------------------------------------------------------------------------
+// stripPatterns
+// ---------------------------------------------------------------------------
+
+describe("mentions.stripPatterns", () => {
+  it("returns pattern for agent display name", () => {
+    const patterns = basecampMentionAdapter.stripPatterns!({
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: { main: { personId: "42", displayName: "Coworker" } },
+      }),
+    });
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0]).toContain("Coworker");
+  });
+
+  it("returns pattern matching specific account when agentId provided", () => {
+    const patterns = basecampMentionAdapter.stripPatterns!({
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: {
+          alpha: { personId: "1", displayName: "Alice" },
+          beta: { personId: "2", displayName: "Bob" },
+        },
+      }),
+      agentId: "beta",
+    });
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0]).toContain("Bob");
+  });
+
+  it("returns empty array when no displayName configured", () => {
+    const patterns = basecampMentionAdapter.stripPatterns!({
+      ctx: mockCtx,
+      cfg: cfg({ accounts: { main: { personId: "42" } } }),
+    });
+    expect(patterns).toEqual([]);
+  });
+
+  it("returns empty array when no config", () => {
+    const patterns = basecampMentionAdapter.stripPatterns!({
+      ctx: mockCtx,
+      cfg: undefined,
+    });
+    expect(patterns).toEqual([]);
+  });
+
+  it("escapes regex special characters in name", () => {
+    const patterns = basecampMentionAdapter.stripPatterns!({
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: { main: { personId: "42", displayName: "Agent (v2.0)" } },
+      }),
+    });
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0]).toContain("\\(");
+    expect(patterns[0]).toContain("\\)");
+    expect(patterns[0]).toContain("\\.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripMentions
+// ---------------------------------------------------------------------------
+
+describe("mentions.stripMentions", () => {
+  it("strips agent name from start of message", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "Coworker can you review this?",
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: { main: { personId: "42", displayName: "Coworker" } },
+      }),
+    });
+    expect(result).toBe("can you review this?");
+  });
+
+  it("strips agent name with colon separator", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "Coworker: please help",
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: { main: { personId: "42", displayName: "Coworker" } },
+      }),
+    });
+    expect(result).toBe("please help");
+  });
+
+  it("strips agent name with comma separator", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "Coworker, what do you think?",
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: { main: { personId: "42", displayName: "Coworker" } },
+      }),
+    });
+    expect(result).toBe("what do you think?");
+  });
+
+  it("is case-insensitive", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "coworker can you review?",
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: { main: { personId: "42", displayName: "Coworker" } },
+      }),
+    });
+    expect(result).toBe("can you review?");
+  });
+
+  it("preserves text when name appears mid-message", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "Hey tell Coworker about this",
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: { main: { personId: "42", displayName: "Coworker" } },
+      }),
+    });
+    expect(result).toBe("Hey tell Coworker about this");
+  });
+
+  it("returns text unchanged when no displayName configured", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "Hello there",
+      ctx: mockCtx,
+      cfg: cfg({ accounts: { main: { personId: "42" } } }),
+    });
+    expect(result).toBe("Hello there");
+  });
+
+  it("returns text unchanged when no config", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "Hello there",
+      ctx: mockCtx,
+      cfg: undefined,
+    });
+    expect(result).toBe("Hello there");
+  });
+
+  it("handles empty text", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "",
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: { main: { personId: "42", displayName: "Coworker" } },
+      }),
+    });
+    expect(result).toBe("");
+  });
+});

--- a/tests/messaging.test.ts
+++ b/tests/messaging.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { basecampMessagingAdapter } from "../src/adapters/messaging.js";
+
+// ---------------------------------------------------------------------------
+// normalizeTarget
+// ---------------------------------------------------------------------------
+
+describe("messaging.normalizeTarget", () => {
+  const normalize = basecampMessagingAdapter.normalizeTarget!;
+
+  it("passes through recording:<id>", () => {
+    expect(normalize("recording:123")).toBe("recording:123");
+  });
+
+  it("passes through bucket:<id>", () => {
+    expect(normalize("bucket:456")).toBe("bucket:456");
+  });
+
+  it("passes through ping:<id>", () => {
+    expect(normalize("ping:789")).toBe("ping:789");
+  });
+
+  it("converts bare numeric to recording:<id>", () => {
+    expect(normalize("42")).toBe("recording:42");
+  });
+
+  it("strips basecamp: prefix from recording:<id>", () => {
+    expect(normalize("basecamp:recording:100")).toBe("recording:100");
+  });
+
+  it("strips basecamp: prefix from bare numeric", () => {
+    expect(normalize("basecamp:55")).toBe("recording:55");
+  });
+
+  it("returns undefined for unrecognized input", () => {
+    expect(normalize("slack:C123")).toBeUndefined();
+    expect(normalize("hello world")).toBeUndefined();
+    expect(normalize("")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// targetResolver.looksLikeId
+// ---------------------------------------------------------------------------
+
+describe("messaging.targetResolver.looksLikeId", () => {
+  const looksLikeId = basecampMessagingAdapter.targetResolver!.looksLikeId!;
+
+  it("recognizes recording:<id>", () => {
+    expect(looksLikeId("recording:123")).toBe(true);
+  });
+
+  it("recognizes bucket:<id>", () => {
+    expect(looksLikeId("bucket:456")).toBe(true);
+  });
+
+  it("recognizes ping:<id>", () => {
+    expect(looksLikeId("ping:789")).toBe(true);
+  });
+
+  it("recognizes bare numeric", () => {
+    expect(looksLikeId("42")).toBe(true);
+  });
+
+  it("recognizes basecamp: prefixed", () => {
+    expect(looksLikeId("basecamp:recording:100")).toBe(true);
+    expect(looksLikeId("basecamp:55")).toBe(true);
+  });
+
+  it("rejects non-Basecamp targets", () => {
+    expect(looksLikeId("slack:C123")).toBe(false);
+    expect(looksLikeId("hello")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// targetResolver.hint
+// ---------------------------------------------------------------------------
+
+describe("messaging.targetResolver.hint", () => {
+  it("provides format hint", () => {
+    expect(basecampMessagingAdapter.targetResolver!.hint).toBe(
+      "recording:<id> | bucket:<id> | ping:<id>",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatTargetDisplay
+// ---------------------------------------------------------------------------
+
+describe("messaging.formatTargetDisplay", () => {
+  const format = basecampMessagingAdapter.formatTargetDisplay!;
+
+  it("formats recording targets", () => {
+    expect(format({ target: "recording:123" })).toBe("Recording 123");
+  });
+
+  it("formats bucket targets", () => {
+    expect(format({ target: "bucket:456" })).toBe("Project 456");
+  });
+
+  it("formats ping targets", () => {
+    expect(format({ target: "ping:789" })).toBe("Ping 789");
+  });
+
+  it("returns raw target for unrecognized format", () => {
+    expect(format({ target: "unknown:abc" })).toBe("unknown:abc");
+  });
+});

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -505,6 +505,10 @@ describe("basecampStatusAdapter", () => {
   describe("probeAccount", () => {
     it("returns ok when bcq auth is successful", async () => {
       mockBcqAuthStatus.mockResolvedValue({ data: { authenticated: true } });
+      mockBcqMe.mockResolvedValue({
+        data: { name: "Jeremy", accounts: [{ id: 1, name: "Test" }] },
+        raw: "",
+      });
       const account = {
         accountId: "test",
         bcqProfile: "dev",
@@ -515,7 +519,10 @@ describe("basecampStatusAdapter", () => {
         timeoutMs: 5000,
         cfg: {} as any,
       });
-      expect(result).toEqual({ ok: true, authenticated: true });
+      expect(result.ok).toBe(true);
+      expect(result.authenticated).toBe(true);
+      expect(result.personName).toBe("Jeremy");
+      expect(result.accountCount).toBe(1);
     });
 
     it("returns not ok when bcq auth fails", async () => {

--- a/tests/project-scoping.test.ts
+++ b/tests/project-scoping.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+}));
+
+import {
+  listBasecampAccountIds,
+  resolveBasecampAccount,
+  resolveProjectScope,
+} from "../src/config.js";
+
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+// ---------------------------------------------------------------------------
+// resolveProjectScope
+// ---------------------------------------------------------------------------
+
+describe("resolveProjectScope", () => {
+  it("returns accountId and bucketId for a virtual account", () => {
+    const result = resolveProjectScope(
+      cfg({
+        virtualAccounts: {
+          "design-project": { accountId: "primary", bucketId: "12345" },
+        },
+      }),
+      "design-project",
+    );
+
+    expect(result).toEqual({ accountId: "primary", bucketId: "12345" });
+  });
+
+  it("returns undefined for non-existent scope", () => {
+    const result = resolveProjectScope(cfg({}), "nonexistent");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when virtualAccounts is empty", () => {
+    const result = resolveProjectScope(
+      cfg({ virtualAccounts: {} }),
+      "anything",
+    );
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listBasecampAccountIds — includes virtual accounts
+// ---------------------------------------------------------------------------
+
+describe("listBasecampAccountIds (with virtual accounts)", () => {
+  it("includes virtual account keys alongside real account keys", () => {
+    const result = listBasecampAccountIds(
+      cfg({
+        accounts: { primary: { personId: "1" } },
+        virtualAccounts: {
+          "design-project": { accountId: "primary", bucketId: "12345" },
+        },
+      }),
+    );
+
+    expect(result).toContain("primary");
+    expect(result).toContain("design-project");
+  });
+
+  it("sorts all IDs alphabetically", () => {
+    const result = listBasecampAccountIds(
+      cfg({
+        accounts: { zulu: { personId: "1" } },
+        virtualAccounts: {
+          alpha: { accountId: "zulu", bucketId: "1" },
+        },
+      }),
+    );
+
+    expect(result).toEqual(["alpha", "zulu"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBasecampAccount — virtual accounts
+// ---------------------------------------------------------------------------
+
+describe("resolveBasecampAccount (virtual accounts)", () => {
+  it("resolves virtual account to real account with scopedBucketId", () => {
+    const result = resolveBasecampAccount(
+      cfg({
+        accounts: {
+          primary: { personId: "42", token: "tok" },
+        },
+        virtualAccounts: {
+          "design-project": { accountId: "primary", bucketId: "12345" },
+        },
+      }),
+      "design-project",
+    );
+
+    expect(result.accountId).toBe("design-project");
+    expect(result.personId).toBe("42");
+    expect(result.token).toBe("tok");
+    expect(result.scopedBucketId).toBe("12345");
+  });
+
+  it("inherits token and bcqProfile from real account", () => {
+    const result = resolveBasecampAccount(
+      cfg({
+        accounts: {
+          primary: { personId: "42", bcqProfile: "prod" },
+        },
+        virtualAccounts: {
+          scoped: { accountId: "primary", bucketId: "999" },
+        },
+      }),
+      "scoped",
+    );
+
+    expect(result.bcqProfile).toBe("prod");
+    expect(result.tokenSource).toBe("bcq");
+  });
+
+  it("returns disabled stub when backing account missing", () => {
+    const result = resolveBasecampAccount(
+      cfg({
+        virtualAccounts: {
+          scoped: { accountId: "missing", bucketId: "123" },
+        },
+      }),
+      "scoped",
+    );
+
+    // The backing account doesn't exist, so we get a disabled stub
+    expect(result.accountId).toBe("scoped");
+    expect(result.enabled).toBe(false);
+    expect(result.scopedBucketId).toBe("123");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch project-scope routing
+// ---------------------------------------------------------------------------
+
+describe("dispatch project-scope routing", () => {
+  // This test verifies the resolveProjectScopeAccountId logic in dispatch.ts
+  // by testing the config-level helpers that feed into it.
+
+  it("resolveProjectScope matches by bucketId for routing", () => {
+    const config = cfg({
+      accounts: { primary: { personId: "1" } },
+      virtualAccounts: {
+        "design": { accountId: "primary", bucketId: "456" },
+        "eng": { accountId: "primary", bucketId: "789" },
+      },
+    });
+
+    expect(resolveProjectScope(config, "design")?.bucketId).toBe("456");
+    expect(resolveProjectScope(config, "eng")?.bucketId).toBe("789");
+    expect(resolveProjectScope(config, "marketing")).toBeUndefined();
+  });
+});

--- a/tests/project-scoping.test.ts
+++ b/tests/project-scoping.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+}));
+
+vi.mock("../src/bcq.js", () => ({
+  bcqApiGet: vi.fn(),
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(),
+}));
+
+import { basecampResolverAdapter } from "../src/adapters/resolver.js";
+import { bcqApiGet } from "../src/bcq.js";
+import { resolveBasecampAccount } from "../src/config.js";
+
+const mockAccount = {
+  accountId: "test",
+  enabled: true,
+  personId: "1",
+  token: "tok",
+  tokenSource: "config" as const,
+  bcqProfile: "default",
+  config: { personId: "1", bcqProfile: "default", bcqAccountId: "99" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolveBasecampAccount).mockReturnValue(mockAccount as any);
+});
+
+const people = [
+  { id: 10, name: "Alice Smith", email_address: "alice@example.com" },
+  { id: 20, name: "Bob Jones", email_address: "bob@example.com" },
+  { id: 30, name: "Carol Davis", email_address: "carol@example.com" },
+];
+
+const projects = [
+  { id: 100, name: "Design Project" },
+  { id: 200, name: "Engineering" },
+  { id: 300, name: "Marketing Campaign" },
+];
+
+// ---------------------------------------------------------------------------
+// resolveTargets — users
+// ---------------------------------------------------------------------------
+
+describe("resolver.resolveTargets (users)", () => {
+  it("resolves by exact ID", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(people);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["10"],
+      kind: "user",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([
+      { input: "10", resolved: true, id: "10", name: "Alice Smith" },
+    ]);
+  });
+
+  it("resolves by exact name (case-insensitive)", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(people);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["bob jones"],
+      kind: "user",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([
+      { input: "bob jones", resolved: true, id: "20", name: "Bob Jones" },
+    ]);
+  });
+
+  it("resolves by partial name", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(people);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["carol"],
+      kind: "user",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([
+      { input: "carol", resolved: true, id: "30", name: "Carol Davis" },
+    ]);
+  });
+
+  it("resolves by email prefix", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(people);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["alice@"],
+      kind: "user",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([
+      { input: "alice@", resolved: true, id: "10", name: "Alice Smith" },
+    ]);
+  });
+
+  it("returns unresolved for no match", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(people);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["nobody"],
+      kind: "user",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([{ input: "nobody", resolved: false }]);
+  });
+
+  it("handles API failure", async () => {
+    vi.mocked(bcqApiGet).mockRejectedValue(new Error("fail"));
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["alice"],
+      kind: "user",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([
+      { input: "alice", resolved: false, note: "Failed to fetch people list" },
+    ]);
+  });
+
+  it("resolves multiple inputs in one call", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(people);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["10", "bob", "nonexistent"],
+      kind: "user",
+      runtime: {} as any,
+    });
+
+    expect(results).toHaveLength(3);
+    expect(results[0]!.resolved).toBe(true);
+    expect(results[1]!.resolved).toBe(true);
+    expect(results[2]!.resolved).toBe(false);
+    // Fetch only called once
+    expect(bcqApiGet).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTargets — groups
+// ---------------------------------------------------------------------------
+
+describe("resolver.resolveTargets (groups)", () => {
+  it("resolves by bucket ID", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(projects);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["100"],
+      kind: "group",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([
+      { input: "100", resolved: true, id: "bucket:100", name: "Design Project" },
+    ]);
+  });
+
+  it("resolves by bucket:<id> prefix", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(projects);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["bucket:200"],
+      kind: "group",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([
+      { input: "bucket:200", resolved: true, id: "bucket:200", name: "Engineering" },
+    ]);
+  });
+
+  it("resolves by project name", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(projects);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["marketing"],
+      kind: "group",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([
+      { input: "marketing", resolved: true, id: "bucket:300", name: "Marketing Campaign" },
+    ]);
+  });
+
+  it("returns unresolved for no match", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(projects);
+
+    const results = await basecampResolverAdapter.resolveTargets({
+      cfg: {} as any,
+      inputs: ["nonexistent"],
+      kind: "group",
+      runtime: {} as any,
+    });
+
+    expect(results).toEqual([{ input: "nonexistent", resolved: false }]);
+  });
+});

--- a/tests/status-enhanced.test.ts
+++ b/tests/status-enhanced.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+}));
+
+vi.mock("../src/bcq.js", () => ({
+  bcqAuthStatus: vi.fn(),
+  bcqMe: vi.fn(),
+  bcqApiGet: vi.fn(),
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(),
+}));
+
+import { basecampStatusAdapter } from "../src/adapters/status.js";
+import type { BasecampProbe } from "../src/adapters/status.js";
+import { bcqAuthStatus, bcqMe, bcqApiGet } from "../src/bcq.js";
+import { resolveBasecampAccount } from "../src/config.js";
+import type { ResolvedBasecampAccount } from "../src/types.js";
+
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+const mockAccount: ResolvedBasecampAccount = {
+  accountId: "test",
+  enabled: true,
+  personId: "42",
+  token: "tok",
+  tokenSource: "config",
+  bcqProfile: "default",
+  config: { personId: "42", bcqProfile: "default", bcqAccountId: "99" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolveBasecampAccount).mockReturnValue(mockAccount);
+});
+
+// ---------------------------------------------------------------------------
+// probeAccount — enhanced with personName and accountCount
+// ---------------------------------------------------------------------------
+
+describe("probeAccount (enhanced)", () => {
+  it("returns personName and accountCount when authenticated", async () => {
+    vi.mocked(bcqAuthStatus).mockResolvedValue({
+      data: { authenticated: true },
+      raw: "",
+    });
+    vi.mocked(bcqMe).mockResolvedValue({
+      data: { name: "Jeremy", accounts: [{}, {}] },
+      raw: "",
+    } as any);
+
+    const probe = await basecampStatusAdapter.probeAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({}),
+    });
+
+    expect(probe.ok).toBe(true);
+    expect(probe.authenticated).toBe(true);
+    expect(probe.personName).toBe("Jeremy");
+    expect(probe.accountCount).toBe(2);
+  });
+
+  it("returns ok=false when not authenticated", async () => {
+    vi.mocked(bcqAuthStatus).mockResolvedValue({
+      data: { authenticated: false },
+      raw: "",
+    });
+
+    const probe = await basecampStatusAdapter.probeAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({}),
+    });
+
+    expect(probe.ok).toBe(false);
+    expect(probe.personName).toBeUndefined();
+  });
+
+  it("returns ok=false with error on exception", async () => {
+    vi.mocked(bcqAuthStatus).mockRejectedValue(new Error("network"));
+
+    const probe = await basecampStatusAdapter.probeAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({}),
+    });
+
+    expect(probe.ok).toBe(false);
+    expect(probe.error).toContain("network");
+  });
+
+  it("handles bcqMe failure gracefully", async () => {
+    vi.mocked(bcqAuthStatus).mockResolvedValue({
+      data: { authenticated: true },
+      raw: "",
+    });
+    vi.mocked(bcqMe).mockRejectedValue(new Error("fail"));
+
+    const probe = await basecampStatusAdapter.probeAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({}),
+    });
+
+    expect(probe.ok).toBe(true);
+    expect(probe.personName).toBeUndefined();
+    expect(probe.accountCount).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auditAccount
+// ---------------------------------------------------------------------------
+
+describe("auditAccount", () => {
+  it("counts accessible projects", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([
+      { id: 1, name: "P1" },
+      { id: 2, name: "P2" },
+    ]);
+
+    const audit = await basecampStatusAdapter.auditAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({
+        accounts: { test: { personId: "42", token: "tok" } },
+      }),
+    });
+
+    expect(audit.projectsAccessible).toBe(2);
+  });
+
+  it("validates persona mappings", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([]);
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      ...mockAccount,
+      token: "tok",
+    });
+
+    const audit = await basecampStatusAdapter.auditAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({
+        accounts: {
+          test: { personId: "42", token: "tok" },
+          other: { personId: "43", token: "tok2" },
+        },
+        personas: { "agent-1": "other", "agent-2": "missing" },
+      }),
+    });
+
+    expect(audit.personasMapped).toBe(2);
+    expect(audit.personasValid).toBe(1);
+    expect(audit.errors).toContainEqual(
+      expect.stringContaining("agent-2"),
+    );
+  });
+
+  it("reports API failure as error", async () => {
+    vi.mocked(bcqApiGet).mockRejectedValue(new Error("forbidden"));
+
+    const audit = await basecampStatusAdapter.auditAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({ accounts: { test: { personId: "42" } } }),
+    });
+
+    expect(audit.projectsAccessible).toBe(0);
+    expect(audit.errors).toContainEqual(
+      expect.stringContaining("Failed to verify project access"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectStatusIssues
+// ---------------------------------------------------------------------------
+
+describe("collectStatusIssues", () => {
+  it("flags unauthenticated accounts", () => {
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: false,
+        lastStartAt: null,
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: false, authenticated: false },
+      },
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.kind).toBe("auth");
+  });
+
+  it("returns empty for authenticated accounts", () => {
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        lastStartAt: null,
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+      },
+    ]);
+
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAccountState
+// ---------------------------------------------------------------------------
+
+describe("resolveAccountState", () => {
+  it("returns disabled when not enabled", () => {
+    expect(
+      basecampStatusAdapter.resolveAccountState!({
+        account: { ...mockAccount, enabled: false },
+        cfg: cfg({}),
+        configured: true,
+        enabled: false,
+      }),
+    ).toBe("disabled");
+  });
+
+  it("returns not configured when not configured", () => {
+    expect(
+      basecampStatusAdapter.resolveAccountState!({
+        account: mockAccount,
+        cfg: cfg({}),
+        configured: false,
+        enabled: true,
+      }),
+    ).toBe("not configured");
+  });
+
+  it("returns configured when enabled and configured", () => {
+    expect(
+      basecampStatusAdapter.resolveAccountState!({
+        account: mockAccount,
+        cfg: cfg({}),
+        configured: true,
+        enabled: true,
+      }),
+    ).toBe("configured");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAccountSnapshot
+// ---------------------------------------------------------------------------
+
+describe("buildAccountSnapshot (enhanced)", () => {
+  it("includes personName and accountCount from probe", () => {
+    const probe: BasecampProbe = {
+      ok: true,
+      authenticated: true,
+      personName: "Jeremy",
+      accountCount: 3,
+    };
+
+    const snapshot = basecampStatusAdapter.buildAccountSnapshot!({
+      account: mockAccount,
+      cfg: cfg({}),
+      probe,
+    });
+
+    expect(snapshot.personName).toBe("Jeremy");
+    expect(snapshot.accountCount).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/adapters/mentions.ts` implementing `ChannelMentionAdapter`
- `stripPatterns()` returns regex patterns for the agent's display name at message start
- `stripMentions()` strips agent name prefix with comma/colon separators, case-insensitive
- Wired into `channel.ts` as the `mentions` adapter slot

## New files
- `src/adapters/mentions.ts` — mentions adapter
- `tests/mentions-adapter.test.ts` — 13 tests

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 382 tests passing (369 existing + 13 new)
- [x] Strips agent name from message start (with colon, comma, space separators)
- [x] Preserves mid-message name occurrences
- [x] Escapes regex special characters in display names
- [x] Gracefully handles missing config/displayName