### PR TITLE
Group N: outbound reliability

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -110,6 +110,8 @@ export async function dispatchBasecampEvent(
   };
 
   // ----- Dispatch with buffered block dispatcher -----
+  let dispatchHadError = false;
+
   await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
     ctx,
     cfg,
@@ -132,6 +134,7 @@ export async function dispatchBasecampEvent(
         });
       },
       onError: (err) => {
+        dispatchHadError = true;
         const errorType = classifyDispatchError(err);
         log?.error?.(
           `[basecamp:dispatch] failed — ` +
@@ -147,11 +150,13 @@ export async function dispatchBasecampEvent(
     },
   });
 
-  log?.info?.(
-    `[basecamp:dispatch] delivered — ` +
-    `agent=${route.agentId} event=${msg.meta.eventKind} ` +
-    `account=${account.accountId} recording=${msg.meta.recordingId}`,
-  );
+  if (!dispatchHadError) {
+    log?.info?.(
+      `[basecamp:dispatch] delivered — ` +
+      `agent=${route.agentId} event=${msg.meta.eventKind} ` +
+      `account=${account.accountId} recording=${msg.meta.recordingId}`,
+    );
+  }
 
   return true;
 }

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -128,13 +128,30 @@ export async function dispatchBasecampEvent(
           content: htmlContent,
           accountId: outboundAccountId,
           profile: outboundProfile,
+          retries: 2,
         });
       },
       onError: (err) => {
-        log?.error?.(`[${account.accountId}] reply error for agent=${route.agentId}: ${String(err)}`);
+        const errorType = classifyDispatchError(err);
+        log?.error?.(
+          `[basecamp:dispatch] failed — ` +
+          `agent=${route.agentId} ` +
+          `event=${msg.meta.eventKind} ` +
+          `recording=${msg.meta.recordingId} ` +
+          `account=${account.accountId} ` +
+          `sender=${msg.sender.id} ` +
+          `type=${errorType} ` +
+          `error=${String(err)}`,
+        );
       },
     },
   });
+
+  log?.info?.(
+    `[basecamp:dispatch] delivered — ` +
+    `agent=${route.agentId} event=${msg.meta.eventKind} ` +
+    `account=${account.accountId} recording=${msg.meta.recordingId}`,
+  );
 
   return true;
 }
@@ -204,4 +221,15 @@ function buildUntrustedContext(msg: BasecampInboundMessage): string[] {
   }
 
   return lines;
+}
+
+/**
+ * Classify a dispatch error into a category for structured logging.
+ */
+function classifyDispatchError(err: unknown): string {
+  const s = String(err);
+  if (s.includes("401") || s.includes("403") || s.includes("Unauthorized") || s.includes("Forbidden")) return "auth";
+  if (s.includes("ETIMEDOUT") || s.includes("ECONNREFUSED") || s.includes("ECONNRESET") || s.includes("timeout")) return "network";
+  if (s.includes("no route") || s.includes("not found")) return "routing";
+  return "unknown";
 }

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -9,7 +9,7 @@
  */
 
 import type { BasecampRecordableType } from "../types.js";
-import { bcqApiPost } from "../bcq.js";
+import { bcqApiPost, withRetry, isRetryableError, BcqError } from "../bcq.js";
 import { markdownToBasecampHtml } from "./format.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount } from "../config.js";
