### PR TITLE
Group M: integration tests + helpers

### DIFF
--- a/tests/error-scenarios.test.ts
+++ b/tests/error-scenarios.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Error scenario tests for bcq failure paths.
+ *
+ * Mocks node:child_process to simulate various bcq failure modes
+ * (timeout, invalid JSON, auth failure, empty output, network errors).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import { bcqGet, bcqMe, bcqTimeline, bcqAuthStatus, BcqError } from "../src/bcq.js";
+import { execFile } from "node:child_process";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// BcqError class
+// ---------------------------------------------------------------------------
+
+describe("BcqError", () => {
+  it("has correct name, message, exitCode, stderr, command", () => {
+    const err = new BcqError("test error", 42, "stderr output", ["bcq", "me"]);
+    expect(err.name).toBe("BcqError");
+    expect(err.message).toBe("test error");
+    expect(err.exitCode).toBe(42);
+    expect(err.stderr).toBe("stderr output");
+    expect(err.command).toEqual(["bcq", "me"]);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("accepts null exitCode for non-process errors", () => {
+    const err = new BcqError("parse error", null, "", []);
+    expect(err.exitCode).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bcqGet error paths
+// ---------------------------------------------------------------------------
+
+describe("bcqGet error scenarios", () => {
+  it("throws BcqError on timeout (killed process)", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err = new Error("Command timed out") as any;
+      err.killed = true;
+      err.code = null;
+      cb(err, "", "");
+      return {} as any;
+    });
+
+    await expect(bcqGet("/test.json")).rejects.toThrow(BcqError);
+    await expect(bcqGet("/test.json")).rejects.toThrow(/timed out/i);
+  });
+
+  it("throws BcqError on invalid JSON output", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, "not valid json{{{", "");
+      return {} as any;
+    });
+
+    await expect(bcqGet("/test.json")).rejects.toThrow(BcqError);
+    await expect(bcqGet("/test.json")).rejects.toThrow(/not valid JSON/i);
+  });
+
+  it("throws BcqError with correct properties on auth failure", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err = new Error("exit code 1") as any;
+      err.code = 1;
+      cb(err, "", "HTTP 401 Unauthorized");
+      return {} as any;
+    });
+
+    try {
+      await bcqGet("/test.json");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BcqError);
+      const bcqErr = err as BcqError;
+      expect(bcqErr.exitCode).toBe(1);
+      expect(bcqErr.stderr).toContain("401");
+    }
+  });
+
+  it("returns empty array for empty stdout", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, "", "");
+      return {} as any;
+    });
+
+    const result = await bcqGet("/test.json");
+    expect(result.data).toEqual([]);
+  });
+
+  it("returns empty array for whitespace-only stdout", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, "   \n  ", "");
+      return {} as any;
+    });
+
+    const result = await bcqGet("/test.json");
+    expect(result.data).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bcqAuthStatus failure paths
+// ---------------------------------------------------------------------------
+
+describe("bcqAuthStatus error scenarios", () => {
+  it("returns authenticated=false on BcqError", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err = new Error("not authenticated") as any;
+      err.code = 1;
+      cb(err, "", "Not authenticated");
+      return {} as any;
+    });
+
+    const result = await bcqAuthStatus();
+    expect(result.data.authenticated).toBe(false);
+  });
+
+  it("returns authenticated=false when response lacks authenticated field", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify({ status: "unknown" }), "");
+      return {} as any;
+    });
+
+    const result = await bcqAuthStatus();
+    expect(result.data.authenticated).toBe(false);
+  });
+
+  it("returns authenticated=true when response has authenticated=true", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify({ authenticated: true }), "");
+      return {} as any;
+    });
+
+    const result = await bcqAuthStatus();
+    expect(result.data.authenticated).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bcqMe failure paths
+// ---------------------------------------------------------------------------
+
+describe("bcqMe error scenarios", () => {
+  it("throws BcqError on network error", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err = new Error("ECONNREFUSED") as any;
+      err.code = null;
+      cb(err, "", "ECONNREFUSED");
+      return {} as any;
+    });
+
+    await expect(bcqMe()).rejects.toThrow(BcqError);
+  });
+
+  it("throws BcqError with stderr on process failure", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err = new Error("process failed") as any;
+      err.code = 2;
+      cb(err, "", "bcq: command not found");
+      return {} as any;
+    });
+
+    try {
+      await bcqMe();
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BcqError);
+      const bcqErr = err as BcqError;
+      expect(bcqErr.exitCode).toBe(2);
+      expect(bcqErr.stderr).toContain("command not found");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bcqTimeline with unexpected but valid JSON
+// ---------------------------------------------------------------------------
+
+describe("bcqTimeline error scenarios", () => {
+  it("handles unexpected but valid JSON shape", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify({ unexpected: true }), "");
+      return {} as any;
+    });
+
+    const result = await bcqTimeline();
+    expect(result.data).toEqual({ unexpected: true });
+  });
+
+  it("handles valid JSON array", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([{ id: 1 }, { id: 2 }]), "");
+      return {} as any;
+    });
+
+    const result = await bcqTimeline<any[]>();
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].id).toBe(1);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared test helpers for the Basecamp OpenClaw plugin.
+ * Provides factory functions for common test fixtures.
+ *
+ * This file does NOT contain any test code (no describe/it/expect).
+ * Import these helpers into test files that need them.
+ */
+import type { ResolvedBasecampAccount, BasecampInboundMessage, BasecampInboundMeta } from "../src/types.js";
+
+/**
+ * Build a minimal OpenClaw config object with optional basecamp section.
+ */
+export function cfg(basecamp?: Record<string, unknown>): any {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+/**
+ * Build a config with pre-configured accounts.
+ */
+export function cfgWithAccounts(
+  accounts: Record<string, { personId: string; token?: string; bcqProfile?: string; bcqAccountId?: string }>,
+  extra?: Record<string, unknown>,
+): any {
+  return cfg({ accounts, ...extra });
+}
+
+/**
+ * Build a default ResolvedBasecampAccount for testing.
+ */
+export function stubAccount(overrides?: Partial<ResolvedBasecampAccount>): ResolvedBasecampAccount {
+  return {
+    accountId: "test-acct",
+    enabled: true,
+    personId: "999",
+    token: "tok-test",
+    tokenSource: "config",
+    config: { personId: "999" },
+    ...overrides,
+  };
+}
+
+/**
+ * Build a default BasecampInboundMessage for testing.
+ */
+export function stubMsg(overrides?: Partial<BasecampInboundMessage> & { meta?: Partial<BasecampInboundMeta> }): BasecampInboundMessage {
+  const meta: BasecampInboundMeta = {
+    bucketId: "456",
+    recordingId: "123",
+    recordableType: "Chat::Transcript",
+    eventKind: "line_created",
+    mentions: [],
+    mentionsAgent: false,
+    attachments: [],
+    sources: ["activity_feed"],
+    ...overrides?.meta,
+  };
+
+  return {
+    channel: "basecamp",
+    accountId: "test-acct",
+    peer: { kind: "group", id: "recording:123" },
+    parentPeer: { kind: "group", id: "bucket:456" },
+    sender: { id: "777", name: "Test User" },
+    text: "Hello from tests",
+    html: "<p>Hello from tests</p>",
+    dedupKey: "activity:test-1",
+    createdAt: "2025-01-15T10:00:00Z",
+    ...overrides,
+    meta,
+  };
+}
+
+/**
+ * Standard mock factory for openclaw/plugin-sdk.
+ * Use in vi.mock("openclaw/plugin-sdk", () => sdkMock())
+ */
+export function sdkMock() {
+  return {
+    DEFAULT_ACCOUNT_ID: "default",
+    normalizeAccountId: (value: string | undefined | null): string => {
+      const trimmed = (value ?? "").trim();
+      return trimmed || "default";
+    },
+  };
+}
+
+/**
+ * Standard mock runtime factory for tests that need getBasecampRuntime.
+ */
+export function stubRuntime(overrides?: Record<string, unknown>) {
+  return {
+    config: {
+      loadConfig: () => ({
+        channels: {
+          basecamp: {
+            accounts: { "test-acct": { personId: "999" } },
+          },
+        },
+      }),
+    },
+    channel: {
+      routing: { resolveAgentRoute: () => null },
+      reply: { dispatchReplyWithBufferedBlockDispatcher: async () => {} },
+    },
+    ...overrides,
+  };
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -19,7 +19,7 @@ export function cfg(basecamp?: Record<string, unknown>): any {
  * Build a config with pre-configured accounts.
  */
 export function cfgWithAccounts(
-  accounts: Record<string, { personId: string; token?: string; bcqProfile?: string; bcqAccountId?: string }>,
+  accounts: Record<string, Record<string, unknown>>,
   extra?: Record<string, unknown>,
 ): any {
   return cfg({ accounts, ...extra });

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -288,7 +288,15 @@ describeIntegration("smoke: status adapter integration", () => {
     const probe = await basecampStatusAdapter.probeAccount!({
       account: testAccount,
       timeoutMs: 10000,
-      cfg: { channels: { basecamp: { accounts: { "2914079": { personId: "3" } } } } } as any,
+      cfg: {
+        channels: {
+          basecamp: {
+            accounts: {
+              [testAccount.accountId]: { personId: testAccount.personId },
+            },
+          },
+        },
+      } as any,
     });
     expect(probe.ok).toBe(true);
     expect(probe.authenticated).toBe(true);

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -3,17 +3,27 @@
  *
  * These tests call the real plugin functions (pollActivityFeed, bcqGet, etc.)
  * and verify they handle real API responses correctly. This is NOT a unit test
- * with mocked responses — it hits the live API via bcq.
+ * with mocked responses -- it hits the live API via bcq.
  *
- * Run with: npx vitest run tests/smoke.test.ts
+ * Gated behind OPENCLAW_INTEGRATION=1. When the env var is unset, all tests
+ * are skipped (shown as "skipped" in vitest output).
+ *
+ * Run with: OPENCLAW_INTEGRATION=1 npx vitest run tests/smoke.test.ts
  */
 
 import { describe, it, expect } from "vitest";
-import { bcqGet, bcqMe, bcqTimeline, bcqReadings } from "../src/bcq.js";
+import { bcqGet, bcqMe, bcqTimeline, bcqReadings, bcqApiGet } from "../src/bcq.js";
 import { pollActivityFeed } from "../src/inbound/activity.js";
 import { pollReadings } from "../src/inbound/readings.js";
 import { EventDedup } from "../src/inbound/dedup.js";
 import type { ResolvedBasecampAccount } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Integration gate
+// ---------------------------------------------------------------------------
+
+const INTEGRATION_ENABLED = process.env.OPENCLAW_INTEGRATION === "1";
+const describeIntegration = INTEGRATION_ENABLED ? describe : describe.skip;
 
 // ---------------------------------------------------------------------------
 // Shared test account (uses bcq's default authenticated account)
@@ -36,10 +46,10 @@ const log = {
 };
 
 // ---------------------------------------------------------------------------
-// bcq.ts — verify our wrapper works
+// bcq.ts -- verify our wrapper works
 // ---------------------------------------------------------------------------
 
-describe("smoke: bcq.ts", () => {
+describeIntegration("smoke: bcq.ts", () => {
   it("bcqMe returns authenticated user", async () => {
     const result = await bcqMe();
     expect(result.data).toBeDefined();
@@ -77,7 +87,7 @@ describe("smoke: bcq.ts", () => {
     const result = await bcqReadings<any>({
       accountId: testAccount.accountId,
     });
-    // 204 No Content → null, 200 → { unreads, reads, memories }
+    // 204 No Content -> null, 200 -> { unreads, reads, memories }
     if (result.data === null) {
       console.log("bcqReadings: 204 No Content (no unread items)");
     } else {
@@ -88,10 +98,10 @@ describe("smoke: bcq.ts", () => {
 });
 
 // ---------------------------------------------------------------------------
-// pollActivityFeed — the full pipeline
+// pollActivityFeed -- the full pipeline
 // ---------------------------------------------------------------------------
 
-describe("smoke: pollActivityFeed", () => {
+describeIntegration("smoke: pollActivityFeed", () => {
   it("polls activity feed and returns normalized events", async () => {
     const result = await pollActivityFeed({
       account: testAccount,
@@ -161,7 +171,7 @@ describe("smoke: pollActivityFeed", () => {
     const first = await pollActivityFeed({ account: testAccount, log });
     expect(first.events.length).toBeGreaterThan(0);
 
-    // Second poll: use the newest timestamp as cursor — should get 0 events
+    // Second poll: use the newest timestamp as cursor -- should get 0 events
     const second = await pollActivityFeed({
       account: testAccount,
       since: first.newestAt,
@@ -176,10 +186,10 @@ describe("smoke: pollActivityFeed", () => {
 });
 
 // ---------------------------------------------------------------------------
-// pollReadings — the full pipeline
+// pollReadings -- the full pipeline
 // ---------------------------------------------------------------------------
 
-describe("smoke: pollReadings", () => {
+describeIntegration("smoke: pollReadings", () => {
   it("pollReadings handles empty and populated responses", async () => {
     const result = await pollReadings({ account: testAccount, log });
 
@@ -199,10 +209,10 @@ describe("smoke: pollReadings", () => {
 });
 
 // ---------------------------------------------------------------------------
-// EventDedup — cross-source dedup with real events
+// EventDedup -- cross-source dedup with real events
 // ---------------------------------------------------------------------------
 
-describe("smoke: EventDedup with real events", () => {
+describeIntegration("smoke: EventDedup with real events", () => {
   it("dedup correctly tracks real activity events", async () => {
     const dedup = new EventDedup({ ttlMs: 60_000 });
 
@@ -238,17 +248,50 @@ describe("smoke: EventDedup with real events", () => {
 // URL parsing against real app_urls
 // ---------------------------------------------------------------------------
 
-describe("smoke: URL parsing with real data", () => {
+describeIntegration("smoke: URL parsing with real data", () => {
   it("parseBucketIdFromUrl handles all real app_urls", async () => {
     const result = await pollActivityFeed({ account: testAccount, log });
 
     for (const msg of result.events) {
-      // The meta should have a bucketId — verify our URL parser agrees
+      // The meta should have a bucketId -- verify our URL parser agrees
       if (msg.meta.bucketId) {
         // Reconstruct: every event came from an app_url that had a bucket
         // We can't get the original URL, but we can check the ID is numeric
         expect(msg.meta.bucketId).toMatch(/^\d+$/);
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Directory listing integration
+// ---------------------------------------------------------------------------
+
+describeIntegration("smoke: directory integration", () => {
+  it("bcqApiGet /people.json returns people array", async () => {
+    const people = await bcqApiGet<any[]>("/people.json", testAccount.accountId);
+    expect(Array.isArray(people)).toBe(true);
+    expect(people.length).toBeGreaterThan(0);
+    expect(people[0]).toHaveProperty("id");
+    expect(people[0]).toHaveProperty("name");
+    console.log(`Directory: ${people.length} people`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status probe integration
+// ---------------------------------------------------------------------------
+
+describeIntegration("smoke: status adapter integration", () => {
+  it("probeAccount returns successful probe for real account", async () => {
+    const { basecampStatusAdapter } = await import("../src/adapters/status.js");
+    const probe = await basecampStatusAdapter.probeAccount!({
+      account: testAccount,
+      timeoutMs: 10000,
+      cfg: { channels: { basecamp: { accounts: { "2914079": { personId: "3" } } } } } as any,
+    });
+    expect(probe.ok).toBe(true);
+    expect(probe.authenticated).toBe(true);
+    console.log("Status probe:", JSON.stringify(probe));
   });
 });


### PR DESCRIPTION
## Summary

- Extract shared test factories into `tests/helpers.ts` (cfg, cfgWithAccounts, stubAccount, stubMsg, sdkMock, stubRuntime)
- Add `tests/error-scenarios.test.ts` with 14 tests covering bcq failure paths (timeout, invalid JSON, auth failure, empty output, network errors, BcqError properties)
- Gate all smoke tests behind `OPENCLAW_INTEGRATION=1` env var using `describe.skip` so they don't run in CI by default
- Add new integration test sections for directory listing and status probe

## Test plan

- [x] `npx vitest run` passes (386 passed, 11 skipped)
- [x] `npx tsc --noEmit` clean
- [x] Error scenario tests exercise mocked `node:child_process` to verify BcqError handling
- [x] Smoke tests show as "skipped" when OPENCLAW_INTEGRATION is unset
- [ ] `OPENCLAW_INTEGRATION=1 npx vitest run tests/smoke.test.ts` runs integration tests against live API