### PR TITLE
Group K: bcq retry + circuit breaker

### DIFF
--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -64,7 +64,7 @@ export class BcqError extends Error {
 // ---------------------------------------------------------------------------
 
 const TRANSIENT_PATTERNS = ["ETIMEDOUT", "ECONNREFUSED", "ECONNRESET"];
-const SERVER_ERROR_PATTERNS = ["5xx", "502", "503", "504"];
+const SERVER_ERROR_PATTERNS = ["5xx", "500", "501", "502", "503", "504"];
 const PERMANENT_PATTERNS = [
   "401",
   "403",
@@ -136,6 +136,8 @@ interface CircuitState {
   failures: number;
   trippedAt: number | null;
   cooldownMs: number;
+  /** True while a half-open probe is in flight — blocks other callers. */
+  halfOpenProbe: boolean;
 }
 
 export class CircuitBreaker {
@@ -153,7 +155,9 @@ export class CircuitBreaker {
     if (!state || state.trippedAt === null) return false;
     const elapsed = Date.now() - state.trippedAt;
     if (elapsed >= state.cooldownMs) {
-      // Half-open: allow one attempt through
+      // Half-open: allow exactly one probe through
+      if (state.halfOpenProbe) return true;
+      state.halfOpenProbe = true;
       return false;
     }
     return true;
@@ -164,8 +168,10 @@ export class CircuitBreaker {
       failures: 0,
       trippedAt: null,
       cooldownMs: this.cooldownMs,
+      halfOpenProbe: false,
     };
     state.failures++;
+    state.halfOpenProbe = false;
     if (state.failures >= this.threshold) {
       state.trippedAt = Date.now();
     }
@@ -177,6 +183,7 @@ export class CircuitBreaker {
     if (!state) return;
     state.failures = 0;
     state.trippedAt = null;
+    state.halfOpenProbe = false;
   }
 
   reset(key: string): void {
@@ -261,7 +268,7 @@ function execBcq<T = unknown>(args: string[], opts: BcqOptions = {}): Promise<Bc
             raw,
             [BCQ_PATH, ...fullArgs],
           );
-          cb?.instance.recordFailure(cb.key);
+          // JSON parse errors are not transient — don't trip the circuit breaker
           reject(err);
         }
       },
@@ -331,7 +338,8 @@ export async function bcqMe(
 ): Promise<
   BcqResult<{ id: number; name: string; email_address: string; attachable_sgid?: string }>
 > {
-  return execBcq(["me"], opts);
+  const fn = () => execBcq<{ id: number; name: string; email_address: string; attachable_sgid?: string }>(["me"], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
 // ---------------------------------------------------------------------------
@@ -343,7 +351,8 @@ export async function bcqMe(
  * Returns an array of timeline events (newest first).
  */
 export async function bcqTimeline<T = unknown>(opts: BcqOptions = {}): Promise<BcqResult<T>> {
-  return execBcq<T>(["timeline"], opts);
+  const fn = () => execBcq<T>(["timeline"], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
 /**
@@ -351,7 +360,8 @@ export async function bcqTimeline<T = unknown>(opts: BcqOptions = {}): Promise<B
  * No dedicated bcq command exists yet — uses raw API.
  */
 export async function bcqReadings<T = unknown>(opts: BcqOptions = {}): Promise<BcqResult<T>> {
-  return execBcq<T>(["api", "get", "/my/readings.json"], opts);
+  const fn = () => execBcq<T>(["api", "get", "/my/readings.json"], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -14,6 +14,19 @@ const BCQ_PATH = process.env.BCQ_BIN ?? join(homedir(), ".local", "bin", "bcq");
 /** Default timeout for bcq commands (30 seconds). */
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+export interface RetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  jitter?: boolean;
+  retryable?: (err: BcqError) => boolean;
+}
+
+export interface CircuitBreakerOptions {
+  threshold?: number;
+  cooldownMs?: number;
+}
+
 export interface BcqOptions {
   /** Basecamp account ID for --account flag. */
   accountId?: string;
@@ -23,6 +36,10 @@ export interface BcqOptions {
   timeoutMs?: number;
   /** Extra CLI flags to append. */
   extraFlags?: string[];
+  /** Retry options for transient failures. */
+  retry?: RetryOptions;
+  /** Circuit breaker to fail fast on repeated failures. */
+  circuitBreaker?: { instance: CircuitBreaker; key: string };
 }
 
 export interface BcqResult<T = unknown> {
@@ -42,13 +59,152 @@ export class BcqError extends Error {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+const TRANSIENT_PATTERNS = ["ETIMEDOUT", "ECONNREFUSED", "ECONNRESET"];
+const SERVER_ERROR_PATTERNS = ["5xx", "502", "503", "504"];
+const PERMANENT_PATTERNS = [
+  "401",
+  "403",
+  "Unauthorized",
+  "Forbidden",
+  "404",
+  "Not Found",
+  "422",
+  "Unprocessable",
+];
+
+export function isRetryableError(err: BcqError): boolean {
+  // JSON parse errors (exitCode null, no process error) are not retryable
+  if (err.exitCode === null) return false;
+
+  const { stderr } = err;
+
+  // Permanent errors — never retry
+  if (PERMANENT_PATTERNS.some((p) => stderr.includes(p))) return false;
+
+  // Transient network errors
+  if (TRANSIENT_PATTERNS.some((p) => stderr.includes(p))) return true;
+
+  // Server errors (5xx) with exit code 1
+  if (err.exitCode === 1 && SERVER_ERROR_PATTERNS.some((p) => stderr.includes(p))) return true;
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Retry wrapper
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withRetry<T>(fn: () => Promise<T>, opts?: RetryOptions): Promise<T> {
+  const maxAttempts = opts?.maxAttempts ?? 3;
+  const baseDelayMs = opts?.baseDelayMs ?? 1000;
+  const maxDelayMs = opts?.maxDelayMs ?? 30000;
+  const jitter = opts?.jitter ?? true;
+  const classify = opts?.retryable ?? isRetryableError;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (!(err instanceof BcqError) || !classify(err)) throw err;
+      if (attempt + 1 >= maxAttempts) break;
+
+      let delay = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+      if (jitter) {
+        delay -= delay * Math.random() * 0.25;
+      }
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
+// ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+
+interface CircuitState {
+  failures: number;
+  trippedAt: number | null;
+  cooldownMs: number;
+}
+
+export class CircuitBreaker {
+  private circuits = new Map<string, CircuitState>();
+  private threshold: number;
+  private cooldownMs: number;
+
+  constructor(opts?: CircuitBreakerOptions) {
+    this.threshold = opts?.threshold ?? 5;
+    this.cooldownMs = opts?.cooldownMs ?? 5 * 60 * 1000;
+  }
+
+  isOpen(key: string): boolean {
+    const state = this.circuits.get(key);
+    if (!state || state.trippedAt === null) return false;
+    const elapsed = Date.now() - state.trippedAt;
+    if (elapsed >= state.cooldownMs) {
+      // Half-open: allow one attempt through
+      return false;
+    }
+    return true;
+  }
+
+  recordFailure(key: string): void {
+    const state = this.circuits.get(key) ?? {
+      failures: 0,
+      trippedAt: null,
+      cooldownMs: this.cooldownMs,
+    };
+    state.failures++;
+    if (state.failures >= this.threshold) {
+      state.trippedAt = Date.now();
+    }
+    this.circuits.set(key, state);
+  }
+
+  recordSuccess(key: string): void {
+    const state = this.circuits.get(key);
+    if (!state) return;
+    state.failures = 0;
+    state.trippedAt = null;
+  }
+
+  reset(key: string): void {
+    this.circuits.delete(key);
+  }
+
+  getState(key: string): { failures: number; trippedAt: number | null } | undefined {
+    const state = this.circuits.get(key);
+    if (!state) return undefined;
+    return { failures: state.failures, trippedAt: state.trippedAt };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core bcq execution
+// ---------------------------------------------------------------------------
+
 /**
  * Execute a bcq command and return parsed JSON output.
  */
-function execBcq<T = unknown>(
-  args: string[],
-  opts: BcqOptions = {},
-): Promise<BcqResult<T>> {
+function execBcq<T = unknown>(args: string[], opts: BcqOptions = {}): Promise<BcqResult<T>> {
+  const cb = opts.circuitBreaker;
+  if (cb && cb.instance.isOpen(cb.key)) {
+    return Promise.reject(
+      new BcqError(`Circuit breaker open for ${cb.key}`, null, "", args),
+    );
+  }
+
   const fullArgs = ["--agent", ...args];
 
   if (opts.accountId) {
@@ -65,7 +221,7 @@ function execBcq<T = unknown>(
 
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  return new Promise((resolve, reject) => {
+  return new Promise<BcqResult<T>>((resolve, reject) => {
     execFile(
       BCQ_PATH,
       fullArgs,
@@ -76,35 +232,37 @@ function execBcq<T = unknown>(
       },
       (error, stdout, stderr) => {
         if (error) {
-          reject(
-            new BcqError(
-              `bcq failed: ${error.message}`,
-              error.code != null ? Number(error.code) : null,
-              stderr,
-              [BCQ_PATH, ...fullArgs],
-            ),
+          const err = new BcqError(
+            `bcq failed: ${error.message}`,
+            error.code != null ? Number(error.code) : null,
+            stderr,
+            [BCQ_PATH, ...fullArgs],
           );
+          cb?.instance.recordFailure(cb.key);
+          reject(err);
           return;
         }
 
         const raw = stdout.trim();
         if (!raw) {
+          cb?.instance.recordSuccess(cb.key);
           resolve({ data: [] as unknown as T, raw });
           return;
         }
 
         try {
           const data = JSON.parse(raw) as T;
+          cb?.instance.recordSuccess(cb.key);
           resolve({ data, raw });
         } catch (parseErr) {
-          reject(
-            new BcqError(
-              `bcq output is not valid JSON: ${String(parseErr)}`,
-              null,
-              raw,
-              [BCQ_PATH, ...fullArgs],
-            ),
+          const err = new BcqError(
+            `bcq output is not valid JSON: ${String(parseErr)}`,
+            null,
+            raw,
+            [BCQ_PATH, ...fullArgs],
           );
+          cb?.instance.recordFailure(cb.key);
+          reject(err);
         }
       },
     );
@@ -121,7 +279,8 @@ export async function bcqGet<T = unknown>(
   path: string,
   opts: BcqOptions = {},
 ): Promise<BcqResult<T>> {
-  return execBcq<T>(["api", "get", path], opts);
+  const fn = () => execBcq<T>(["api", "get", path], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
 /**
@@ -137,7 +296,8 @@ export async function bcqPost<T = unknown>(
   path: string,
   opts: BcqOptions = {},
 ): Promise<BcqResult<T>> {
-  return execBcq<T>(["api", "post", path], opts);
+  const fn = () => execBcq<T>(["api", "post", path], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
 /**
@@ -147,7 +307,8 @@ export async function bcqPut<T = unknown>(
   path: string,
   opts: BcqOptions = {},
 ): Promise<BcqResult<T>> {
-  return execBcq<T>(["api", "put", path], opts);
+  const fn = () => execBcq<T>(["api", "put", path], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
 /**
@@ -157,7 +318,8 @@ export async function bcqDelete<T = unknown>(
   path: string,
   opts: BcqOptions = {},
 ): Promise<BcqResult<T>> {
-  return execBcq<T>(["api", "delete", path], opts);
+  const fn = () => execBcq<T>(["api", "delete", path], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
 /**
@@ -166,7 +328,9 @@ export async function bcqDelete<T = unknown>(
  */
 export async function bcqMe(
   opts: BcqOptions = {},
-): Promise<BcqResult<{ id: number; name: string; email_address: string; attachable_sgid?: string }>> {
+): Promise<
+  BcqResult<{ id: number; name: string; email_address: string; attachable_sgid?: string }>
+> {
   return execBcq(["me"], opts);
 }
 
@@ -178,9 +342,7 @@ export async function bcqMe(
  * Fetch the account-wide activity timeline via `bcq timeline`.
  * Returns an array of timeline events (newest first).
  */
-export async function bcqTimeline<T = unknown>(
-  opts: BcqOptions = {},
-): Promise<BcqResult<T>> {
+export async function bcqTimeline<T = unknown>(opts: BcqOptions = {}): Promise<BcqResult<T>> {
   return execBcq<T>(["timeline"], opts);
 }
 
@@ -188,9 +350,7 @@ export async function bcqTimeline<T = unknown>(
  * Fetch readings (Hey! menu) via `bcq api get /my/readings.json`.
  * No dedicated bcq command exists yet — uses raw API.
  */
-export async function bcqReadings<T = unknown>(
-  opts: BcqOptions = {},
-): Promise<BcqResult<T>> {
+export async function bcqReadings<T = unknown>(opts: BcqOptions = {}): Promise<BcqResult<T>> {
   return execBcq<T>(["api", "get", "/my/readings.json"], opts);
 }
 
@@ -204,25 +364,20 @@ export async function bcqReadings<T = unknown>(
  */
 export async function bcqWhich(): Promise<BcqResult<{ path: string }>> {
   return new Promise((resolve, reject) => {
-    execFile(
-      BCQ_PATH,
-      ["--version"],
-      { timeout: 5_000 },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(
-            new BcqError(
-              `bcq not found or not executable at ${BCQ_PATH}: ${error.message}`,
-              error.code != null ? Number(error.code) : null,
-              stderr,
-              [BCQ_PATH, "--version"],
-            ),
-          );
-          return;
-        }
-        resolve({ data: { path: BCQ_PATH }, raw: stdout.trim() });
-      },
-    );
+    execFile(BCQ_PATH, ["--version"], { timeout: 5_000 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(
+          new BcqError(
+            `bcq not found or not executable at ${BCQ_PATH}: ${error.message}`,
+            error.code != null ? Number(error.code) : null,
+            stderr,
+            [BCQ_PATH, "--version"],
+          ),
+        );
+        return;
+      }
+      resolve({ data: { path: BCQ_PATH }, raw: stdout.trim() });
+    });
   });
 }
 
@@ -234,10 +389,7 @@ export async function bcqAuthStatus(
   opts: BcqOptions = {},
 ): Promise<BcqResult<{ authenticated: boolean }>> {
   try {
-    const result = await execBcq<{ authenticated?: boolean }>(
-      ["auth", "status"],
-      opts,
-    );
+    const result = await execBcq<{ authenticated?: boolean }>(["auth", "status"], opts);
     const authenticated =
       typeof result.data === "object" &&
       result.data !== null &&
@@ -255,9 +407,7 @@ export async function bcqAuthStatus(
  * List available bcq profiles.
  * Runs `bcq profile list` to enumerate configured profiles.
  */
-export async function bcqProfileList(
-  opts: BcqOptions = {},
-): Promise<BcqResult<string[]>> {
+export async function bcqProfileList(opts: BcqOptions = {}): Promise<BcqResult<string[]>> {
   try {
     const result = await execBcq<string[]>(["profile", "list"], opts);
     const profiles = Array.isArray(result.data) ? result.data : [];
@@ -283,8 +433,9 @@ export async function bcqApiGet<T = unknown>(
   path: string,
   accountId?: string,
   profile?: string,
+  retry?: RetryOptions,
 ): Promise<T> {
-  const result = await bcqGet<T>(path, { accountId, profile });
+  const result = await bcqGet<T>(path, { accountId, profile, retry });
   return result.data;
 }
 
@@ -297,8 +448,9 @@ export async function bcqApiPost<T = unknown>(
   body?: string,
   accountId?: string,
   profile?: string,
+  retry?: RetryOptions,
 ): Promise<T> {
-  const opts: BcqOptions = { accountId, profile };
+  const opts: BcqOptions = { accountId, profile, retry };
   if (body) {
     opts.extraFlags = ["-d", body];
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,8 @@ export const BasecampConfigSchema = z.object({
     .object({
       maxAttempts: z.number().positive().optional(),
       baseDelayMs: z.number().positive().optional(),
+      maxDelayMs: z.number().positive().optional(),
+      jitter: z.boolean().optional(),
     })
     .optional(),
   circuitBreaker: z
@@ -284,6 +286,26 @@ export function resolvePollingIntervals(cfg: unknown) {
     activityIntervalMs: section?.polling?.activityIntervalMs ?? 120_000,
     readingsIntervalMs: section?.polling?.readingsIntervalMs ?? 60_000,
     directPollIntervalMs: section?.polling?.directPollIntervalMs ?? 300_000,
+  };
+}
+
+/** Resolve retry options from config, with defaults. */
+export function resolveRetryConfig(cfg: OpenClawConfig): { maxAttempts: number; baseDelayMs: number; maxDelayMs: number; jitter: boolean } {
+  const section = getBasecampSection(cfg);
+  return {
+    maxAttempts: section?.retry?.maxAttempts ?? 3,
+    baseDelayMs: section?.retry?.baseDelayMs ?? 1000,
+    maxDelayMs: section?.retry?.maxDelayMs ?? 30000,
+    jitter: section?.retry?.jitter ?? true,
+  };
+}
+
+/** Resolve circuit breaker options from config, with defaults. */
+export function resolveCircuitBreakerConfig(cfg: OpenClawConfig): { threshold: number; cooldownMs: number } {
+  const section = getBasecampSection(cfg);
+  return {
+    threshold: section?.circuitBreaker?.threshold ?? 5,
+    cooldownMs: section?.circuitBreaker?.cooldownMs ?? 5 * 60 * 1000,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,18 @@ export const BasecampConfigSchema = z.object({
       directPollIntervalMs: z.number().positive().optional(),
     })
     .optional(),
+  retry: z
+    .object({
+      maxAttempts: z.number().positive().optional(),
+      baseDelayMs: z.number().positive().optional(),
+    })
+    .optional(),
+  circuitBreaker: z
+    .object({
+      threshold: z.number().positive().optional(),
+      cooldownMs: z.number().positive().optional(),
+    })
+    .optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -380,6 +380,8 @@ export type BasecampChannelConfig = {
   retry?: {
     maxAttempts?: number;
     baseDelayMs?: number;
+    maxDelayMs?: number;
+    jitter?: boolean;
   };
   /** Circuit breaker options for bcq API calls. */
   circuitBreaker?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -376,6 +376,16 @@ export type BasecampChannelConfig = {
     readingsIntervalMs?: number;
     directPollIntervalMs?: number;
   };
+  /** Retry options for bcq API calls. */
+  retry?: {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+  };
+  /** Circuit breaker options for bcq API calls. */
+  circuitBreaker?: {
+    threshold?: number;
+    cooldownMs?: number;
+  };
 };
 
 /**

--- a/tests/circuit-breaker.test.ts
+++ b/tests/circuit-breaker.test.ts
@@ -80,6 +80,28 @@ describe("CircuitBreaker", () => {
     expect(cb.isOpen("acct-1")).toBe(true);
   });
 
+  it("half-open allows only one probe (subsequent callers are blocked)", () => {
+    const cb = new CircuitBreaker({ threshold: 2, cooldownMs: 60_000 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+
+    // Advance past cooldown (half-open)
+    vi.advanceTimersByTime(60_000);
+
+    // First caller gets through (the probe)
+    expect(cb.isOpen("acct-1")).toBe(false);
+
+    // Second caller is blocked while probe is in flight
+    expect(cb.isOpen("acct-1")).toBe(true);
+    expect(cb.isOpen("acct-1")).toBe(true);
+
+    // Probe succeeds -> circuit closes, all callers allowed through
+    cb.recordSuccess("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(false);
+  });
+
   it("recordSuccess resets failure count", () => {
     const cb = new CircuitBreaker({ threshold: 3 });
 

--- a/tests/circuit-breaker.test.ts
+++ b/tests/circuit-breaker.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CircuitBreaker } from "../src/bcq.js";
+
+describe("CircuitBreaker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("circuit starts closed (isOpen returns false)", () => {
+    const cb = new CircuitBreaker({ threshold: 3 });
+    expect(cb.isOpen("acct-1")).toBe(false);
+  });
+
+  it("trips after threshold consecutive failures", () => {
+    const cb = new CircuitBreaker({ threshold: 3, cooldownMs: 60_000 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(false);
+
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+  });
+
+  it("isOpen returns true when tripped", () => {
+    const cb = new CircuitBreaker({ threshold: 2, cooldownMs: 60_000 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+
+    expect(cb.isOpen("acct-1")).toBe(true);
+  });
+
+  it("fails fast when circuit is open (before cooldown)", () => {
+    const cb = new CircuitBreaker({ threshold: 2, cooldownMs: 60_000 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+
+    // Advance less than cooldown
+    vi.advanceTimersByTime(30_000);
+    expect(cb.isOpen("acct-1")).toBe(true);
+  });
+
+  it("recovers after cooldown period (half-open -> closed on success)", () => {
+    const cb = new CircuitBreaker({ threshold: 2, cooldownMs: 60_000 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+
+    // Advance past cooldown
+    vi.advanceTimersByTime(60_000);
+    // Half-open: isOpen returns false to allow one attempt
+    expect(cb.isOpen("acct-1")).toBe(false);
+
+    // Simulate successful request
+    cb.recordSuccess("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(false);
+    expect(cb.getState("acct-1")).toEqual({ failures: 0, trippedAt: null });
+  });
+
+  it("re-trips on failure during half-open", () => {
+    const cb = new CircuitBreaker({ threshold: 2, cooldownMs: 60_000 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+
+    // Advance past cooldown (half-open)
+    vi.advanceTimersByTime(60_000);
+    expect(cb.isOpen("acct-1")).toBe(false);
+
+    // Request fails again during half-open -> re-trips
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+  });
+
+  it("recordSuccess resets failure count", () => {
+    const cb = new CircuitBreaker({ threshold: 3 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    cb.recordSuccess("acct-1");
+
+    expect(cb.getState("acct-1")).toEqual({ failures: 0, trippedAt: null });
+    expect(cb.isOpen("acct-1")).toBe(false);
+
+    // Needs full threshold again to trip
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(false);
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+  });
+
+  it("reset() force-resets the circuit", () => {
+    const cb = new CircuitBreaker({ threshold: 2, cooldownMs: 60_000 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+
+    cb.reset("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(false);
+    expect(cb.getState("acct-1")).toBeUndefined();
+  });
+
+  it("independent circuits per key", () => {
+    const cb = new CircuitBreaker({ threshold: 2, cooldownMs: 60_000 });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+    expect(cb.isOpen("acct-2")).toBe(false);
+
+    cb.recordFailure("acct-2");
+    expect(cb.isOpen("acct-2")).toBe(false);
+    cb.recordFailure("acct-2");
+    expect(cb.isOpen("acct-2")).toBe(true);
+
+    // Reset one doesn't affect the other
+    cb.reset("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(false);
+    expect(cb.isOpen("acct-2")).toBe(true);
+  });
+
+  it("getState returns correct state", () => {
+    const cb = new CircuitBreaker({ threshold: 3, cooldownMs: 60_000 });
+
+    expect(cb.getState("acct-1")).toBeUndefined();
+
+    cb.recordFailure("acct-1");
+    expect(cb.getState("acct-1")).toEqual({ failures: 1, trippedAt: null });
+
+    cb.recordFailure("acct-1");
+    cb.recordFailure("acct-1");
+    const state = cb.getState("acct-1");
+    expect(state?.failures).toBe(3);
+    expect(state?.trippedAt).toBeTypeOf("number");
+  });
+
+  it("recordSuccess on unknown key is a no-op", () => {
+    const cb = new CircuitBreaker();
+    cb.recordSuccess("unknown");
+    expect(cb.getState("unknown")).toBeUndefined();
+  });
+
+  it("uses default threshold of 5 and cooldown of 5 minutes", () => {
+    const cb = new CircuitBreaker();
+
+    for (let i = 0; i < 4; i++) cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(false);
+
+    cb.recordFailure("acct-1");
+    expect(cb.isOpen("acct-1")).toBe(true);
+
+    // 4 minutes not enough
+    vi.advanceTimersByTime(4 * 60 * 1000);
+    expect(cb.isOpen("acct-1")).toBe(true);
+
+    // 5 minutes is enough
+    vi.advanceTimersByTime(1 * 60 * 1000);
+    expect(cb.isOpen("acct-1")).toBe(false);
+  });
+});

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi } from "vitest";
+import { BcqError, isRetryableError, withRetry } from "../src/bcq.js";
+
+function bcqErr(
+  exitCode: number | null,
+  stderr: string,
+  message = "bcq failed",
+): BcqError {
+  return new BcqError(message, exitCode, stderr, ["bcq"]);
+}
+
+// ---------------------------------------------------------------------------
+// isRetryableError
+// ---------------------------------------------------------------------------
+
+describe("isRetryableError", () => {
+  it("returns true for ETIMEDOUT", () => {
+    expect(isRetryableError(bcqErr(1, "connect ETIMEDOUT 1.2.3.4:443"))).toBe(true);
+  });
+
+  it("returns true for ECONNREFUSED", () => {
+    expect(isRetryableError(bcqErr(1, "connect ECONNREFUSED 127.0.0.1:443"))).toBe(true);
+  });
+
+  it("returns true for ECONNRESET", () => {
+    expect(isRetryableError(bcqErr(1, "socket hang up ECONNRESET"))).toBe(true);
+  });
+
+  it("returns true for 502 server error", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 502 Bad Gateway"))).toBe(true);
+  });
+
+  it("returns true for 503 server error", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 503 Service Unavailable"))).toBe(true);
+  });
+
+  it("returns true for 504 server error", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 504 Gateway Timeout"))).toBe(true);
+  });
+
+  it("returns true for generic 5xx", () => {
+    expect(isRetryableError(bcqErr(1, "server returned 5xx"))).toBe(true);
+  });
+
+  it("returns false for 401", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 401 Unauthorized"))).toBe(false);
+  });
+
+  it("returns false for 403", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 403 Forbidden"))).toBe(false);
+  });
+
+  it("returns false for Unauthorized text", () => {
+    expect(isRetryableError(bcqErr(1, "Unauthorized access denied"))).toBe(false);
+  });
+
+  it("returns false for Forbidden text", () => {
+    expect(isRetryableError(bcqErr(1, "Forbidden: insufficient permissions"))).toBe(false);
+  });
+
+  it("returns false for 404", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 404 Not Found"))).toBe(false);
+  });
+
+  it("returns false for Not Found text", () => {
+    expect(isRetryableError(bcqErr(1, "Not Found: resource missing"))).toBe(false);
+  });
+
+  it("returns false for 422", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 422 Unprocessable Entity"))).toBe(false);
+  });
+
+  it("returns false for Unprocessable text", () => {
+    expect(isRetryableError(bcqErr(1, "Unprocessable: invalid body"))).toBe(false);
+  });
+
+  it("returns false for JSON parse error (exitCode null)", () => {
+    expect(
+      isRetryableError(bcqErr(null, "unexpected token <", "bcq output is not valid JSON")),
+    ).toBe(false);
+  });
+
+  it("returns false for unknown error with exit code 2", () => {
+    expect(isRetryableError(bcqErr(2, "something unknown happened"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withRetry
+// ---------------------------------------------------------------------------
+
+describe("withRetry", () => {
+  const fast = { baseDelayMs: 1, maxDelayMs: 4, jitter: false };
+
+  it("retries on transient error and succeeds on 2nd attempt", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(bcqErr(1, "connect ETIMEDOUT"))
+      .mockResolvedValueOnce({ data: "ok", raw: "ok" });
+
+    const result = await withRetry(fn, { ...fast, maxAttempts: 3 });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ data: "ok", raw: "ok" });
+  });
+
+  it("does not retry on permanent error (401)", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(bcqErr(1, "HTTP 401 Unauthorized"));
+
+    await expect(withRetry(fn, { ...fast, maxAttempts: 3 })).rejects.toThrow("bcq failed");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on 404", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(bcqErr(1, "HTTP 404 Not Found"));
+
+    await expect(withRetry(fn, { ...fast, maxAttempts: 3 })).rejects.toThrow("bcq failed");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on 422", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(bcqErr(1, "HTTP 422 Unprocessable"));
+
+    await expect(withRetry(fn, { ...fast, maxAttempts: 3 })).rejects.toThrow("bcq failed");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on JSON parse error (exitCode null)", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(bcqErr(null, "unexpected <html>", "bcq output is not valid JSON"));
+
+    await expect(withRetry(fn, { ...fast, maxAttempts: 3 })).rejects.toThrow(
+      "bcq output is not valid JSON",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects maxAttempts limit", async () => {
+    const fn = vi.fn().mockImplementation(async () => {
+      throw bcqErr(1, "ETIMEDOUT");
+    });
+
+    await expect(withRetry(fn, { ...fast, maxAttempts: 4 })).rejects.toThrow("bcq failed");
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  it("applies exponential backoff (delays increase)", async () => {
+    const delays: number[] = [];
+    const fn = vi.fn().mockImplementation(async () => {
+      throw bcqErr(1, "ECONNREFUSED");
+    });
+
+    const origSetTimeout = globalThis.setTimeout;
+    const timeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((cb: TimerHandler, ms?: number, ...args: unknown[]) => {
+        if (typeof ms === "number" && ms > 0) delays.push(ms);
+        return origSetTimeout(cb, 0, ...args);
+      });
+
+    await expect(
+      withRetry(fn, { maxAttempts: 4, baseDelayMs: 100, jitter: false }),
+    ).rejects.toThrow();
+
+    expect(delays).toEqual([100, 200, 400]);
+    timeoutSpy.mockRestore();
+  });
+
+  it("applies jitter when enabled (delay is reduced up to 25%)", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(1); // max jitter: 25% reduction
+    const delays: number[] = [];
+    const fn = vi.fn().mockImplementation(async () => {
+      throw bcqErr(1, "ETIMEDOUT");
+    });
+
+    const origSetTimeout = globalThis.setTimeout;
+    const timeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((cb: TimerHandler, ms?: number, ...args: unknown[]) => {
+        if (typeof ms === "number" && ms > 0) delays.push(ms);
+        return origSetTimeout(cb, 0, ...args);
+      });
+
+    await expect(
+      withRetry(fn, { maxAttempts: 2, baseDelayMs: 1000, jitter: true }),
+    ).rejects.toThrow();
+
+    // With random()=1, jitter = 1000 * 1 * 0.25 = 250, so delay = 750
+    expect(delays).toEqual([750]);
+    timeoutSpy.mockRestore();
+    vi.spyOn(Math, "random").mockRestore();
+  });
+
+  it("custom retryable function overrides default", async () => {
+    // 404 is normally not retryable, but custom function says yes
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(bcqErr(1, "HTTP 404 Not Found"))
+      .mockResolvedValueOnce({ data: "found", raw: "found" });
+
+    const result = await withRetry(fn, {
+      ...fast,
+      maxAttempts: 3,
+      retryable: () => true,
+    });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ data: "found", raw: "found" });
+  });
+
+  it("caps delay at maxDelayMs", async () => {
+    const delays: number[] = [];
+    const fn = vi.fn().mockImplementation(async () => {
+      throw bcqErr(1, "ETIMEDOUT");
+    });
+
+    const origSetTimeout = globalThis.setTimeout;
+    const timeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((cb: TimerHandler, ms?: number, ...args: unknown[]) => {
+        if (typeof ms === "number" && ms > 0) delays.push(ms);
+        return origSetTimeout(cb, 0, ...args);
+      });
+
+    await expect(
+      withRetry(fn, { maxAttempts: 5, baseDelayMs: 1000, maxDelayMs: 3000, jitter: false }),
+    ).rejects.toThrow();
+
+    expect(delays).toEqual([1000, 2000, 3000, 3000]);
+    timeoutSpy.mockRestore();
+  });
+
+  it("rethrows non-BcqError immediately", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new Error("not a BcqError"));
+
+    await expect(withRetry(fn, { ...fast, maxAttempts: 3 })).rejects.toThrow("not a BcqError");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -38,6 +38,14 @@ describe("isRetryableError", () => {
     expect(isRetryableError(bcqErr(1, "HTTP 504 Gateway Timeout"))).toBe(true);
   });
 
+  it("returns true for 500 server error", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 500 Internal Server Error"))).toBe(true);
+  });
+
+  it("returns true for 501 server error", () => {
+    expect(isRetryableError(bcqErr(1, "HTTP 501 Not Implemented"))).toBe(true);
+  });
+
   it("returns true for generic 5xx", () => {
     expect(isRetryableError(bcqErr(1, "server returned 5xx"))).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Add `withRetry` wrapper with exponential backoff + jitter for transient bcq errors (ETIMEDOUT, ECONNREFUSED, ECONNRESET, 5xx)
- Add `isRetryableError` classifier that rejects permanent errors (401, 403, 404, 422, JSON parse) immediately
- Add `CircuitBreaker` class with per-key tracking, configurable threshold/cooldown, and half-open recovery
- Wire retry into `bcqGet`, `bcqPost`, `bcqPut`, `bcqDelete`, `bcqApiGet`, `bcqApiPost`
- Wire circuit breaker into `execBcq` (check before exec, record on success/failure)
- Add `retry` and `circuitBreaker` fields to `BasecampChannelConfig` type and Zod schema

## Test plan

- [x] 28 tests in `tests/retry.test.ts` covering `isRetryableError` (transient vs permanent classification) and `withRetry` (backoff, jitter, maxAttempts, maxDelayMs cap, custom retryable, non-BcqError rethrow)
- [x] 12 tests in `tests/circuit-breaker.test.ts` covering trip threshold, cooldown, half-open recovery, re-trip, per-key isolation, reset, defaults
- [x] Full suite: 409 tests across 21 files pass
- [x] `tsc --noEmit` clean