@@ -28,17 +28,32 @@ export async function postCampfireLine(params: {
   content: string;
   accountId?: string;
   profile?: string;
-}): Promise<{ ok: boolean; recordingId?: string; error?: string }> {
-  const { bucketId, transcriptId, content, accountId, profile } = params;
+  retries?: number;
+}): Promise<{ ok: boolean; recordingId?: string; retryable?: boolean; error?: string }> {
+  const { bucketId, transcriptId, content, accountId, profile, retries } = params;
   const path = `/buckets/${bucketId}/chats/${transcriptId}/lines.json`;
   const body = JSON.stringify({ content });
 
+  const doPost = () => bcqApiPost(path, body, accountId, profile);
+
   try {
-    const result = await bcqApiPost(path, body, accountId, profile);
+    const result = retries && retries > 0
+      ? await withRetry(doPost, { maxAttempts: retries + 1 })
+      : await doPost();
     const parsed = typeof result === "string" ? JSON.parse(result) : result;
+    console.log(
+      `[basecamp:outbound] sent ok — ` +
+      `type=campfire recording=${transcriptId} account=${accountId ?? "default"}`,
+    );
     return { ok: true, recordingId: String(parsed?.id ?? "") };
   } catch (err) {
-    return { ok: false, error: String(err) };
+    const retryable = err instanceof BcqError && isRetryableError(err);
+    console.warn(
+      `[basecamp:outbound] failed — ` +
+      `type=campfire recording=${transcriptId} account=${accountId ?? "default"} ` +
+      `retryable=${retryable} error=${String(err)}`,
+    );
+    return { ok: false, retryable, error: String(err) };
   }
 }
 
@@ -52,17 +67,32 @@ export async function postComment(params: {
   content: string;
   accountId?: string;
   profile?: string;
-}): Promise<{ ok: boolean; commentId?: string; error?: string }> {
-  const { bucketId, recordingId, content, accountId, profile } = params;
+  retries?: number;
+}): Promise<{ ok: boolean; commentId?: string; retryable?: boolean; error?: string }> {
+  const { bucketId, recordingId, content, accountId, profile, retries } = params;
   const path = `/buckets/${bucketId}/recordings/${recordingId}/comments.json`;
   const body = JSON.stringify({ content });
 
+  const doPost = () => bcqApiPost(path, body, accountId, profile);
+
   try {
-    const result = await bcqApiPost(path, body, accountId, profile);
+    const result = retries && retries > 0
+      ? await withRetry(doPost, { maxAttempts: retries + 1 })
+      : await doPost();
     const parsed = typeof result === "string" ? JSON.parse(result) : result;
+    console.log(
+      `[basecamp:outbound] sent ok — ` +
+      `type=comment recording=${recordingId} account=${accountId ?? "default"}`,
+    );
     return { ok: true, commentId: String(parsed?.id ?? "") };
   } catch (err) {
-    return { ok: false, error: String(err) };
+    const retryable = err instanceof BcqError && isRetryableError(err);
+    console.warn(
+      `[basecamp:outbound] failed — ` +
+      `type=comment recording=${recordingId} account=${accountId ?? "default"} ` +
+      `retryable=${retryable} error=${String(err)}`,
+    );
+    return { ok: false, retryable, error: String(err) };
   }
 }
 
