### PR TITLE
Group J: Deepen agent-prompt, status, and outbound adapters

### DIFF
--- a/src/adapters/agent-prompt.ts
+++ b/src/adapters/agent-prompt.ts
@@ -3,24 +3,67 @@
  *
  * Provides Basecamp-specific guidance to agents about peer ID formats,
  * mention conventions, threading model, surface types, and reactions.
+ * Hints are context-aware: virtual accounts, personas, and bucket configs
+ * produce additional guidance when present.
  */
 
-import type { ChannelPlugin } from "openclaw/plugin-sdk";
-import type { ResolvedBasecampAccount } from "../types.js";
+import type { ChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ResolvedBasecampAccount, BasecampChannelConfig } from "../types.js";
 
 // ChannelAgentPromptAdapter is not exported from the SDK, so extract it from ChannelPlugin.
 type AgentPromptAdapter = NonNullable<ChannelPlugin<ResolvedBasecampAccount>["agentPrompt"]>;
 
+function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
+  return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+}
+
+const STATIC_HINTS = [
+  "Basecamp peer IDs use the format recording:<id>, bucket:<id>, or ping:<id>.",
+  "To @mention someone in Basecamp, use their bc-attachment SGID tag.",
+  "Basecamp comments are flat per recording — there are no nested threads.",
+  "Basecamp surfaces include: Campfire (real-time chat), Card Table (kanban), " +
+    "Todo List, Check-in (recurring questions), Ping (direct messages), " +
+    "Message Board, and Documents.",
+  "Basecamp supports boost reactions on recordings.",
+  "Campfire messages and Ping messages are delivered as chat lines. " +
+    "All other surfaces receive comments on the recording.",
+];
+
 export const basecampAgentPromptAdapter: AgentPromptAdapter = {
-  messageToolHints: () => [
-    "Basecamp peer IDs use the format recording:<id>, bucket:<id>, or ping:<id>.",
-    "To @mention someone in Basecamp, use their bc-attachment SGID tag.",
-    "Basecamp comments are flat per recording — there are no nested threads.",
-    "Basecamp surfaces include: Campfire (real-time chat), Card Table (kanban), " +
-      "Todo List, Check-in (recurring questions), Ping (direct messages), " +
-      "Message Board, and Documents.",
-    "Basecamp supports boost reactions on recordings.",
-    "Campfire messages and Ping messages are delivered as chat lines. " +
-      "All other surfaces receive comments on the recording.",
-  ],
+  messageToolHints: ({ cfg, accountId }) => {
+    const hints = [...STATIC_HINTS];
+    const section = getBasecampSection(cfg);
+    if (!section) return hints;
+
+    // Virtual account (project-scoped) context
+    if (accountId && section.virtualAccounts?.[accountId]) {
+      const va = section.virtualAccounts[accountId];
+      hints.push(
+        `This account is project-scoped to bucket ${va.bucketId}. ` +
+        `Messages are limited to this specific Basecamp project.`,
+      );
+    }
+
+    // Persona mapping context
+    if (section.personas && Object.keys(section.personas).length > 0) {
+      hints.push(
+        "This channel uses persona mappings — different agents may send " +
+        "as different Basecamp identities.",
+      );
+    }
+
+    // Bucket-level requireMention settings
+    if (section.buckets) {
+      const mentionBuckets = Object.entries(section.buckets)
+        .filter(([, v]) => v?.requireMention === true)
+        .map(([k]) => k);
+      if (mentionBuckets.length > 0) {
+        hints.push(
+          `Some projects require @mention to trigger the agent: bucket(s) ${mentionBuckets.join(", ")}.`,
+        );
+      }
+    }
+
+    return hints;
+  },
 };

--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -167,19 +167,40 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
   },
 
   collectStatusIssues: (accounts) => {
-    // Status issues are collected per-channel from the account snapshots.
-    // Return issues for accounts with problems.
-    return accounts
-      .filter((s) => {
-        const probe = s.probe as BasecampProbe | undefined;
-        return probe && !probe.authenticated;
-      })
-      .map((s) => ({
-        channel: "basecamp" as const,
-        accountId: s.accountId,
-        kind: "auth" as const,
-        message: "Account is not authenticated",
-        fix: "Run `bcq auth login` to authenticate",
-      }));
+    const issues: Array<{
+      channel: "basecamp";
+      accountId: string;
+      kind: "auth" | "runtime" | "config";
+      message: string;
+      fix?: string;
+    }> = [];
+
+    for (const s of accounts) {
+      const probe = s.probe as BasecampProbe | undefined;
+
+      // Unauthenticated accounts
+      if (probe && !probe.authenticated) {
+        issues.push({
+          channel: "basecamp",
+          accountId: s.accountId,
+          kind: "auth",
+          message: "Account is not authenticated",
+          fix: "Run `bcq auth login` to authenticate",
+        });
+      }
+
+      // Configured but never started (no runtime record)
+      if (s.configured && s.enabled && !s.running && !s.lastStartAt) {
+        issues.push({
+          channel: "basecamp",
+          accountId: s.accountId,
+          kind: "runtime",
+          message: "Account is configured but has never started",
+          fix: "Start the channel with `openclaw start` or check gateway logs",
+        });
+      }
+    }
+
+    return issues;
   },
 };

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -183,8 +183,16 @@ export async function sendBasecampText(params: {
     );
   }
 
