### PR TITLE
Group I: Add elevated, commands, and auth adapter stubs

### DIFF
--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -5,7 +5,7 @@
  * Phase 1 uses bcq for all Basecamp API access; native API replaces polling in Phase 2.
  */
 
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -269,6 +269,56 @@ export async function bcqProfileList(
     }
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Interactive auth helpers (used by channel auth adapter)
+// ---------------------------------------------------------------------------
+
+/**
+ * Launch `bcq auth login` as an interactive subprocess.
+ * This opens the browser for Basecamp OAuth and waits for completion.
+ */
+export async function execBcqAuthLogin(
+  opts: { profile?: string } = {},
+): Promise<void> {
+  const args = ["auth", "login"];
+  if (opts.profile) {
+    args.push("--profile", opts.profile);
+  }
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(BCQ_PATH, args, {
+      stdio: "inherit",
+      env: { ...process.env },
+    });
+
+    proc.on("error", (err: Error) => {
+      reject(
+        new BcqError(
+          `bcq auth login failed to start: ${err.message}`,
+          null,
+          "",
+          [BCQ_PATH, ...args],
+        ),
+      );
+    });
+
+    proc.on("close", (code: number | null) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new BcqError(
+            `bcq auth login exited with code ${code}`,
+            code,
+            "",
+            [BCQ_PATH, ...args],
+          ),
+        );
+      }
+    });
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -12,7 +12,7 @@ import {
 import { getBasecampRuntime } from "./runtime.js";
 import { sendBasecampText } from "./outbound/send.js";
 import { dispatchBasecampEvent } from "./dispatch.js";
-import { bcqAuthStatus } from "./bcq.js";
+import { bcqAuthStatus, execBcqAuthLogin } from "./bcq.js";
 import { basecampOnboardingAdapter } from "./adapters/onboarding.js";
 import { basecampSetupAdapter } from "./adapters/setup.js";
 import { basecampStatusAdapter } from "./adapters/status.js";
@@ -65,6 +65,23 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
   groups: basecampGroupAdapter,
 
   agentPrompt: basecampAgentPromptAdapter,
+
+  elevated: {
+    allowFromFallback: () => undefined,
+  },
+
+  commands: {
+    enforceOwnerForCommands: true,
+    skipWhenConfigEmpty: true,
+  },
+
+  auth: {
+    login: async ({ cfg, accountId }) => {
+      const account = resolveBasecampAccount(cfg, accountId);
+      const profile = account.bcqProfile;
+      await execBcqAuthLogin({ profile });
+    },
+  },
 
   reload: { configPrefixes: ["channels.basecamp"] },
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+  buildChannelConfigSchema: (schema: unknown) => schema,
+}));
+
+vi.mock("../src/bcq.js", () => ({
+  bcqAuthStatus: vi.fn(),
+  execBcqAuthLogin: vi.fn(),
+}));
+
+vi.mock("../src/config.js", () => ({
+  BasecampConfigSchema: {},
+  listBasecampAccountIds: vi.fn(),
+  resolveBasecampAccount: vi.fn(),
+  resolveBasecampAccountAsync: vi.fn(),
+  resolveDefaultBasecampAccountId: vi.fn(),
+}));
+
+vi.mock("../src/runtime.js", () => ({
+  getBasecampRuntime: vi.fn(),
+}));
+
+vi.mock("../src/outbound/send.js", () => ({
+  sendBasecampText: vi.fn(),
+}));
+
+vi.mock("../src/dispatch.js", () => ({
+  dispatchBasecampEvent: vi.fn(),
+}));
+
+vi.mock("../src/adapters/onboarding.js", () => ({
+  basecampOnboardingAdapter: {},
+}));
+
+vi.mock("../src/adapters/setup.js", () => ({
+  basecampSetupAdapter: {},
+}));
+
+vi.mock("../src/adapters/status.js", () => ({
+  basecampStatusAdapter: {},
+}));
+
+vi.mock("../src/adapters/pairing.js", () => ({
+  basecampPairingAdapter: {},
+}));
+
+vi.mock("../src/adapters/directory.js", () => ({
+  basecampDirectoryAdapter: {},
+}));
+
+vi.mock("../src/adapters/messaging.js", () => ({
+  basecampMessagingAdapter: {},
+}));
+
+vi.mock("../src/adapters/resolver.js", () => ({
+  basecampResolverAdapter: {},
+}));
+
+vi.mock("../src/adapters/heartbeat.js", () => ({
+  basecampHeartbeatAdapter: {},
+}));
+
+vi.mock("../src/adapters/groups.js", () => ({
+  basecampGroupAdapter: {},
+}));
+
+vi.mock("../src/adapters/agent-prompt.js", () => ({
+  basecampAgentPromptAdapter: {},
+}));
+
+import { basecampChannel } from "../src/channel.js";
+import { execBcqAuthLogin } from "../src/bcq.js";
+import { resolveBasecampAccount } from "../src/config.js";
+
+const mockAccount = {
+  accountId: "test",
+  enabled: true,
+  personId: "42",
+  token: "tok",
+  tokenSource: "config" as const,
+  bcqProfile: "myprofile",
+  config: { personId: "42", bcqProfile: "myprofile" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolveBasecampAccount).mockReturnValue(mockAccount as any);
+});
+
+// ---------------------------------------------------------------------------
+// auth.login
+// ---------------------------------------------------------------------------
+
+describe("auth.login", () => {
+  it("calls execBcqAuthLogin with the account's bcqProfile", async () => {
+    vi.mocked(execBcqAuthLogin).mockResolvedValue(undefined);
+
+    await basecampChannel.auth!.login!({
+      cfg: {} as any,
+      accountId: "test",
+      runtime: {} as any,
+    });
+
+    expect(execBcqAuthLogin).toHaveBeenCalledWith({ profile: "myprofile" });
+  });
+
+  it("calls execBcqAuthLogin with undefined profile when account has no bcqProfile", async () => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      ...mockAccount,
+      bcqProfile: undefined,
+    } as any);
+    vi.mocked(execBcqAuthLogin).mockResolvedValue(undefined);
+
+    await basecampChannel.auth!.login!({
+      cfg: {} as any,
+      accountId: "test",
+      runtime: {} as any,
+    });
+
+    expect(execBcqAuthLogin).toHaveBeenCalledWith({ profile: undefined });
+  });
+
+  it("propagates errors from execBcqAuthLogin", async () => {
+    vi.mocked(execBcqAuthLogin).mockRejectedValue(new Error("bcq auth login exited with code 1"));
+
+    await expect(
+      basecampChannel.auth!.login!({
+        cfg: {} as any,
+        accountId: "test",
+        runtime: {} as any,
+      }),
+    ).rejects.toThrow("bcq auth login exited with code 1");
+  });
+
+  it("uses default account when accountId is not provided", async () => {
+    vi.mocked(execBcqAuthLogin).mockResolvedValue(undefined);
+
+    await basecampChannel.auth!.login!({
+      cfg: {} as any,
+      runtime: {} as any,
+    });
+
+    expect(resolveBasecampAccount).toHaveBeenCalledWith({}, undefined);
+    expect(execBcqAuthLogin).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elevated.allowFromFallback
+// ---------------------------------------------------------------------------
+
+describe("elevated.allowFromFallback", () => {
+  it("returns undefined (no automatic fallback)", () => {
+    const result = basecampChannel.elevated!.allowFromFallback!({
+      cfg: {} as any,
+      accountId: "test",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined regardless of config contents", () => {
+    const result = basecampChannel.elevated!.allowFromFallback!({
+      cfg: { channels: { basecamp: { allowFrom: [1, 2, 3] } } } as any,
+      accountId: null,
+    });
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commands
+// ---------------------------------------------------------------------------
+
+describe("commands", () => {
+  it("enforces owner for commands", () => {
+    expect(basecampChannel.commands!.enforceOwnerForCommands).toBe(true);
+  });
+
+  it("skips when config is empty", () => {
+    expect(basecampChannel.commands!.skipWhenConfigEmpty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `elevated.allowFromFallback` — returns `undefined` (conscious choice: Basecamp has no cheap "team members" enumeration)
- Adds `commands` flags — `enforceOwnerForCommands: true`, `skipWhenConfigEmpty: true`
- Adds `auth.login` — resolves the account's `bcqProfile` and shells out to `bcq auth login` for interactive OAuth
- Adds `execBcqAuthLogin()` helper in `src/bcq.ts` that spawns bcq as an interactive subprocess

## Test plan

- [x] `tests/auth.test.ts` — 8 tests covering auth.login with/without profile, error propagation, elevated fallback, commands flags
- [x] `npx tsc --noEmit` clean
- [x] 377 tests passing