@@ -94,8 +124,9 @@ export async function postReplyToEvent(params: {
   content: string;
   accountId?: string;
   profile?: string;
-}): Promise<{ ok: boolean; messageId?: string; error?: string }> {
-  const { bucketId, recordingId, recordableType, peerId, content, accountId, profile } = params;
+  retries?: number;
+}): Promise<{ ok: boolean; messageId?: string; retryable?: boolean; error?: string }> {
+  const { bucketId, recordingId, recordableType, peerId, content, accountId, profile, retries } = params;
   const parsed = parsePeerId(peerId);
 
   // Chat lines go to the transcript
@@ -104,11 +135,6 @@ export async function postReplyToEvent(params: {
     recordableType === "Chat::Line" ||
     parsed.prefix === "ping"
   ) {
-    // Always use recordingId for the transcript ID:
-    // - For Chat::Transcript events, recordingId IS the transcript
-    // - For Chat::Line events, recordingId is the transcript (parent)
-    // - For Pings, recordingId should be the transcript recording ID
-    //   (from inbound meta), NOT the circle bucket ID from peer.id
     const transcriptId = recordingId;
     const result = await postCampfireLine({
       bucketId,
@@ -116,8 +142,9 @@ export async function postReplyToEvent(params: {
       content,
       accountId,
       profile,
+      retries,
     });
-    return { ok: result.ok, messageId: result.recordingId, error: result.error };
+    return { ok: result.ok, messageId: result.recordingId, retryable: result.retryable, error: result.error };
   }
 
   // Everything else gets a comment on the recording
@@ -127,8 +154,9 @@ export async function postReplyToEvent(params: {
     content,
     accountId,
     profile,
+    retries,
   });
-  return { ok: result.ok, messageId: result.commentId, error: result.error };
+  return { ok: result.ok, messageId: result.commentId, retryable: result.retryable, error: result.error };
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -5,9 +5,8 @@ import type {
   ResolvedBasecampAccount,
 } from "../src/types.js";
 import { getBasecampRuntime } from "../src/runtime.js";
-import { resolvePersonaAccountId, resolveBasecampAccount } from "../src/config.js";
+import { resolvePersonaAccountId } from "../src/config.js";
 import { postReplyToEvent } from "../src/outbound/send.js";
-import { markdownToBasecampHtml } from "../src/outbound/format.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -189,5 +188,26 @@ describe("dispatch outbound reliability", () => {
     expect(deliveryLog![0]).toContain("event=created");
     expect(deliveryLog![0]).toContain("account=test-acct");
     expect(deliveryLog![0]).toContain("recording=123");
+  });
+
+  it("does not log 'delivered' when onError was called", async () => {
+    // Make dispatchReplyWithBufferedBlockDispatcher call onError
+    mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions }: any) => {
+        dispatcherOptions.onError(new Error("send failed"));
+      },
+    );
+
+    const logInfo = vi.fn();
+    const logError = vi.fn();
+    const log = { info: logInfo, warn: vi.fn(), error: logError };
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
+
+    const deliveryLog = logInfo.mock.calls.find((c: string[]) =>
+      c[0].includes("[basecamp:dispatch] delivered"),
+    );
+    expect(deliveryLog).toBeUndefined();
+    expect(logError).toHaveBeenCalled();
   });
 });

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { dispatchBasecampEvent } from "../src/dispatch.js";
+import type {
+  BasecampInboundMessage,
+  ResolvedBasecampAccount,
+} from "../src/types.js";
+import { getBasecampRuntime } from "../src/runtime.js";
+import { resolvePersonaAccountId, resolveBasecampAccount } from "../src/config.js";
+import { postReplyToEvent } from "../src/outbound/send.js";
+import { markdownToBasecampHtml } from "../src/outbound/format.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../src/runtime.js", () => ({
+  getBasecampRuntime: vi.fn(),
+}));
+vi.mock("../src/config.js", () => ({
+  resolvePersonaAccountId: vi.fn(),
+  resolveBasecampAccount: vi.fn(),
+}));
+vi.mock("../src/outbound/send.js", () => ({
+  postReplyToEvent: vi.fn(),
+}));
+vi.mock("../src/outbound/format.js", () => ({
+  markdownToBasecampHtml: vi.fn((text: string) => `<p>${text}</p>`),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockRuntime = {
+  config: {
+    loadConfig: vi.fn(() => ({
+      channels: {
+        basecamp: {
+          accounts: { "test-acct": { personId: "999" } },
+        },
+      },
+    })),
+  },
+  channel: {
+    routing: { resolveAgentRoute: vi.fn() },
+    reply: { dispatchReplyWithBufferedBlockDispatcher: vi.fn() },
+  },
+};
+
+const mockMsg: BasecampInboundMessage = {
+  channel: "basecamp",
+  accountId: "test-acct",
+  peer: { kind: "group", id: "recording:123" },
+  parentPeer: { kind: "group", id: "bucket:456" },
+  sender: { id: "777", name: "Test User" },
+  text: "Hello",
+  html: "<p>Hello</p>",
+  meta: {
+    bucketId: "456",
+    recordingId: "123",
+    recordableType: "Chat::Transcript",
+    eventKind: "created",
+    mentions: [],
+    mentionsAgent: false,
+    attachments: [],
+    sources: ["activity_feed"],
+  },
+  dedupKey: "activity:1",
+  createdAt: "2025-01-15T10:00:00Z",
+};
+
+const mockAccount: ResolvedBasecampAccount = {
+  accountId: "test-acct",
+  enabled: true,
+  personId: "999",
+  token: "tok-abc",
+  tokenSource: "config",
+  config: { personId: "999" },
+};
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getBasecampRuntime).mockReturnValue(mockRuntime as any);
+  vi.mocked(resolvePersonaAccountId).mockReturnValue(undefined);
+  mockRuntime.channel.routing.resolveAgentRoute.mockReturnValue({
+    agentId: "agent-1",
+    matchedBy: "peer",
+    sessionKey: "session:abc",
+  });
+  mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(
+    undefined,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("dispatch outbound reliability", () => {
+  it("deliver callback calls postReplyToEvent with retries: 2", async () => {
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    const deliver = call.dispatcherOptions.deliver;
+
+    await deliver({ text: "Agent reply" }, {});
+
+    expect(postReplyToEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bucketId: "456",
+        recordingId: "123",
+        recordableType: "Chat::Transcript",
+        retries: 2,
+      }),
+    );
+  });
+
+  it("onError logs structured error with event metadata", async () => {
+    const logError = vi.fn();
+    const log = { info: vi.fn(), warn: vi.fn(), error: logError };
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    const onError = call.dispatcherOptions.onError;
+
+    onError(new Error("ETIMEDOUT connecting to host"));
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    const logged = logError.mock.calls[0][0];
+    expect(logged).toContain("[basecamp:dispatch] failed");
+    expect(logged).toContain("agent=agent-1");
+    expect(logged).toContain("event=created");
+    expect(logged).toContain("recording=123");
+    expect(logged).toContain("account=test-acct");
+    expect(logged).toContain("sender=777");
+    expect(logged).toContain("type=network");
+    expect(logged).toContain("ETIMEDOUT");
+  });
+
+  it("onError classifies auth errors", async () => {
+    const logError = vi.fn();
+    const log = { info: vi.fn(), warn: vi.fn(), error: logError };
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    call.dispatcherOptions.onError(new Error("401 Unauthorized"));
+
+    expect(logError.mock.calls[0][0]).toContain("type=auth");
+  });
+
+  it("onError classifies unknown errors", async () => {
+    const logError = vi.fn();
+    const log = { info: vi.fn(), warn: vi.fn(), error: logError };
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    call.dispatcherOptions.onError(new Error("something unexpected"));
+
+    expect(logError.mock.calls[0][0]).toContain("type=unknown");
+  });
+
+  it("logs delivery confirmation after successful dispatch", async () => {
+    const logInfo = vi.fn();
+    const log = { info: logInfo, warn: vi.fn(), error: vi.fn() };
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
+
+    // The delivery log should be the last info call
+    const deliveryLog = logInfo.mock.calls.find((c: string[]) =>
+      c[0].includes("[basecamp:dispatch] delivered"),
+    );
+    expect(deliveryLog).toBeDefined();
+    expect(deliveryLog![0]).toContain("agent=agent-1");
+    expect(deliveryLog![0]).toContain("event=created");
+    expect(deliveryLog![0]).toContain("account=test-acct");
+    expect(deliveryLog![0]).toContain("recording=123");
+  });
+});

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -199,6 +199,7 @@ describe("dispatchBasecampEvent", () => {
       content: "<p>Agent reply</p>",
       accountId: "test-acct",
       profile: undefined,
+      retries: 2,
     });
   });
 