+  if (parsed.prefix === "bucket") {
+    throw new Error(
+      `sendBasecampText: cannot send to bucket peer "${to}" directly. ` +
+      `Bucket peers represent a project scope, not a specific conversation. ` +
+      `Use a recording: or ping: peer, or the dispatch bridge for replies.`,
+    );
+  }
+
   throw new Error(
     `sendBasecampText: unsupported peer format "${to}". ` +
-    `Expected "ping:<id>" or "recording:<id>".`,
+    `Expected "recording:<id>", "ping:<id>", or "bucket:<id>".`,
   );
 }

--- a/tests/agent-prompt.test.ts
+++ b/tests/agent-prompt.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { basecampAgentPromptAdapter } from "../src/adapters/agent-prompt.js";
 
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
 describe("agentPrompt.messageToolHints", () => {
   it("returns non-empty array of hints", () => {
     const hints = basecampAgentPromptAdapter.messageToolHints!({
@@ -42,5 +47,99 @@ describe("agentPrompt.messageToolHints", () => {
 
     expect(joined).toContain("flat");
     expect(joined).toContain("no nested threads");
+  });
+
+  // --- Dynamic hint tests ---
+
+  it("adds project-scoped hint for virtual account", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: cfg({
+        virtualAccounts: {
+          "project-x": { accountId: "main", bucketId: "12345" },
+        },
+      }),
+      accountId: "project-x",
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).toContain("project-scoped");
+    expect(joined).toContain("bucket 12345");
+  });
+
+  it("does not add project-scoped hint for non-virtual account", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: cfg({
+        virtualAccounts: {
+          "project-x": { accountId: "main", bucketId: "12345" },
+        },
+      }),
+      accountId: "main",
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).not.toContain("project-scoped");
+  });
+
+  it("adds persona mapping hint when personas configured", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: cfg({
+        personas: { "agent-1": "account-a", "agent-2": "account-b" },
+      }),
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).toContain("persona mappings");
+    expect(joined).toContain("different Basecamp identities");
+  });
+
+  it("does not add persona hint when no personas configured", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: cfg({ personas: {} }),
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).not.toContain("persona");
+  });
+
+  it("adds requireMention hint when buckets have requireMention", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: cfg({
+        buckets: {
+          "111": { requireMention: true },
+          "222": { requireMention: false },
+          "333": { requireMention: true },
+        },
+      }),
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).toContain("require @mention");
+    expect(joined).toContain("111");
+    expect(joined).toContain("333");
+    expect(joined).not.toContain("222");
+  });
+
+  it("does not add requireMention hint when no buckets require it", () => {
+    const hints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: cfg({
+        buckets: {
+          "111": { requireMention: false },
+        },
+      }),
+    });
+    const joined = hints.join(" ");
+
+    expect(joined).not.toContain("require @mention");
+  });
+
+  it("returns only static hints when config has no dynamic sections", () => {
+    const staticHints = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: {} as any,
+    });
+    const withEmpty = basecampAgentPromptAdapter.messageToolHints!({
+      cfg: cfg({}),
+    });
+
+    expect(staticHints).toEqual(withEmpty);
   });
 });

--- a/tests/status-enhanced.test.ts
+++ b/tests/status-enhanced.test.ts
@@ -204,12 +204,14 @@ describe("collectStatusIssues", () => {
     expect(issues[0]!.kind).toBe("auth");
   });
 
-  it("returns empty for authenticated accounts", () => {
+  it("returns empty for authenticated running accounts", () => {
     const issues = basecampStatusAdapter.collectStatusIssues!([
       {
         accountId: "test",
         running: true,
-        lastStartAt: null,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
         lastStopAt: null,
         lastError: null,
         probe: { ok: true, authenticated: true },
@@ -217,6 +219,70 @@ describe("collectStatusIssues", () => {
     ]);
 
     expect(issues).toHaveLength(0);
+  });
+
+  it("flags configured-but-never-started accounts", () => {
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        configured: true,
+        enabled: true,
+        running: false,
+        lastStartAt: null,
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+      },
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.kind).toBe("runtime");
+    expect(issues[0]!.message).toContain("never started");
+  });
+
+  it("does not flag stopped accounts that have started before", () => {
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        configured: true,
+        enabled: true,
+        running: false,
+        lastStartAt: Date.now() - 60_000,
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+      },
+    ]);
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it("can report both auth and runtime issues for different accounts", () => {
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "unauthed",
+        probe: { ok: false, authenticated: false },
+        running: false,
+        lastStartAt: null,
+        lastStopAt: null,
+        lastError: null,
+      },
+      {
+        accountId: "never-started",
+        configured: true,
+        enabled: true,
+        running: false,
+        lastStartAt: null,
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+      },
+    ]);
+
+    expect(issues).toHaveLength(2);
+    const kinds = issues.map((i) => i.kind);
+    expect(kinds).toContain("auth");
+    expect(kinds).toContain("runtime");
   });
 });
 


### PR DESCRIPTION
## Summary

- **Agent prompt**: `messageToolHints` is now context-aware — appends hints for project-scoped virtual accounts, persona mappings, and per-bucket `requireMention` settings
- **Status**: `collectStatusIssues` detects configured-but-never-started accounts (kind: `runtime`) alongside unauthenticated accounts (kind: `auth`)
- **Outbound**: `sendBasecampText` adds explicit error path for `bucket:` peers explaining they're a project scope, not a conversation target

## Test plan

- [x] `tests/agent-prompt.test.ts` — 11 tests (4 existing static + 7 new dynamic hint cases)
- [x] `tests/status-enhanced.test.ts` — 16 tests (added never-started, multi-account issue detection)
- [x] `npx tsc --noEmit` clean
- [x] 379 tests passing