### PR TITLE
Group O: Config-driven engagement gate + outbound bcqAccountId fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import { setBasecampRuntime } from "./src/runtime.js";
 import { handleBasecampWebhook } from "./src/inbound/webhooks.js";
 
 const plugin = {
-  id: "basecamp",
+  id: "openclaw-basecamp",
   name: "Basecamp",
   description: "Basecamp channel — Campfire, cards, todos, check-ins, pings",
   configSchema: emptyPluginConfigSchema(),

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,8 @@
 {
-  "id": "basecamp",
+  "id": "openclaw-basecamp",
+  "name": "Basecamp",
+  "description": "Campfire chats, card tables, to-do lists, check-ins, pings — every Basecamp surface as a live agent interaction point.",
+  "version": "0.1.0",
   "channels": ["basecamp"],
   "configSchema": {
     "type": "object",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@37signals/openclaw-basecamp",
       "version": "0.1.0",
       "dependencies": {
-        "typescript": "*"
+        "typescript": "^5.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "openclaw": ">=2026.2.0",
@@ -11549,6 +11550,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12001,7 +12003,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "typescript": "^5.0.0",
-    "zod": "^3.22.0"
+    "zod": "^4.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,19 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "channel": {
+      "id": "basecamp",
+      "label": "Basecamp",
+      "selectionLabel": "Basecamp (Campfire, Cards, Todos, Check-ins, Pings)",
+      "docsPath": "/channels/basecamp",
+      "docsLabel": "basecamp",
+      "blurb": "Campfire chats, card tables, to-do lists, check-ins, pings — every Basecamp surface as a live agent interaction point."
+    },
+    "install": {
+      "npmSpec": "@37signals/openclaw-basecamp",
+      "defaultChoice": "npm"
+    }
   },
   "dependencies": {
     "typescript": "^5.0.0",

--- a/src/adapters/pairing.ts
+++ b/src/adapters/pairing.ts
@@ -32,7 +32,7 @@ export const basecampPairingAdapter: ChannelPairingAdapter = {
       await bcqApiPost(
         `/circles/people/${id}/lines.json`,
         JSON.stringify({ content: `<p>${PAIRING_APPROVED_MESSAGE}</p>` }),
-        account.config.bcqAccountId ?? account.accountId,
+        account.config.bcqAccountId,
         profile,
       );
     } catch {

--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -239,8 +239,10 @@ function execBcq<T = unknown>(args: string[], opts: BcqOptions = {}): Promise<Bc
       },
       (error, stdout, stderr) => {
         if (error) {
+          const stderrTrimmed = stderr.trim();
+          const cmdStr = [BCQ_PATH, ...fullArgs].join(" ");
           const err = new BcqError(
-            `bcq failed: ${error.message}`,
+            `bcq failed (${cmdStr}): ${error.message}${stderrTrimmed ? `\nstderr: ${stderrTrimmed}` : ""}`,
             error.code != null ? Number(error.code) : null,
             stderr,
             [BCQ_PATH, ...fullArgs],

--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -385,6 +385,26 @@ export async function bcqMarkReadingsRead(
   return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
+/**
+ * Resolve a Ping (Circle) to its chat transcript ID.
+ * Fetches GET /circles/<bucketId>.json and extracts the transcript ID
+ * from the room_url field (format: /buckets/<id>/chats/<transcriptId>).
+ */
+export async function bcqResolvePingTranscript(
+  bucketId: string,
+  opts: BcqOptions = {},
+): Promise<string | undefined> {
+  const result = await bcqGet<{ room_url?: string }>(
+    `/circles/${bucketId}.json`,
+    opts,
+  );
+  const roomUrl = result.data?.room_url;
+  if (!roomUrl) return undefined;
+  // room_url format: /buckets/<bucketId>/chats/<transcriptId>
+  const match = /\/chats\/(\d+)/.exec(roomUrl);
+  return match ? match[1] : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // bcq introspection helpers (used at startup for validation & diagnostics)
 // ---------------------------------------------------------------------------

--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -366,6 +366,25 @@ export async function bcqReadings<T = unknown>(opts: BcqOptions = {}): Promise<B
   return opts.retry ? withRetry(fn, opts.retry) : fn();
 }
 
+/**
+ * Mark readings as read via `PUT /my/unreads` with a list of readable SGIDs.
+ * This is the bulk mark-as-read endpoint — accepts up to ~50 SGIDs per call.
+ */
+export async function bcqMarkReadingsRead(
+  sgids: string[],
+  opts: BcqOptions = {},
+): Promise<BcqResult<unknown>> {
+  if (sgids.length === 0) return { data: null, raw: "" };
+
+  const body = JSON.stringify({ readables: sgids });
+  const fn = () =>
+    execBcq(["api", "put", "/my/unreads.json"], {
+      ...opts,
+      extraFlags: [...(opts.extraFlags ?? []), "-d", body],
+    });
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
+}
+
 // ---------------------------------------------------------------------------
 // bcq introspection helpers (used at startup for validation & diagnostics)
 // ---------------------------------------------------------------------------

--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -240,11 +240,27 @@ function execBcq<T = unknown>(args: string[], opts: BcqOptions = {}): Promise<Bc
       (error, stdout, stderr) => {
         if (error) {
           const stderrTrimmed = stderr.trim();
+          const stdoutTrimmed = stdout.trim();
           const cmdStr = [BCQ_PATH, ...fullArgs].join(" ");
+          // Node's error.message is often just "Command failed: <cmd>" which is
+          // redundant. Prefer stderr, then stdout (bcq may write errors there),
+          // then meaningful parts of error.message, then exit code / signal.
+          const meaningfulMsg = error.message.replace(/^Command failed:.*$/, "").trim();
+          const detail =
+            stderrTrimmed ||
+            stdoutTrimmed ||
+            (error.killed ? "timed out (killed)" : null) ||
+            (error.signal ? `killed by ${error.signal}` : null) ||
+            meaningfulMsg ||
+            `exit code ${error.code ?? "unknown"}`;
+          const exitCode =
+            typeof error.code === "number" ? error.code :
+            typeof (error as any).status === "number" ? (error as any).status :
+            null;
           const err = new BcqError(
-            `bcq failed (${cmdStr}): ${error.message}${stderrTrimmed ? `\nstderr: ${stderrTrimmed}` : ""}`,
-            error.code != null ? Number(error.code) : null,
-            stderr,
+            `bcq failed (${cmdStr}): ${detail}`,
+            exitCode,
+            stderrTrimmed || stdoutTrimmed,
             [BCQ_PATH, ...fullArgs],
           );
           cb?.instance.recordFailure(cb.key);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -244,23 +244,38 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         });
       };
 
+      // Mark channel as running
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: true,
+        lastStartAt: Date.now(),
+      });
+
       // Start the composite poller (activity feed + readings)
       ctx.log?.info(`[${account.accountId}] starting composite poller`);
 
       // startCompositePoller returns Promise<void> — it runs until abortSignal fires
-      await startCompositePoller({
-        account,
-        cfg: ctx.cfg,
-        abortSignal: ctx.abortSignal,
-        onEvent,
-        stateDir,
-        log: {
-          info: (msg) => ctx.log?.info?.(msg),
-          warn: (msg) => ctx.log?.warn?.(msg),
-          debug: (msg) => ctx.log?.debug?.(msg),
-          error: (msg) => ctx.log?.error?.(msg),
-        },
-      });
+      try {
+        await startCompositePoller({
+          account,
+          cfg: ctx.cfg,
+          abortSignal: ctx.abortSignal,
+          onEvent,
+          stateDir,
+          log: {
+            info: (msg) => ctx.log?.info?.(msg),
+            warn: (msg) => ctx.log?.warn?.(msg),
+            debug: (msg) => ctx.log?.debug?.(msg),
+            error: (msg) => ctx.log?.error?.(msg),
+          },
+        });
+      } finally {
+        ctx.setStatus({
+          accountId: account.accountId,
+          running: false,
+          lastStopAt: Date.now(),
+        });
+      }
     },
     logoutAccount: async ({ accountId, cfg }) => {
       return { cleared: false, loggedOut: false };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -108,7 +108,8 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       "virtualAccounts": { label: "Project scopes", help: "Maps synthetic account IDs to specific projects", advanced: true },
       "dmPolicy": { label: "DM policy", help: "Controls who can DM agents: open, pairing, closed" },
       "allowFrom": { label: "Allowed senders", help: "Basecamp person IDs allowed to message agents" },
-      "buckets": { label: "Per-project settings", help: "Override requireMention and tool policies per bucket", advanced: true },
+      "engage": { label: "Engagement policy", help: "Event types that trigger agent response: dm, mention, assignment, checkin, conversation, activity" },
+      "buckets": { label: "Per-project settings", help: "Override engage, requireMention, and tool policies per bucket", advanced: true },
     },
   },
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,10 @@ const BasecampVirtualAccountSchema = z.object({
   bucketId: z.string(),
 });
 
+const EngagementTypeSchema = z.enum([
+  "dm", "mention", "assignment", "checkin", "conversation", "activity",
+]);
+
 const BasecampBucketConfigSchema = z.object({
   requireMention: z.boolean().optional(),
   tools: z.object({
@@ -35,6 +39,7 @@ const BasecampBucketConfigSchema = z.object({
     deny: z.array(z.string()).optional(),
   }).optional(),
   enabled: z.boolean().optional(),
+  engage: z.array(EngagementTypeSchema).optional(),
 });
 
 export const BasecampConfigSchema = z.object({
@@ -45,6 +50,7 @@ export const BasecampConfigSchema = z.object({
   dmPolicy: z.enum(["open", "pairing", "closed"]).optional(),
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   buckets: z.record(z.string(), BasecampBucketConfigSchema).optional(),
+  engage: z.array(EngagementTypeSchema).optional(),
   polling: z
     .object({
       activityIntervalMs: z.number().positive().optional(),

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -96,7 +96,16 @@ export async function dispatchBasecampEvent(
   const outboundProfile = outboundAccount.bcqProfile;
   // Use the bcq account ID for API calls — NOT the OpenClaw account ID.
   // The OpenClaw account ID ("default") is never valid for bcq --account.
-  const outboundBcqAccountId = outboundAccount.config.bcqAccountId;
+  const outboundBcqAccountId =
+    outboundAccount.config.bcqAccountId ??
+    (/^\d+$/.test(outboundAccount.accountId) ? outboundAccount.accountId : undefined);
+  if (!outboundBcqAccountId) {
+    log?.error(
+      `[${account.accountId}] outbound dispatch: unable to resolve bcq account id for outbound account ` +
+      `"${outboundAccount.accountId}". Set config.bcqAccountId to a valid Basecamp account id.`,
+    );
+    return false;
+  }
 
   // ----- Build MsgContext -----
   // OpenClaw expects ChatType "direct" | "group" — NOT "dm"
@@ -229,8 +238,8 @@ function resolveEngagePolicy(
 ): BasecampEngagementType[] {
   const section = cfg.channels?.basecamp as BasecampChannelConfig | undefined;
 
-  // Per-bucket override
-  const bucketConfig = section?.buckets?.[bucketId];
+  // Per-bucket override (exact match → wildcard fallback)
+  const bucketConfig = section?.buckets?.[bucketId] ?? section?.buckets?.["*"];
   if (bucketConfig?.engage) return bucketConfig.engage;
 
   // Channel-level

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -73,12 +73,14 @@ export async function dispatchBasecampEvent(
   // ----- Resolve persona for outbound -----
   // The agent may have a dedicated Basecamp persona (service account).
   const personaAccountId = resolvePersonaAccountId(cfg, route.agentId);
-  const outboundAccountId = personaAccountId ?? account.accountId;
   // Resolve the outbound account's bcqProfile (persona may have its own profile)
   const outboundAccount = personaAccountId
     ? resolveBasecampAccount(cfg, personaAccountId)
     : account;
   const outboundProfile = outboundAccount.bcqProfile;
+  // Use the bcq account ID for API calls — NOT the OpenClaw account ID.
+  // The OpenClaw account ID ("default") is never valid for bcq --account.
+  const outboundBcqAccountId = outboundAccount.config.bcqAccountId;
 
   // ----- Build MsgContext -----
   // OpenClaw expects ChatType "direct" | "group" — NOT "dm"
@@ -128,7 +130,7 @@ export async function dispatchBasecampEvent(
           recordableType: msg.meta.recordableType,
           peerId: msg.peer.id,
           content: htmlContent,
-          accountId: outboundAccountId,
+          accountId: outboundBcqAccountId,
           profile: outboundProfile,
           retries: 2,
         });

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -11,7 +11,8 @@
  *    to send the agent's response back to the correct Basecamp surface
  */
 
-import type { BasecampInboundMessage, BasecampChannelConfig, ResolvedBasecampAccount } from "./types.js";
+import type { BasecampInboundMessage, BasecampChannelConfig, BasecampEngagementType, ResolvedBasecampAccount } from "./types.js";
+import { DEFAULT_ENGAGE } from "./types.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { getBasecampRuntime } from "./runtime.js";
 import { resolvePersonaAccountId, resolveBasecampAccount } from "./config.js";
@@ -62,6 +63,21 @@ export async function dispatchBasecampEvent(
 
   if (!route) {
     log?.debug?.(`[${account.accountId}] no agent route for peer=${msg.peer.id}`);
+    return false;
+  }
+
+  // ----- Engagement gate -----
+  // Classify the event, then check it against the configured engagement
+  // policy. Defaults to ["dm", "mention", "assignment", "checkin"].
+  // Per-bucket overrides take precedence over channel-level config.
+  const engagement = classifyEngagement(msg);
+  const engagePolicy = resolveEngagePolicy(cfg, msg.meta.bucketId);
+  if (!engagePolicy.includes(engagement)) {
+    log?.debug?.(
+      `[${account.accountId}] engagement gate: dropping ` +
+      `engagement=${engagement} event=${msg.meta.eventKind} type=${msg.meta.recordableType} ` +
+      `peer=${msg.peer.id} policy=[${engagePolicy.join(",")}]`,
+    );
     return false;
   }
 
@@ -166,6 +182,62 @@ export async function dispatchBasecampEvent(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Classify an inbound event into an engagement type.
+ *
+ * Ordered from most direct to most ambient:
+ *   dm           — 1:1 Ping
+ *   mention      — @mentioned
+ *   assignment   — assigned/unassigned to agent
+ *   checkin      — check-in question directed at agent (Hey! inbox)
+ *   conversation — chat lines, comments in bound surfaces
+ *   activity     — everything else (card moves, todo completions, edits…)
+ */
+function classifyEngagement(msg: BasecampInboundMessage): BasecampEngagementType {
+  if (msg.peer.kind === "dm") return "dm";
+  if (msg.meta.mentionsAgent) return "mention";
+  if (msg.meta.assignedToAgent) return "assignment";
+
+  // Check-in reminders: Question in Hey! inbox = you're a respondent
+  if (
+    msg.meta.recordableType === "Question" &&
+    msg.meta.sources.includes("readings")
+  ) {
+    return "checkin";
+  }
+
+  // Conversational surfaces: chat and comments
+  if (
+    msg.meta.recordableType === "Chat::Line" ||
+    msg.meta.recordableType === "Chat::Transcript" ||
+    msg.meta.recordableType === "Comment"
+  ) {
+    return "conversation";
+  }
+
+  return "activity";
+}
+
+/**
+ * Resolve the engagement policy for a given bucket.
+ * Per-bucket `engage` overrides channel-level; falls back to DEFAULT_ENGAGE.
+ */
+function resolveEngagePolicy(
+  cfg: OpenClawConfig,
+  bucketId: string,
+): BasecampEngagementType[] {
+  const section = cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+
+  // Per-bucket override
+  const bucketConfig = section?.buckets?.[bucketId];
+  if (bucketConfig?.engage) return bucketConfig.engage;
+
+  // Channel-level
+  if (section?.engage) return section.engage;
+
+  return DEFAULT_ENGAGE;
+}
 
 /**
  * Classify a dispatch error into a broad category for structured logging.

--- a/src/inbound/activity.ts
+++ b/src/inbound/activity.ts
@@ -44,7 +44,7 @@ export async function pollActivityFeed(
   log?.debug?.(`[${account.accountId}] polling activity feed via bcq timeline`);
 
   const result = await bcqTimeline<BasecampActivityEvent[]>({
-    accountId: account.accountId,
+    accountId: account.config.bcqAccountId,
     profile: account.bcqProfile,
   });
 

--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -322,6 +322,14 @@ export function normalizeActivityEvent(
 
   const parentPeer = resolveParentPeer(bucketId, false);
 
+  // Detect assignment events directed at the agent.
+  // bc3 assignment event kinds put the assignee's display name in `target`.
+  const isAssignmentKind = raw.kind.endsWith("_assigned") || raw.kind.endsWith("_unassigned");
+  const isAssignedToAgent = isAssignmentKind &&
+    typeof raw.target === "string" &&
+    typeof account.displayName === "string" &&
+    raw.target === account.displayName;
+
   const meta: BasecampInboundMeta = {
     bucketId,
     recordingId,
@@ -329,6 +337,7 @@ export function normalizeActivityEvent(
     eventKind: resolveEventKind(raw.kind) as BasecampInboundMeta["eventKind"],
     mentions: sgids,
     mentionsAgent: isAgentMentioned,
+    assignedToAgent: isAssignedToAgent || undefined,
     attachments: (raw.attachments ?? []).map((a) => ({
       sgid: a.sgid ?? "",
       url: a.url,

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -18,6 +18,7 @@ import { EventDedup } from "./dedup.js";
 import { CursorStore } from "./cursors.js";
 import { pollActivityFeed } from "./activity.js";
 import { pollReadings } from "./readings.js";
+import { bcqMarkReadingsRead } from "../bcq.js";
 import { isSelfMessage } from "./normalize.js";
 
 export interface CompositePollerOptions {
@@ -194,6 +195,19 @@ export async function startCompositePoller(
             dispatched++;
           } catch (err) {
             log?.error?.("[" + account.accountId + "] dispatch error for reading " + event.dedupKey + ": " + String(err));
+          }
+        }
+
+        // Mark processed readings as read so they don't reappear
+        if (result.processedSgids.length > 0) {
+          try {
+            await bcqMarkReadingsRead(result.processedSgids, {
+              accountId: account.config.bcqAccountId ?? account.accountId,
+              profile: account.bcqProfile,
+            });
+            log?.debug?.("[" + account.accountId + "] marked " + result.processedSgids.length + " readings as read");
+          } catch (err) {
+            log?.warn?.("[" + account.accountId + "] failed to mark readings as read: " + String(err));
           }
         }
 

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -202,7 +202,7 @@ export async function startCompositePoller(
         if (result.processedSgids.length > 0) {
           try {
             await bcqMarkReadingsRead(result.processedSgids, {
-              accountId: account.config.bcqAccountId ?? account.accountId,
+              accountId: account.config.bcqAccountId,
               profile: account.bcqProfile,
             });
             log?.debug?.("[" + account.accountId + "] marked " + result.processedSgids.length + " readings as read");

--- a/src/inbound/readings.ts
+++ b/src/inbound/readings.ts
@@ -49,7 +49,7 @@ export async function pollReadings(
     reads?: BasecampReadingsEntry[];
     memories?: BasecampReadingsEntry[];
   }>({
-    accountId: account.accountId,
+    accountId: account.config.bcqAccountId,
     profile: account.bcqProfile,
   });
 

--- a/src/inbound/readings.ts
+++ b/src/inbound/readings.ts
@@ -18,6 +18,8 @@ export interface ReadingsPollResult {
   events: BasecampInboundMessage[];
   /** ISO timestamp of the newest reading (for cursor advancement). */
   newestAt: string | undefined;
+  /** Readable SGIDs of all processed entries — pass to bcqMarkReadingsRead. */
+  processedSgids: string[];
 }
 
 export interface ReadingsPollerOptions {
@@ -53,7 +55,7 @@ export async function pollReadings(
 
   const unreads = result.data?.unreads;
   if (!Array.isArray(unreads) || unreads.length === 0) {
-    return { events: [], newestAt: undefined };
+    return { events: [], newestAt: undefined, processedSgids: [] };
   }
 
   log?.debug?.(`[${account.accountId}] readings returned ${unreads.length} unreads`);
@@ -67,6 +69,7 @@ export async function pollReadings(
     : unreads;
 
   const events: BasecampInboundMessage[] = [];
+  const processedSgids: string[] = [];
   let newestAt: string | undefined;
 
   for (const raw of filtered) {
@@ -75,6 +78,10 @@ export async function pollReadings(
       if (!normalized) continue;
 
       events.push(normalized);
+
+      if (raw.readable_sgid) {
+        processedSgids.push(raw.readable_sgid);
+      }
 
       const ts = raw.unread_at ?? raw.created_at;
       if (!newestAt || ts > newestAt) {
@@ -87,5 +94,5 @@ export async function pollReadings(
     }
   }
 
-  return { events, newestAt };
+  return { events, newestAt, processedSgids };
 }

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -9,10 +9,28 @@
  */
 
 import type { BasecampRecordableType } from "../types.js";
-import { bcqApiPost, withRetry, isRetryableError, BcqError } from "../bcq.js";
+import { bcqApiPost, withRetry, isRetryableError, BcqError, bcqResolvePingTranscript } from "../bcq.js";
 import { markdownToBasecampHtml } from "./format.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount } from "../config.js";
+
+// ---------------------------------------------------------------------------
+// Ping transcript cache — avoids re-fetching /circles/<id>.json per reply
+// ---------------------------------------------------------------------------
+
+const pingTranscriptCache = new Map<string, string>();
+
+async function resolvePingTranscriptCached(
+  bucketId: string,
+  accountId?: string,
+  profile?: string,
+): Promise<string | undefined> {
+  const cached = pingTranscriptCache.get(bucketId);
+  if (cached) return cached;
+  const transcriptId = await bcqResolvePingTranscript(bucketId, { accountId, profile });
+  if (transcriptId) pingTranscriptCache.set(bucketId, transcriptId);
+  return transcriptId;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers — Basecamp API write operations via bcq
@@ -129,11 +147,27 @@ export async function postReplyToEvent(params: {
   const { bucketId, recordingId, recordableType, peerId, content, accountId, profile, retries } = params;
   const parsed = parsePeerId(peerId);
 
+  // Pings: resolve the transcript ID from the circle's bucket ID
+  if (parsed.prefix === "ping") {
+    const transcriptId = await resolvePingTranscriptCached(bucketId, accountId, profile);
+    if (!transcriptId) {
+      return { ok: false, error: `Could not resolve Ping transcript for circle bucket=${bucketId}` };
+    }
+    const result = await postCampfireLine({
+      bucketId,
+      transcriptId,
+      content,
+      accountId,
+      profile,
+      retries,
+    });
+    return { ok: result.ok, messageId: result.recordingId, retryable: result.retryable, error: result.error };
+  }
+
   // Chat lines go to the transcript
   if (
     recordableType === "Chat::Transcript" ||
-    recordableType === "Chat::Line" ||
-    parsed.prefix === "ping"
+    recordableType === "Chat::Line"
   ) {
     const transcriptId = recordingId;
     const result = await postCampfireLine({

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,33 @@ export type BasecampRecordableType =
   | "Vault"
   | "Schedule::Entry";
 
+/**
+ * Engagement types — how an event relates to the agent.
+ *
+ * Ordered from most specific (direct address) to most ambient:
+ *   dm           — 1:1 Ping, someone is talking directly to the agent
+ *   mention      — agent was @mentioned in any surface
+ *   assignment   — agent was assigned/unassigned to a recording
+ *   checkin      — check-in question directed at the agent (Hey! inbox)
+ *   conversation — chat lines, comments in bound surfaces (not addressed)
+ *   activity     — general project activity (card moves, todo completions…)
+ */
+export type BasecampEngagementType =
+  | "dm"
+  | "mention"
+  | "assignment"
+  | "checkin"
+  | "conversation"
+  | "activity";
+
+/** Default engagement types that trigger agent response. */
+export const DEFAULT_ENGAGE: BasecampEngagementType[] = [
+  "dm",
+  "mention",
+  "assignment",
+  "checkin",
+];
+
 /** Event kinds emitted by the composite event fabric. */
 export type BasecampEventKind =
   // Chat
@@ -308,6 +335,8 @@ export type BasecampBucketConfig = {
   requireMention?: boolean;
   tools?: { allow?: string[]; deny?: string[] };
   enabled?: boolean;
+  /** Override engagement types for this bucket. */
+  engage?: BasecampEngagementType[];
 };
 
 // ---------------------------------------------------------------------------
@@ -370,6 +399,12 @@ export type BasecampChannelConfig = {
   allowFrom?: Array<string | number>;
   /** Per-bucket behavior overrides. Key is bucket ID or "*" for wildcard. */
   buckets?: Record<string, BasecampBucketConfig>;
+  /**
+   * Engagement types that trigger agent response.
+   * Defaults to ["dm", "mention", "assignment", "checkin"].
+   * Per-bucket overrides in `buckets.<id>.engage` take precedence.
+   */
+  engage?: BasecampEngagementType[];
   /** Polling cadence overrides (milliseconds). */
   polling?: {
     activityIntervalMs?: number;

--- a/tests/dispatch-enhanced.test.ts
+++ b/tests/dispatch-enhanced.test.ts
@@ -59,7 +59,7 @@ const mockMsg: BasecampInboundMessage = {
     recordableType: "Chat::Transcript",
     eventKind: "created",
     mentions: [],
-    mentionsAgent: false,
+    mentionsAgent: true,
     attachments: [],
     sources: ["activity_feed"],
   },

--- a/tests/dispatch-enhanced.test.ts
+++ b/tests/dispatch-enhanced.test.ts
@@ -73,7 +73,7 @@ const mockAccount: ResolvedBasecampAccount = {
   personId: "999",
   token: "tok-abc",
   tokenSource: "config",
-  config: { personId: "999" },
+  config: { personId: "999", bcqAccountId: "12345" },
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -60,7 +60,7 @@ const mockMsg: BasecampInboundMessage = {
     recordableType: "Chat::Transcript",
     eventKind: "created",
     mentions: [],
-    mentionsAgent: false,
+    mentionsAgent: true,
     attachments: [],
     sources: ["activity_feed"],
   },

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -74,7 +74,7 @@ const mockAccount: ResolvedBasecampAccount = {
   personId: "999",
   token: "tok-abc",
   tokenSource: "config",
-  config: { personId: "999" },
+  config: { personId: "999", bcqAccountId: "12345" },
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -180,6 +180,43 @@ describe("dispatchBasecampEvent", () => {
     );
   });
 
+  it("returns false and logs error when bcqAccountId is undefined", async () => {
+    const accountNoBcq: ResolvedBasecampAccount = {
+      ...mockAccount,
+      config: { personId: "999" },
+    };
+    const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+
+    const result = await dispatchBasecampEvent(mockMsg, { account: accountNoBcq, log });
+
+    expect(result).toBe(false);
+    expect(log.error).toHaveBeenCalledTimes(1);
+    expect(log.error.mock.calls[0][0]).toContain("unable to resolve bcq account id");
+    expect(
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("falls back to numeric accountId when bcqAccountId is unset", async () => {
+    const accountNumericId: ResolvedBasecampAccount = {
+      ...mockAccount,
+      accountId: "2914079",
+      config: { personId: "999" },
+    };
+
+    const result = await dispatchBasecampEvent(mockMsg, { account: accountNumericId });
+
+    expect(result).toBe(true);
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
+    const deliver = call.dispatcherOptions.deliver;
+    await deliver({ text: "Reply" }, {});
+
+    expect(postReplyToEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "2914079" }),
+    );
+  });
+
   it("deliver callback calls postReplyToEvent with correct params", async () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
@@ -390,6 +427,49 @@ describe("dispatchBasecampEvent", () => {
 
     const result = await dispatchBasecampEvent(chatMsg, { account: mockAccount });
     expect(result).toBe(true);
+  });
+
+  it("respects wildcard bucket engage override", async () => {
+    mockRuntime.config.loadConfig.mockReturnValue({
+      channels: {
+        basecamp: {
+          accounts: { "test-acct": { personId: "999" } },
+          buckets: { "*": { engage: ["dm", "mention", "conversation", "activity"] } },
+        },
+      },
+    });
+
+    const cardMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Kanban::Card",
+        eventKind: "moved",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(cardMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("prefers exact bucket engage over wildcard", async () => {
+    mockRuntime.config.loadConfig.mockReturnValue({
+      channels: {
+        basecamp: {
+          accounts: { "test-acct": { personId: "999" } },
+          buckets: {
+            "456": { engage: ["dm"] },
+            "*": { engage: ["dm", "mention", "conversation", "activity"] },
+          },
+        },
+      },
+    });
+
+    // Mention should be dropped — exact bucket only allows "dm"
+    const result = await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+    expect(result).toBe(false);
   });
 
   it("respects channel-level engage to include activity", async () => {

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -61,7 +61,7 @@ const mockMsg: BasecampInboundMessage = {
     recordableType: "Chat::Transcript",
     eventKind: "created",
     mentions: [],
-    mentionsAgent: false,
+    mentionsAgent: true,
     attachments: [],
     sources: ["activity_feed"],
   },
@@ -252,5 +252,168 @@ describe("dispatchBasecampEvent", () => {
       mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
         .calls[0][0];
     expect(call.ctx.ChatType).toBe("direct");
+  });
+
+  // -----------------------------------------------------------------------
+  // Engagement gate — config-driven classification
+  // -----------------------------------------------------------------------
+
+  it("drops activity events by default (not in default engage policy)", async () => {
+    const cardMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Kanban::Card",
+        eventKind: "moved",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(cardMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("drops conversation events by default", async () => {
+    const chatMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(chatMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("dispatches @mentions (in default engage policy)", async () => {
+    const mentionedMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Kanban::Card",
+        mentionsAgent: true,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(mentionedMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("dispatches DMs even without @mention", async () => {
+    const dmMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      peer: { kind: "dm", id: "ping:789" },
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(dmMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("dispatches assignment events (assignedToAgent)", async () => {
+    const assignMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Todo",
+        eventKind: "assigned",
+        mentionsAgent: false,
+        assignedToAgent: true,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(assignMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("dispatches check-in reminders (Question from readings)", async () => {
+    const checkinMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Question",
+        mentionsAgent: false,
+        sources: ["readings"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(checkinMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("drops Question from activity_feed (classified as activity, not checkin)", async () => {
+    const questionMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Question",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(questionMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("respects per-bucket engage override to include conversation", async () => {
+    // Override config to include conversation for bucket 456
+    mockRuntime.config.loadConfig.mockReturnValue({
+      channels: {
+        basecamp: {
+          accounts: { "test-acct": { personId: "999" } },
+          buckets: { "456": { engage: ["dm", "mention", "conversation"] } },
+        },
+      },
+    });
+
+    const chatMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(chatMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("respects channel-level engage to include activity", async () => {
+    mockRuntime.config.loadConfig.mockReturnValue({
+      channels: {
+        basecamp: {
+          accounts: { "test-acct": { personId: "999" } },
+          engage: ["dm", "mention", "assignment", "checkin", "conversation", "activity"],
+        },
+      },
+    });
+
+    const cardMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Kanban::Card",
+        eventKind: "moved",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(cardMsg, { account: mockAccount });
+    expect(result).toBe(true);
   });
 });

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -75,7 +75,7 @@ const mockAccount: ResolvedBasecampAccount = {
   personId: "999",
   token: "tok-abc",
   tokenSource: "config",
-  config: { personId: "999" },
+  config: { personId: "999", bcqAccountId: "12345" },
 };
 
 // ---------------------------------------------------------------------------
@@ -160,7 +160,7 @@ describe("dispatchBasecampEvent", () => {
       token: "tok-persona",
       tokenSource: "config",
       bcqProfile: "persona-profile",
-      config: { personId: "888", bcqProfile: "persona-profile" },
+      config: { personId: "888", bcqProfile: "persona-profile", bcqAccountId: "67890" },
     } as any);
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
@@ -174,7 +174,7 @@ describe("dispatchBasecampEvent", () => {
 
     expect(postReplyToEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        accountId: "persona-acct",
+        accountId: "67890",
         profile: "persona-profile",
       }),
     );
@@ -197,7 +197,7 @@ describe("dispatchBasecampEvent", () => {
       recordableType: "Chat::Transcript",
       peerId: "recording:123",
       content: "<p>Agent reply</p>",
-      accountId: "test-acct",
+      accountId: "12345",
       profile: undefined,
       retries: 2,
     });

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -427,6 +427,43 @@ describe("normalizeActivityEvent", () => {
 
     expect(msg.meta.sources).toContain("activity_feed");
   });
+
+  it("sets assignedToAgent when assignment target matches agent displayName", () => {
+    const acct = { ...mockAccount, displayName: "Clawdito" };
+    const raw = makeActivityEvent({
+      kind: "todo_assigned",
+      target: "Clawdito",
+      recording: { id: 203, type: "Todo", title: "Do the thing" },
+    });
+    const msg = normalizeActivityEvent(raw, acct);
+
+    expect(msg.meta.assignedToAgent).toBe(true);
+    expect(msg.meta.eventKind).toBe("assigned");
+  });
+
+  it("does not set assignedToAgent when target is a different person", () => {
+    const acct = { ...mockAccount, displayName: "Clawdito" };
+    const raw = makeActivityEvent({
+      kind: "todo_assigned",
+      target: "Alice",
+      recording: { id: 203, type: "Todo", title: "Do the thing" },
+    });
+    const msg = normalizeActivityEvent(raw, acct);
+
+    expect(msg.meta.assignedToAgent).toBeUndefined();
+  });
+
+  it("does not set assignedToAgent for non-assignment event kinds", () => {
+    const acct = { ...mockAccount, displayName: "Clawdito" };
+    const raw = makeActivityEvent({
+      kind: "todo_completed",
+      target: "Clawdito",
+      recording: { id: 203, type: "Todo", title: "Do the thing" },
+    });
+    const msg = normalizeActivityEvent(raw, acct);
+
+    expect(msg.meta.assignedToAgent).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three dogfood fixes from live testing against the 37signals Basecamp account, plus review feedback fixes:

- **Fix outbound bcq account ID in dispatch path** — The deliver callback was passing the OpenClaw account ID (e.g. "default") as bcq `--account`, which is never valid for Basecamp API calls. Now uses `account.config.bcqAccountId` (the numeric Basecamp account ID), with a numeric-accountId regex fallback and error bail when neither is available.

- **Detect assignment events directed at agent** — bc3 assignment event kinds (`todo_assigned`, `todo_unassigned`, etc.) put the assignee's display name in `raw.target`. Match against `account.displayName` to set `meta.assignedToAgent`, enabling the engagement gate to dispatch assignment-directed events without requiring @mention.

- **Config-driven engagement gate** — Classify inbound events by how they relate to the agent (dm, mention, assignment, checkin, conversation, activity), then match against a configurable `engage` policy. Default policy dispatches only when the agent is directly addressed. Per-bucket overrides via `buckets.<id>.engage` (including `"*"` wildcard) take precedence over channel-level config, enabling installations to opt in to broader engagement within specific projects.

- **Improve bcq error messages** — Node's `execFile` wraps failures as "Command failed: <cmd>" which is redundant. Now prefers stderr, then stdout (bcq may write errors there), then killed/signal info before falling back to the original message.

## Test plan

- [x] `npx vitest run` — 553 tests pass
- [ ] Verify outbound replies use the correct bcq account ID (not "default")
- [ ] Verify assignment events dispatch when agent is the assignee
- [x] Verify conversation/activity events are dropped by default — confirmed in gateway logs: `engagement gate: dropping engagement=activity event=created type=Kanban::Card`
- [ ] Verify per-bucket `engage` override allows broader engagement