--- a/tests/outbound-retry.test.ts
+++ b/tests/outbound-retry.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/bcq.js", () => ({
+  bcqApiPost: vi.fn(),
+  withRetry: vi.fn(),
+  isRetryableError: vi.fn(),
+  BcqError: class BcqError extends Error {
+    constructor(
+      msg: string,
+      public exitCode: number | null,
+      public stderr: string,
+      public command: string[],
+    ) {
+      super(msg);
+      this.name = "BcqError";
+    }
+  },
+}));
+vi.mock("../src/outbound/format.js", () => ({
+  markdownToBasecampHtml: vi.fn((t: string) => t),
+}));
+vi.mock("../src/runtime.js", () => ({
+  getBasecampRuntime: vi.fn(),
+}));
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(),
+}));
+
+import { postCampfireLine, postComment, postReplyToEvent } from "../src/outbound/send.js";
+import { bcqApiPost, withRetry, isRetryableError, BcqError } from "../src/bcq.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// postCampfireLine
+// ---------------------------------------------------------------------------
+
+describe("postCampfireLine", () => {
+  it("calls bcqApiPost directly when retries is not set", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 42 });
+
+    const result = await postCampfireLine({
+      bucketId: "1",
+      transcriptId: "2",
+      content: "Hello",
+    });
+
+    expect(result).toEqual({ ok: true, recordingId: "42" });
+    expect(bcqApiPost).toHaveBeenCalledTimes(1);
+    expect(withRetry).not.toHaveBeenCalled();
+  });
+
+  it("calls withRetry with correct maxAttempts when retries > 0", async () => {
+    vi.mocked(withRetry).mockResolvedValue({ id: 99 });
+
+    const result = await postCampfireLine({
+      bucketId: "1",
+      transcriptId: "2",
+      content: "Hello",
+      retries: 3,
+    });
+
+    expect(result).toEqual({ ok: true, recordingId: "99" });
+    expect(withRetry).toHaveBeenCalledTimes(1);
+    expect(withRetry).toHaveBeenCalledWith(expect.any(Function), { maxAttempts: 4 });
+    expect(bcqApiPost).not.toHaveBeenCalled(); // withRetry wraps it
+  });
+
+  it("returns retryable=true on transient BcqError", async () => {
+    const err = new (BcqError as any)("timeout", 1, "ETIMEDOUT", ["bcq"]);
+    vi.mocked(bcqApiPost).mockRejectedValue(err);
+    vi.mocked(isRetryableError).mockReturnValue(true);
+
+    const result = await postCampfireLine({
+      bucketId: "1",
+      transcriptId: "2",
+      content: "Hello",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.retryable).toBe(true);
+    expect(result.error).toContain("timeout");
+  });
+
+  it("returns retryable=false on permanent BcqError", async () => {
+    const err = new (BcqError as any)("forbidden", 1, "403 Forbidden", ["bcq"]);
+    vi.mocked(bcqApiPost).mockRejectedValue(err);
+    vi.mocked(isRetryableError).mockReturnValue(false);
+
+    const result = await postCampfireLine({
+      bucketId: "1",
+      transcriptId: "2",
+      content: "Hello",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.retryable).toBe(false);
+  });
+
+  it("returns retryable=false for non-BcqError", async () => {
+    vi.mocked(bcqApiPost).mockRejectedValue(new Error("generic error"));
+
+    const result = await postCampfireLine({
+      bucketId: "1",
+      transcriptId: "2",
+      content: "Hello",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.retryable).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postComment
+// ---------------------------------------------------------------------------
+
+describe("postComment", () => {
+  it("calls bcqApiPost directly when retries is not set", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 55 });
+
+    const result = await postComment({
+      bucketId: "1",
+      recordingId: "2",
+      content: "A comment",
+    });
+
+    expect(result).toEqual({ ok: true, commentId: "55" });
+    expect(bcqApiPost).toHaveBeenCalledTimes(1);
+    expect(withRetry).not.toHaveBeenCalled();
+  });
+
+  it("calls withRetry with correct maxAttempts when retries > 0", async () => {
+    vi.mocked(withRetry).mockResolvedValue({ id: 77 });
+
+    const result = await postComment({
+      bucketId: "1",
+      recordingId: "2",
+      content: "A comment",
+      retries: 2,
+    });
+
+    expect(result).toEqual({ ok: true, commentId: "77" });
+    expect(withRetry).toHaveBeenCalledWith(expect.any(Function), { maxAttempts: 3 });
+  });
+
+  it("returns retryable on BcqError failure", async () => {
+    const err = new (BcqError as any)("fail", 1, "ECONNRESET", ["bcq"]);
+    vi.mocked(bcqApiPost).mockRejectedValue(err);
+    vi.mocked(isRetryableError).mockReturnValue(true);
+
+    const result = await postComment({
+      bucketId: "1",
+      recordingId: "2",
+      content: "A comment",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.retryable).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postReplyToEvent
+// ---------------------------------------------------------------------------
+
+describe("postReplyToEvent", () => {
+  it("passes retries through to postCampfireLine for Chat::Transcript", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 10 });
+
+    const result = await postReplyToEvent({
+      bucketId: "1",
+      recordingId: "2",
+      recordableType: "Chat::Transcript",
+      peerId: "recording:2",
+      content: "Reply",
+      retries: 2,
+    });
+
+    expect(result.ok).toBe(true);
+    // bcqApiPost should be called — postCampfireLine with retries=2 calls withRetry
+    // But since withRetry is mocked and not called (retries > 0 path calls withRetry),
+    // let's verify withRetry was called
+    expect(withRetry).toHaveBeenCalledWith(expect.any(Function), { maxAttempts: 3 });
+  });
+
+  it("passes retries through to postComment for non-chat types", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 20 });
+
+    const result = await postReplyToEvent({
+      bucketId: "1",
+      recordingId: "2",
+      recordableType: "Todo",
+      peerId: "recording:2",
+      content: "Comment reply",
+      retries: 1,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(withRetry).toHaveBeenCalledWith(expect.any(Function), { maxAttempts: 2 });
+  });
+
+  it("returns retryable field from underlying call", async () => {
+    const err = new (BcqError as any)("timeout", 1, "ETIMEDOUT", ["bcq"]);
+    vi.mocked(bcqApiPost).mockRejectedValue(err);
+    vi.mocked(isRetryableError).mockReturnValue(true);
+
+    const result = await postReplyToEvent({
+      bucketId: "1",
+      recordingId: "2",
+      recordableType: "Message",
+      peerId: "recording:2",
+      content: "Reply",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.retryable).toBe(true);
+  });
+});

--- a/tests/outbound-retry.test.ts
+++ b/tests/outbound-retry.test.ts
@@ -168,7 +168,7 @@ describe("postComment", () => {
 
 describe("postReplyToEvent", () => {
   it("passes retries through to postCampfireLine for Chat::Transcript", async () => {
-    vi.mocked(bcqApiPost).mockResolvedValue({ id: 10 });
+    vi.mocked(withRetry).mockResolvedValue({ id: 10 });
 
     const result = await postReplyToEvent({
       bucketId: "1",
@@ -180,14 +180,12 @@ describe("postReplyToEvent", () => {
     });
 
     expect(result.ok).toBe(true);
-    // bcqApiPost should be called — postCampfireLine with retries=2 calls withRetry
-    // But since withRetry is mocked and not called (retries > 0 path calls withRetry),
-    // let's verify withRetry was called
+    expect(result.messageId).toBe("10");
     expect(withRetry).toHaveBeenCalledWith(expect.any(Function), { maxAttempts: 3 });
   });
 
   it("passes retries through to postComment for non-chat types", async () => {
-    vi.mocked(bcqApiPost).mockResolvedValue({ id: 20 });
+    vi.mocked(withRetry).mockResolvedValue({ id: 20 });
 
     const result = await postReplyToEvent({
       bucketId: "1",
@@ -199,6 +197,7 @@ describe("postReplyToEvent", () => {
     });
 
     expect(result.ok).toBe(true);
+    expect(result.messageId).toBe("20");
     expect(withRetry).toHaveBeenCalledWith(expect.any(Function), { maxAttempts: 2 });
   });
 


### PR DESCRIPTION
## Summary
- Wire `withRetry` into outbound send functions (`postCampfireLine`, `postComment`, `postReplyToEvent`) via opt-in `retries` parameter
- Dispatch bridge passes `retries: 2` for transient failure resilience on outbound delivery
- Return `retryable` field from send functions so callers can distinguish transient vs permanent failures
- Enrich dispatch `onError` with structured logging: agent, event kind, recording, account, sender, classified error type
- Add `classifyDispatchError` helper (auth / network / routing / unknown)
- Add structured outbound logging on success and failure in send functions
- Add delivery confirmation log after successful dispatch

## Test plan
- [x] `tests/outbound-retry.test.ts` — 11 tests covering retry wiring, retryable classification, passthrough for all send functions
- [x] `tests/dispatch-outbound.test.ts` — 5 tests covering retries: 2 passthrough, structured error classification, delivery logging
- [x] Updated existing `dispatch.test.ts` assertion to expect new `retries: 2` field
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 425/425 passing