### PR TITLE
Engagement gate: DM policy, outbound delivery, webhook hardening, assignments poller

### DIFF
--- a/src/adapters/mentions.ts
+++ b/src/adapters/mentions.ts
@@ -16,6 +16,22 @@ function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefi
 }
 
 /**
+ * Resolve the Basecamp account ID for an agent, using persona mapping.
+ * agentId may be an OpenClaw agent ID that maps to a Basecamp account via
+ * the personas config. Falls back to treating agentId as a direct account key.
+ */
+function resolveAccountIdForAgent(cfg: OpenClawConfig, agentId?: string): string | undefined {
+  if (!agentId) return undefined;
+  const section = getBasecampSection(cfg);
+  // Check persona mapping: agentId → accountId
+  const personaAccountId = section?.personas?.[agentId];
+  if (personaAccountId) return personaAccountId;
+  // Fall back to treating agentId as a direct account key
+  if (section?.accounts?.[agentId]) return agentId;
+  return undefined;
+}
+
+/**
  * Resolve the agent's display name for a given account.
  * Uses the account config's displayName field.
  */
@@ -29,17 +45,15 @@ function resolveAgentDisplayName(cfg: OpenClawConfig | undefined, accountId?: st
     return section.accounts[accountId]!.displayName;
   }
 
-  // Fall back to first account with a displayName
-  for (const acct of Object.values(section.accounts)) {
-    if (acct.displayName) return acct.displayName;
-  }
-
+  // Without a resolved accountId, don't fall back to an arbitrary account's
+  // displayName — in multi-persona setups that could strip legitimate text.
   return undefined;
 }
 
 export const basecampMentionAdapter: ChannelMentionAdapter = {
   stripPatterns: ({ cfg, agentId }) => {
-    const name = resolveAgentDisplayName(cfg, agentId);
+    const accountId = cfg ? resolveAccountIdForAgent(cfg, agentId) : agentId;
+    const name = resolveAgentDisplayName(cfg, accountId);
     if (!name) return [];
     // Match agent's display name at the start of text, followed by
     // optional punctuation and whitespace (common mention artifact pattern)
@@ -48,7 +62,8 @@ export const basecampMentionAdapter: ChannelMentionAdapter = {
   },
 
   stripMentions: ({ text, cfg, agentId }) => {
-    const name = resolveAgentDisplayName(cfg, agentId);
+    const accountId = cfg ? resolveAccountIdForAgent(cfg, agentId) : agentId;
+    const name = resolveAgentDisplayName(cfg, accountId);
     if (!name) return text;
 
     // Strip agent's display name from the start of the message

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -49,7 +49,7 @@ const dmPolicy: ChannelOnboardingDmPolicy = {
   channel,
   policyKey: "channels.basecamp.dmPolicy",
   allowFromKey: "channels.basecamp.allowFrom",
-  getCurrent: (cfg) => (getBasecampSection(cfg)?.dmPolicy as DmPolicy) ?? "open",
+  getCurrent: (cfg) => (getBasecampSection(cfg)?.dmPolicy as DmPolicy) ?? "pairing",
   setPolicy: (cfg, policy) => setBasecampDmPolicy(cfg, policy),
 };
 

--- a/src/adapters/outbound.ts
+++ b/src/adapters/outbound.ts
@@ -3,30 +3,47 @@
  *
  * Provides resolveTarget for pre-send validation and chunkMarkdownText
  * for splitting long agent output within Basecamp's 10K character limit.
+ *
+ * IMPORTANT: Direct sendText delivery is not supported. Basecamp outbound
+ * delivery requires bucket/recording/recordableType context that a bare
+ * peer ID cannot provide. All agent replies flow through the dispatch
+ * bridge (dispatch.ts → postReplyToEvent), which has full context from
+ * the originating inbound event.
  */
 
-const VALID_TARGET = /^(recording|ping):\d+$/;
+/** Basecamp's per-message character limit. Shared by channel config and dispatch. */
+export const BASECAMP_TEXT_CHUNK_LIMIT = 10_000;
 
 export type ResolveTargetResult =
   | { ok: true; to: string }
   | { ok: false; error: string };
 
 /**
- * Validate an outbound target string before attempting delivery.
- * Must match recording:<id> or ping:<id>. bucket:<id> peers represent a
- * project scope, not a specific conversation, and are not valid send targets.
+ * Validate an outbound target for direct sendText delivery.
+ *
+ * Currently always returns ok:false — direct sendText delivery is not
+ * supported for Basecamp targets. Peer IDs (recording:<id>, ping:<id>)
+ * lack the bucketId/recordableType context needed for API calls.
+ *
+ * Agent replies are delivered through the dispatch bridge's deliver
+ * callback, which has full context from the inbound event.
  */
 export function resolveOutboundTarget(to: string): ResolveTargetResult {
   if (!to) {
     return { ok: false, error: "Target is empty" };
   }
-  if (VALID_TARGET.test(to)) {
-    return { ok: true, to };
+  // Recognize valid Basecamp peer formats for clear error messages
+  if (/^(recording|ping):\d+$/.test(to)) {
+    return {
+      ok: false,
+      error: `Basecamp target "${to}" requires bucket context for delivery. ` +
+        `Direct sendText is not supported — agent replies use the dispatch bridge`,
+    };
   }
   if (/^bucket:\d+$/.test(to)) {
     return {
       ok: false,
-      error: `"${to}" is a project scope, not a conversation target. Use a recording: or ping: peer instead`,
+      error: `"${to}" is a project scope, not a conversation target`,
     };
   }
   return {

--- a/src/adapters/security.ts
+++ b/src/adapters/security.ts
@@ -14,14 +14,12 @@ function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefi
 }
 
 export const basecampSecurityAdapter = {
-  resolveDmPolicy: ({ cfg, accountId, account: _account }: { cfg: OpenClawConfig; accountId?: string | null; account: ResolvedBasecampAccount }) => {
+  resolveDmPolicy: ({ cfg, accountId: _accountId, account: _account }: { cfg: OpenClawConfig; accountId?: string | null; account: ResolvedBasecampAccount }) => {
     const section = getBasecampSection(cfg);
     const dmPolicy = section?.dmPolicy ?? "pairing";
     const allowFrom = section?.allowFrom ?? [];
-    const basePath =
-      accountId != null && accountId !== DEFAULT_ACCOUNT_ID
-        ? `channels.basecamp.accounts.${accountId}.`
-        : "channels.basecamp.";
+    // DM policy is channel-level (channels.basecamp.dmPolicy), not per-account.
+    const basePath = "channels.basecamp.";
     return {
       policy: dmPolicy,
       allowFrom,

--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -383,6 +383,15 @@ export async function bcqReadings<T = unknown>(opts: BcqOptions = {}): Promise<B
 }
 
 /**
+ * Fetch current assignments via `GET /my/assignments.json`.
+ * Returns priorities + non_priorities arrays of assigned todos.
+ */
+export async function bcqAssignments<T = unknown>(opts: BcqOptions = {}): Promise<BcqResult<T>> {
+  const fn = () => execBcq<T>(["api", "get", "/my/assignments.json"], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
+}
+
+/**
  * Mark readings as read via `PUT /my/unreads` with a list of readable SGIDs.
  * This is the bulk mark-as-read endpoint — accepts up to ~50 SGIDs per call.
  */

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -31,7 +31,7 @@ import { basecampHeartbeatAdapter } from "./adapters/heartbeat.js";
 import { basecampGroupAdapter } from "./adapters/groups.js";
 import { basecampAgentPromptAdapter } from "./adapters/agent-prompt.js";
 import { basecampSecurityAdapter } from "./adapters/security.js";
-import { resolveOutboundTarget, chunkMarkdownText } from "./adapters/outbound.js";
+import { resolveOutboundTarget, chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
 import { basecampMentionAdapter } from "./adapters/mentions.js";
 
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
@@ -157,7 +157,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
 
   outbound: {
     deliveryMode: "direct",
-    textChunkLimit: 10000,
+    textChunkLimit: BASECAMP_TEXT_CHUNK_LIMIT,
     chunkerMode: "markdown",
     chunker: (text, limit) => chunkMarkdownText(text, limit),
     resolveTarget: ({ to }) => {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -130,11 +130,11 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       bcqProfile: account.bcqProfile,
     }),
     setAccountEnabled: ({ cfg, accountId, enabled }) =>
-      setAccountEnabledInConfigSection({ cfg, sectionKey: "channels.basecamp", accountId, enabled }),
+      setAccountEnabledInConfigSection({ cfg, sectionKey: "basecamp", accountId, enabled }),
     deleteAccount: ({ cfg, accountId }) => {
       const updated = deleteAccountFromConfigSection({
         cfg,
-        sectionKey: "channels.basecamp",
+        sectionKey: "basecamp",
         accountId,
       });
       // Clean up persona entries pointing to the deleted account

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -106,7 +106,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       "accounts.*.personId": { label: "Person ID", help: "Your Basecamp person ID (numeric)" },
       "personas": { label: "Agent personas", help: "Maps agent IDs to Basecamp account IDs for multi-identity outbound", advanced: true },
       "virtualAccounts": { label: "Project scopes", help: "Maps synthetic account IDs to specific projects", advanced: true },
-      "dmPolicy": { label: "DM policy", help: "Controls who can DM agents: open, pairing, closed" },
+      "dmPolicy": { label: "DM policy", help: "Controls who can DM agents: pairing, allowlist, open, disabled" },
       "allowFrom": { label: "Allowed senders", help: "Basecamp person IDs allowed to message agents" },
       "engage": { label: "Engagement policy", help: "Event types that trigger agent response: dm, mention, assignment, checkin, conversation, activity" },
       "buckets": { label: "Per-project settings", help: "Override engage, requireMention, and tool policies per bucket", advanced: true },

--- a/src/config.ts
+++ b/src/config.ts
@@ -343,6 +343,6 @@ export function resolveAccountForBucket(
       if (va.bucketId === bucketId) return key;
     }
   }
-  // Fall back to the default account
+  // No virtual account mapping for this bucket
   return undefined;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,8 @@ export const BasecampConfigSchema = z.object({
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   buckets: z.record(z.string(), BasecampBucketConfigSchema).optional(),
   engage: z.array(EngagementTypeSchema).optional(),
+  /** Secret token for webhook URL verification. Required to accept webhook requests. */
+  webhookSecret: z.string().optional(),
   polling: z
     .object({
       activityIntervalMs: z.number().positive().optional(),
@@ -317,4 +319,30 @@ export function resolveBasecampDmPolicy(cfg: OpenClawConfig) {
 export function resolveBasecampAllowFrom(cfg: OpenClawConfig): string[] {
   const section = getBasecampSection(cfg);
   return (section?.allowFrom ?? []).map((entry) => String(entry));
+}
+
+/** Get the webhook secret (undefined = webhooks disabled). */
+export function resolveWebhookSecret(cfg: OpenClawConfig): string | undefined {
+  const section = getBasecampSection(cfg);
+  return section?.webhookSecret;
+}
+
+/**
+ * Resolve the account for a given bucket ID.
+ * Checks virtualAccounts for a scope mapping, then falls back to the
+ * first concrete account. Returns undefined if no account found.
+ */
+export function resolveAccountForBucket(
+  cfg: OpenClawConfig,
+  bucketId: string,
+): string | undefined {
+  const section = getBasecampSection(cfg);
+  // Check virtualAccounts for a scope mapping to this bucket
+  if (section?.virtualAccounts) {
+    for (const [key, va] of Object.entries(section.virtualAccounts)) {
+      if (va.bucketId === bucketId) return key;
+    }
+  }
+  // Fall back to the default account
+  return undefined;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,7 +47,7 @@ export const BasecampConfigSchema = z.object({
   accounts: z.record(z.string(), BasecampAccountConfigSchema).optional(),
   virtualAccounts: z.record(z.string(), BasecampVirtualAccountSchema).optional(),
   personas: z.record(z.string(), z.string()).optional(),
-  dmPolicy: z.enum(["open", "pairing", "closed"]).optional(),
+  dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   buckets: z.record(z.string(), BasecampBucketConfigSchema).optional(),
   engage: z.array(EngagementTypeSchema).optional(),
@@ -307,10 +307,10 @@ export function resolveCircuitBreakerConfig(cfg: OpenClawConfig): { threshold: n
   };
 }
 
-/** Get the DM policy for Basecamp Pings. */
+/** Get the DM policy for Basecamp Pings. Defaults to "pairing". */
 export function resolveBasecampDmPolicy(cfg: OpenClawConfig) {
   const section = getBasecampSection(cfg);
-  return section?.dmPolicy ?? "open";
+  return section?.dmPolicy ?? "pairing";
 }
 
 /** Get the allow-from list. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,7 @@ export const BasecampConfigSchema = z.object({
     .object({
       activityIntervalMs: z.number().positive().optional(),
       readingsIntervalMs: z.number().positive().optional(),
-      directPollIntervalMs: z.number().positive().optional(),
+      assignmentsIntervalMs: z.number().positive().optional(),
     })
     .optional(),
   retry: z
@@ -285,7 +285,7 @@ export function resolvePollingIntervals(cfg: unknown) {
   return {
     activityIntervalMs: section?.polling?.activityIntervalMs ?? 120_000,
     readingsIntervalMs: section?.polling?.readingsIntervalMs ?? 60_000,
-    directPollIntervalMs: section?.polling?.directPollIntervalMs ?? 300_000,
+    assignmentsIntervalMs: section?.polling?.assignmentsIntervalMs ?? 300_000,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,21 +98,13 @@ function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
 }
 
 /**
- * List all account IDs configured under channels.basecamp.accounts,
- * including virtual (project-scoped) account keys.
+ * List concrete account IDs configured under channels.basecamp.accounts.
+ * Virtual (project-scoped) account aliases are excluded — they are routing
+ * aliases for real accounts, not independent accounts that need workers.
  * Returns [DEFAULT_ACCOUNT_ID] if none are configured.
  */
 export function listBasecampAccountIds(cfg: OpenClawConfig): string[] {
   const ids = new Set(listConfiguredAccountIds(cfg));
-
-  // Include virtual account (project-scope) keys
-  const section = getBasecampSection(cfg);
-  const virtualAccounts = section?.virtualAccounts;
-  if (virtualAccounts && typeof virtualAccounts === "object") {
-    for (const key of Object.keys(virtualAccounts)) {
-      if (key) ids.add(normalizeAccountId(key));
-    }
-  }
 
   if (ids.size === 0) {
     return [DEFAULT_ACCOUNT_ID];

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -15,7 +15,7 @@ import type { BasecampInboundMessage, BasecampChannelConfig, BasecampEngagementT
 import { DEFAULT_ENGAGE } from "./types.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { getBasecampRuntime } from "./runtime.js";
-import { resolvePersonaAccountId, resolveBasecampAccount } from "./config.js";
+import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom } from "./config.js";
 import { postReplyToEvent } from "./outbound/send.js";
 import { markdownToBasecampHtml } from "./outbound/format.js";
 
@@ -79,6 +79,31 @@ export async function dispatchBasecampEvent(
       `peer=${msg.peer.id} policy=[${engagePolicy.join(",")}]`,
     );
     return false;
+  }
+
+  // ----- DM policy enforcement -----
+  // Even when engagement=dm passes the engage gate, verify the sender is
+  // allowed under the configured DM policy (SDK vocabulary:
+  // pairing | allowlist | open | disabled).
+  if (engagement === "dm") {
+    const dmPolicy = resolveBasecampDmPolicy(cfg);
+    if (dmPolicy === "disabled") {
+      log?.debug?.(
+        `[${account.accountId}] dm policy: dropping dm from sender=${msg.sender.id} (policy=disabled)`,
+      );
+      return false;
+    }
+    if (dmPolicy === "pairing" || dmPolicy === "allowlist") {
+      const allowFrom = resolveBasecampAllowFrom(cfg);
+      if (!allowFrom.includes(msg.sender.id)) {
+        log?.debug?.(
+          `[${account.accountId}] dm policy: dropping dm from sender=${msg.sender.id} ` +
+          `(policy=${dmPolicy}, not in allowFrom=[${allowFrom.join(",")}])`,
+        );
+        return false;
+      }
+    }
+    // dmPolicy === "open" → allow all DMs through
   }
 
   log?.info?.(

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -18,6 +18,7 @@ import { getBasecampRuntime } from "./runtime.js";
 import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom } from "./config.js";
 import { postReplyToEvent } from "./outbound/send.js";
 import { markdownToBasecampHtml } from "./outbound/format.js";
+import { chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
 
 export type DispatchOptions = {
   /** The resolved account that received this event. */
@@ -171,19 +172,28 @@ export async function dispatchBasecampEvent(
       deliver: async (payload, info) => {
         if (!payload.text) return;
 
-        // Convert agent markdown output to Basecamp HTML
-        const htmlContent = markdownToBasecampHtml(payload.text);
+        // Chunk long agent output to fit within Basecamp's character limit.
+        // Each chunk is converted to HTML and sent as a separate message.
+        const chunks = chunkMarkdownText(payload.text, BASECAMP_TEXT_CHUNK_LIMIT);
 
-        await postReplyToEvent({
-          bucketId: msg.meta.bucketId,
-          recordingId: msg.meta.recordingId,
-          recordableType: msg.meta.recordableType,
-          peerId: msg.peer.id,
-          content: htmlContent,
-          accountId: outboundBcqAccountId,
-          profile: outboundProfile,
-          retries: 2,
-        });
+        for (const chunk of chunks) {
+          const htmlContent = markdownToBasecampHtml(chunk);
+
+          const result = await postReplyToEvent({
+            bucketId: msg.meta.bucketId,
+            recordingId: msg.meta.recordingId,
+            recordableType: msg.meta.recordableType,
+            peerId: msg.peer.id,
+            content: htmlContent,
+            accountId: outboundBcqAccountId,
+            profile: outboundProfile,
+            retries: 2,
+          });
+
+          if (!result.ok) {
+            throw new Error(result.error ?? "Outbound delivery failed");
+          }
+        }
       },
       onError: (err) => {
         dispatchHadError = true;

--- a/src/inbound/assignments.ts
+++ b/src/inbound/assignments.ts
@@ -1,0 +1,139 @@
+/**
+ * Assignments polling source.
+ *
+ * Polls GET /my/assignments.json via bcq to detect todos newly assigned
+ * to the service account. Uses a set-diff approach: tracks known todo IDs
+ * and emits events only for new assignments.
+ *
+ * Unlike activity/readings pollers (timestamp cursors), this source uses
+ * ID-set cursors because the API returns current state, not an event stream.
+ *
+ * First poll with no cursor: bootstrap — records all current IDs, emits nothing.
+ * Subsequent polls: diff current vs stored — new IDs emit assignment events.
+ */
+
+import type {
+  BasecampAssignmentTodo,
+  BasecampInboundMessage,
+  ResolvedBasecampAccount,
+} from "../types.js";
+import { bcqAssignments } from "../bcq.js";
+import { normalizeAssignmentTodo } from "./normalize.js";
+
+export interface AssignmentsPollResult {
+  events: BasecampInboundMessage[];
+  /** Updated set of known todo IDs (for cursor persistence). */
+  knownIds: Set<string>;
+}
+
+export interface AssignmentsPollerOptions {
+  account: ResolvedBasecampAccount;
+  /** Previously known assignment todo IDs (from cursor). Empty set = never polled. */
+  knownIds: Set<string>;
+  /** True if this is the first poll (bootstrap — don't emit events). */
+  isBootstrap: boolean;
+  log?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    debug?: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+/**
+ * Expected response shape from GET /my/assignments.json.
+ * May also be a flat array in some API versions.
+ */
+type AssignmentsResponse = {
+  priorities?: BasecampAssignmentTodo[];
+  non_priorities?: BasecampAssignmentTodo[];
+};
+
+/**
+ * Flatten all assignment records from the response, recursing into children.
+ * bc3's assignments API nests child assignments (e.g. todos under todolists).
+ */
+function flattenTodos(items: BasecampAssignmentTodo[]): BasecampAssignmentTodo[] {
+  const result: BasecampAssignmentTodo[] = [];
+  for (const item of items) {
+    result.push(item);
+    if (Array.isArray(item.children) && item.children.length > 0) {
+      result.push(...flattenTodos(item.children));
+    }
+  }
+  return result;
+}
+
+/** Extract all todos from the assignments response (handles both shapes). */
+function extractTodos(data: unknown): BasecampAssignmentTodo[] {
+  let items: BasecampAssignmentTodo[];
+  if (Array.isArray(data)) {
+    items = data as BasecampAssignmentTodo[];
+  } else {
+    const resp = data as AssignmentsResponse;
+    items = [];
+    if (Array.isArray(resp?.priorities)) {
+      items.push(...resp.priorities);
+    }
+    if (Array.isArray(resp?.non_priorities)) {
+      items.push(...resp.non_priorities);
+    }
+  }
+  return flattenTodos(items);
+}
+
+/**
+ * Poll assignments for newly-assigned todos.
+ */
+export async function pollAssignments(
+  opts: AssignmentsPollerOptions,
+): Promise<AssignmentsPollResult> {
+  const { account, knownIds, isBootstrap, log } = opts;
+
+  log?.debug?.(`[${account.accountId}] polling assignments`);
+
+  const result = await bcqAssignments({
+    accountId: account.config.bcqAccountId,
+    profile: account.bcqProfile,
+  });
+
+  const todos = extractTodos(result.data);
+  const currentIds = new Set(todos.map((t) => String(t.id)));
+
+  log?.debug?.(
+    `[${account.accountId}] assignments: ${currentIds.size} current, ${knownIds.size} known`,
+  );
+
+  // Bootstrap: record all current IDs without emitting events.
+  if (isBootstrap) {
+    log?.info?.(
+      `[${account.accountId}] assignments bootstrap: recording ${currentIds.size} existing assignments`,
+    );
+    return { events: [], knownIds: currentIds };
+  }
+
+  // Diff: find newly-assigned todos
+  const newIds = new Set<string>();
+  for (const id of currentIds) {
+    if (!knownIds.has(id)) {
+      newIds.add(id);
+    }
+  }
+
+  const events: BasecampInboundMessage[] = [];
+  for (const todo of todos) {
+    const todoId = String(todo.id);
+    if (!newIds.has(todoId)) continue;
+
+    try {
+      const normalized = normalizeAssignmentTodo(todo, account);
+      events.push(normalized);
+    } catch (err) {
+      log?.warn?.(
+        `[${account.accountId}] failed to normalize assignment todo id=${todo.id}: ${String(err)}`,
+      );
+    }
+  }
+
+  return { events, knownIds: currentIds };
+}

--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -11,6 +11,7 @@
 
 import type {
   BasecampActivityEvent,
+  BasecampAssignmentTodo,
   BasecampInboundMessage,
   BasecampInboundMeta,
   BasecampPeer,
@@ -313,14 +314,22 @@ export function normalizeActivityEvent(
 
   const effectiveRecordableType = recordableType ?? "Document";
 
+  // Detect Pings: activity events for Pings use /circles/<id> URLs
+  // instead of /buckets/<id>. Also check recording.type if available.
+  const isPing =
+    raw.app_url?.includes("/circles/") === true ||
+    raw.recording?.type === "Ping" ||
+    raw.recording?.recordable_type === "Ping";
+
   const peer = resolveBasecampPeer({
     recordableType: effectiveRecordableType,
     recordingId,
     parentRecordingId,
     bucketId,
+    isPing,
   });
 
-  const parentPeer = resolveParentPeer(bucketId, false);
+  const parentPeer = resolveParentPeer(bucketId, isPing);
 
   // Detect assignment events directed at the agent.
   // bc3 assignment event kinds put the assignee's display name in `target`.
@@ -463,6 +472,81 @@ export function normalizeReadingsEvent(
     meta,
     dedupKey: dedupPrimary,
     createdAt: raw.unread_at ?? raw.created_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Assignment normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a newly-discovered assignment todo into a BasecampInboundMessage.
+ *
+ * Called by the assignments poller when a todo ID appears that wasn't in the
+ * previous known-set. The event is always classified as an assignment directed
+ * at the agent (assignedToAgent=true).
+ */
+export function normalizeAssignmentTodo(
+  raw: BasecampAssignmentTodo,
+  account: ResolvedBasecampAccount,
+): BasecampInboundMessage {
+  const bucketId = String(raw.bucket.id);
+  const recordingId = String(raw.id);
+  const text = raw.content ?? raw.title ?? "";
+  const html = text;
+
+  const sender: BasecampSender = raw.creator
+    ? {
+        id: String(raw.creator.id),
+        name: raw.creator.name,
+        email: raw.creator.email_address,
+        avatarUrl: raw.creator.avatar_url,
+      }
+    : { id: "unknown", name: "Unknown" };
+
+  // Use the actual type from the API response when available (e.g. "Todo",
+  // "Schedule"). Fall back to "Todo" for legacy/untyped payloads.
+  const recordableType: BasecampRecordableType =
+    (raw.type && normalizeRecordingType(raw.type)) || "Todo";
+
+  const peer = resolveBasecampPeer({
+    recordableType,
+    recordingId,
+    bucketId,
+  });
+
+  const parentPeer = resolveParentPeer(bucketId, false);
+
+  const meta: BasecampInboundMeta = {
+    bucketId,
+    recordingId,
+    recordableType,
+    eventKind: "assigned" as BasecampInboundMeta["eventKind"],
+    mentions: [],
+    mentionsAgent: false,
+    assignedToAgent: true,
+    assignees: raw.assignees?.map((a) => String(a.id)),
+    attachments: [],
+    dueOn: raw.due_on ?? undefined,
+    sources: ["assignments"],
+  };
+
+  // Include updated_at in the dedup key so re-assignments after a previous
+  // unassign→reassign cycle within the 24h TTL produce distinct keys.
+  const updatedSuffix = raw.updated_at ? `:${raw.updated_at}` : "";
+  const dedupPrimary = EventDedup.primaryKey("direct", `assign:${recordingId}${updatedSuffix}`);
+
+  return {
+    channel: "basecamp",
+    accountId: account.accountId,
+    peer,
+    parentPeer,
+    sender,
+    text,
+    html,
+    meta,
+    dedupKey: dedupPrimary,
+    createdAt: raw.updated_at ?? raw.created_at ?? new Date().toISOString(),
   };
 }
 

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -1,12 +1,17 @@
 /**
  * Composite event fabric orchestrator.
  *
- * Coordinates ActivityFeedPoller + ReadingsPoller with dedup,
- * cursor persistence, and configurable intervals.
+ * Coordinates three polling sources with dedup, cursor persistence,
+ * and configurable intervals:
  *
- * Polling cadence (defaults):
- * - Activity feed: every 120s
- * - Readings: every 60s
+ * - Activity feed (120s default): account-wide timeline events
+ * - Readings (60s default): Hey! inbox unreads
+ * - Assignments (300s default): set-diff of /my/assignments.json
+ *
+ * Activity and readings use timestamp cursors (events are streams).
+ * Assignments uses an ID-set cursor (API returns current state, not events).
+ * On first assignments poll, bootstraps by recording existing IDs without
+ * emitting events to avoid flooding agents with stale assignments.
  *
  * Respects AbortSignal for graceful shutdown. Uses exponential
  * backoff on errors (max 5 minutes).
@@ -18,6 +23,7 @@ import { EventDedup } from "./dedup.js";
 import { CursorStore } from "./cursors.js";
 import { pollActivityFeed } from "./activity.js";
 import { pollReadings } from "./readings.js";
+import { pollAssignments } from "./assignments.js";
 import { bcqMarkReadingsRead } from "../bcq.js";
 import { isSelfMessage } from "./normalize.js";
 
@@ -80,6 +86,7 @@ export async function startCompositePoller(
   const intervals = resolvePollingIntervals(cfg);
   const activityIntervalMs = intervals.activityIntervalMs;
   const readingsIntervalMs = intervals.readingsIntervalMs;
+  const assignmentsIntervalMs = intervals.assignmentsIntervalMs;
 
   const dedup = new EventDedup();
   const stateDir = opts.stateDir ?? "/tmp/openclaw-basecamp-state";
@@ -110,13 +117,32 @@ export async function startCompositePoller(
 
   let activityBackoff = 0;
   let readingsBackoff = 0;
+  let assignmentsBackoff = 0;
   const MAX_BACKOFF_MS = 5 * 60 * 1000;
 
   let lastActivityPoll = 0;
   let lastReadingsPoll = 0;
+  let lastAssignmentsPoll = 0;
+
+  // Assignments poller: set-diff cursor (known todo IDs, not timestamps).
+  // If the cursor has no stored IDs, the first poll is a bootstrap (snapshot only).
+  const storedIds = cursors.getCustom("assignmentIds");
+  let assignmentKnownIds: Set<string> = new Set();
+  let assignmentsBootstrapped = false;
+  if (storedIds !== undefined) {
+    try {
+      const parsed = JSON.parse(storedIds);
+      if (Array.isArray(parsed)) {
+        assignmentKnownIds = new Set(parsed as string[]);
+        assignmentsBootstrapped = true;
+      }
+    } catch {
+      log?.warn?.(`[${account.accountId}] corrupt assignment cursor — will re-bootstrap`);
+    }
+  }
 
   log?.info?.(
-    "[" + account.accountId + "] composite poller started (activity=" + activityIntervalMs + "ms, readings=" + readingsIntervalMs + "ms)",
+    "[" + account.accountId + "] composite poller started (activity=" + activityIntervalMs + "ms, readings=" + readingsIntervalMs + "ms, assignments=" + assignmentsIntervalMs + "ms)",
   );
 
   while (!abortSignal?.aborted) {
@@ -231,10 +257,57 @@ export async function startCompositePoller(
       }
     }
 
+    // Poll assignments (set-diff: detect newly assigned todos)
+    const assignmentsDue = now - lastAssignmentsPoll >= assignmentsIntervalMs + assignmentsBackoff;
+    if (assignmentsDue) {
+      lastAssignmentsPoll = now;
+      try {
+        const result = await pollAssignments({
+          account,
+          knownIds: assignmentKnownIds,
+          isBootstrap: !assignmentsBootstrapped,
+          log,
+        });
+
+        let dispatched = 0;
+        for (const event of result.events) {
+          if (dedup.isDuplicate(event.dedupKey)) continue;
+          if (isSelfMessage(event.sender.id, account)) continue;
+
+          try {
+            await onEvent(event);
+            dispatched++;
+          } catch (err) {
+            log?.error?.("[" + account.accountId + "] dispatch error for assignment " + event.dedupKey + ": " + String(err));
+          }
+        }
+
+        // Persist updated known-ID set
+        assignmentKnownIds = result.knownIds;
+        assignmentsBootstrapped = true;
+        cursors.setCustom("assignmentIds", JSON.stringify([...result.knownIds]));
+        await saveCursorsWithRetry(cursors, account.accountId, log);
+
+        if (dispatched > 0) {
+          log?.info?.("[" + account.accountId + "] assignments: " + result.events.length + " new, " + dispatched + " dispatched");
+        }
+
+        assignmentsBackoff = 0;
+      } catch (err) {
+        assignmentsBackoff = clamp(
+          assignmentsBackoff === 0 ? assignmentsIntervalMs : assignmentsBackoff * 2,
+          assignmentsIntervalMs,
+          MAX_BACKOFF_MS,
+        );
+        log?.error?.("[" + account.accountId + "] assignments error (backoff=" + assignmentsBackoff + "ms): " + String(err));
+      }
+    }
+
     // Sleep until next poll
     const nextActivityDue = lastActivityPoll + activityIntervalMs + activityBackoff - Date.now();
     const nextReadingsDue = lastReadingsPoll + readingsIntervalMs + readingsBackoff - Date.now();
-    const sleepMs = Math.max(1000, Math.min(nextActivityDue, nextReadingsDue));
+    const nextAssignmentsDue = lastAssignmentsPoll + assignmentsIntervalMs + assignmentsBackoff - Date.now();
+    const sleepMs = Math.max(1000, Math.min(nextActivityDue, nextReadingsDue, nextAssignmentsDue));
 
     await abortableSleep(sleepMs, abortSignal);
   }

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -16,7 +16,7 @@ import { normalizeWebhookPayload, isSelfMessage } from "./normalize.js";
 import { EventDedup } from "./dedup.js";
 import { dispatchBasecampEvent } from "../dispatch.js";
 import { getBasecampRuntime } from "../runtime.js";
-import { resolveBasecampAccount, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
+import { resolveBasecampAccount, resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter
@@ -205,7 +205,8 @@ export async function handleBasecampWebhook(
         return;
       }
     }
-    account = resolveBasecampAccount(cfg, scopeAccountId);
+    const effectiveAccountId = scopeAccountId ?? resolveDefaultBasecampAccountId(cfg);
+    account = resolveBasecampAccount(cfg, effectiveAccountId);
     if (!account.enabled) {
       console.warn(`[basecamp:webhook] resolved account "${account.accountId}" is disabled, dropping`);
       return;

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -16,7 +16,7 @@ import { normalizeWebhookPayload, isSelfMessage } from "./normalize.js";
 import { EventDedup } from "./dedup.js";
 import { dispatchBasecampEvent } from "../dispatch.js";
 import { getBasecampRuntime } from "../runtime.js";
-import { resolveBasecampAccount } from "../config.js";
+import { resolveBasecampAccount, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter
@@ -134,6 +134,36 @@ export async function handleBasecampWebhook(
     return;
   }
 
+  // ----- Webhook secret verification -----
+  // Reject requests when no webhookSecret is configured (disabled by default)
+  // or when the provided token doesn't match.
+  let cfg;
+  try {
+    const runtime = getBasecampRuntime();
+    cfg = runtime.config.loadConfig();
+  } catch (err) {
+    console.error("[basecamp:webhook] failed to load config:", err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Internal error" }));
+    return;
+  }
+
+  const webhookSecret = resolveWebhookSecret(cfg);
+  if (!webhookSecret) {
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Webhooks not configured (set channels.basecamp.webhookSecret)" }));
+    return;
+  }
+
+  // Check token from query string: /webhooks/basecamp?token=<secret>
+  const urlObj = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const providedToken = urlObj.searchParams.get("token");
+  if (!providedToken || providedToken !== webhookSecret) {
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid webhook token" }));
+    return;
+  }
+
   // Read and parse body
   let payload: BasecampWebhookPayload;
   try {
@@ -156,14 +186,30 @@ export async function handleBasecampWebhook(
   res.writeHead(200, { "Content-Type": "application/json" });
   res.end(JSON.stringify({ ok: true }));
 
-  // Resolve account from the webhook delivery context.
-  // Basecamp webhooks include a bucket.id — we use it to find the account.
-  // For Phase 1, we resolve the default account.
+  // Resolve account from bucket ID in the webhook payload.
+  // Check virtualAccounts for a scope mapping. Reject unmapped buckets
+  // in multi-account mode to prevent dispatching under the wrong identity.
   let account: ResolvedBasecampAccount;
   try {
-    const runtime = getBasecampRuntime();
-    const cfg = runtime.config.loadConfig();
-    account = resolveBasecampAccount(cfg);
+    const bucketId = String(payload.recording.bucket.id);
+    const scopeAccountId = resolveAccountForBucket(cfg, bucketId);
+    if (!scopeAccountId) {
+      // No virtualAccount mapping for this bucket. In multi-account mode
+      // this is ambiguous — reject rather than guess wrong identity.
+      const accountIds = listBasecampAccountIds(cfg);
+      if (accountIds.length > 1) {
+        console.warn(
+          `[basecamp:webhook] unmapped bucket ${bucketId} with ${accountIds.length} accounts configured, dropping ` +
+          `(add a virtualAccounts entry to route this bucket to an account)`,
+        );
+        return;
+      }
+    }
+    account = resolveBasecampAccount(cfg, scopeAccountId);
+    if (!account.enabled) {
+      console.warn(`[basecamp:webhook] resolved account "${account.accountId}" is disabled, dropping`);
+      return;
+    }
   } catch (err) {
     console.error("[basecamp:webhook] failed to resolve account:", err);
     return;

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -176,9 +176,9 @@ export async function handleBasecampWebhook(
   }
 
   // Validate minimal required fields
-  if (!payload.kind || !payload.recording?.id || !payload.creator?.id) {
+  if (!payload.kind || !payload.recording?.id || !payload.creator?.id || !payload.recording?.bucket?.id) {
     res.writeHead(422, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Missing required fields: kind, recording.id, creator.id" }));
+    res.end(JSON.stringify({ error: "Missing required fields: kind, recording.id, recording.bucket.id, creator.id" }));
     return;
   }
 

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -164,12 +164,18 @@ export async function postReplyToEvent(params: {
     return { ok: result.ok, messageId: result.recordingId, retryable: result.retryable, error: result.error };
   }
 
+  // For child events (Chat::Line, Comment), the peer points to the parent
+  // recording (transcript or commentable). Use it as the outbound target
+  // so replies land on the right thread.
+  const peerTarget = parsePeerId(peerId);
+  const parentId = peerTarget.prefix === "recording" ? peerTarget.id : undefined;
+
   // Chat lines go to the transcript
   if (
     recordableType === "Chat::Transcript" ||
     recordableType === "Chat::Line"
   ) {
-    const transcriptId = recordingId;
+    const transcriptId = parentId ?? recordingId;
     const result = await postCampfireLine({
       bucketId,
       transcriptId,
@@ -182,9 +188,10 @@ export async function postReplyToEvent(params: {
   }
 
   // Everything else gets a comment on the recording
+  const targetRecordingId = parentId ?? recordingId;
   const result = await postComment({
     bucketId,
-    recordingId,
+    recordingId: targetRecordingId,
     content,
     accountId,
     profile,

--- a/src/types.ts
+++ b/src/types.ts
@@ -412,6 +412,8 @@ export type BasecampChannelConfig = {
    * Per-bucket overrides in `buckets.<id>.engage` take precedence.
    */
   engage?: BasecampEngagementType[];
+  /** Secret token for webhook URL verification. Webhook requests are rejected when unset. */
+  webhookSecret?: string;
   /** Polling cadence overrides (milliseconds). */
   polling?: {
     activityIntervalMs?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export type BasecampEventKind =
 export type BasecampEventSource =
   | "activity_feed"
   | "readings"
+  | "assignments"
   | "webhook"
   | "action_cable"
   | "direct_poll";
@@ -307,6 +308,48 @@ export type BasecampWebhookPayload = {
   };
 };
 
+/**
+ * Raw todo entry from GET /my/assignments.json.
+ * The response is `{ priorities: Todo[], non_priorities: Todo[] }`.
+ * Each todo represents a currently-assigned (incomplete) task.
+ */
+export type BasecampAssignmentTodo = {
+  id: number;
+  content?: string;
+  title?: string;
+  app_url?: string;
+  starts_on?: string | null;
+  due_on?: string | null;
+  completed?: boolean;
+  created_at?: string;
+  updated_at?: string;
+  /** Recordable type name from short_recordable_name(), e.g. "Todo", "Schedule". */
+  type?: string;
+  bucket: {
+    id: number;
+    name: string;
+    app_url?: string;
+  };
+  assignees?: Array<{
+    id: number;
+    name: string;
+    avatar_url?: string;
+  }>;
+  creator?: {
+    id: number;
+    name: string;
+    email_address?: string;
+    avatar_url?: string;
+  };
+  parent?: {
+    id: number;
+    title?: string;
+    app_url?: string;
+  };
+  /** Nested child assignments (recursive). */
+  children?: BasecampAssignmentTodo[];
+};
+
 // ---------------------------------------------------------------------------
 // Raw API entity shapes (for directory / resolver adapters)
 // ---------------------------------------------------------------------------
@@ -418,7 +461,7 @@ export type BasecampChannelConfig = {
   polling?: {
     activityIntervalMs?: number;
     readingsIntervalMs?: number;
-    directPollIntervalMs?: number;
+    assignmentsIntervalMs?: number;
   };
   /** Retry options for bcq API calls. */
   retry?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -393,8 +393,15 @@ export type BasecampChannelConfig = {
   virtualAccounts?: Record<string, BasecampVirtualAccountConfig>;
   /** Agent ID → account ID mapping for multi-persona outbound. */
   personas?: Record<string, string>;
-  /** DM policy for Ping conversations. */
-  dmPolicy?: "open" | "pairing" | "closed";
+  /**
+   * DM policy for Ping conversations.
+   * Uses the SDK's standard vocabulary:
+   *   pairing  — DMs allowed through the pairing flow (default)
+   *   allowlist — DMs allowed only from sender IDs in allowFrom
+   *   open     — DMs allowed from anyone
+   *   disabled — DMs completely blocked
+   */
+  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
   /** Allowed sender person IDs for DM/pairing. */
   allowFrom?: Array<string | number>;
   /** Per-bucket behavior overrides. Key is bucket ID or "*" for wildcard. */

--- a/tests/assignments.test.ts
+++ b/tests/assignments.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  BasecampAssignmentTodo,
+  ResolvedBasecampAccount,
+} from "../src/types.js";
+import { normalizeAssignmentTodo } from "../src/inbound/normalize.js";
+
+// ---------------------------------------------------------------------------
+// Mock bcq
+// ---------------------------------------------------------------------------
+
+vi.mock("../src/bcq.js", () => ({
+  bcqAssignments: vi.fn(),
+}));
+
+import { bcqAssignments } from "../src/bcq.js";
+import { pollAssignments } from "../src/inbound/assignments.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockAccount: ResolvedBasecampAccount = {
+  accountId: "test-acct",
+  enabled: true,
+  personId: "999",
+  displayName: "Clawdito",
+  attachableSgid: "sgid://bc3/Person/999",
+  token: "test-token",
+  tokenSource: "config",
+  config: { personId: "999", bcqAccountId: "2914079" },
+};
+
+function makeTodo(overrides: Partial<BasecampAssignmentTodo> = {}): BasecampAssignmentTodo {
+  return {
+    id: 100,
+    content: "Fix the widget",
+    title: "Fix the widget",
+    app_url: "https://3.basecamp.com/2914079/buckets/500/todos/100",
+    created_at: "2025-01-15T10:00:00Z",
+    updated_at: "2025-01-15T12:00:00Z",
+    bucket: { id: 500, name: "Test Project" },
+    assignees: [{ id: 999, name: "Clawdito" }],
+    creator: { id: 42, name: "Alice", email_address: "alice@example.com" },
+    ...overrides,
+  };
+}
+
+const log = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// normalizeAssignmentTodo
+// ---------------------------------------------------------------------------
+
+describe("normalizeAssignmentTodo", () => {
+  it("produces a BasecampInboundMessage with correct fields", () => {
+    const todo = makeTodo();
+    const msg = normalizeAssignmentTodo(todo, mockAccount);
+
+    expect(msg.channel).toBe("basecamp");
+    expect(msg.accountId).toBe("test-acct");
+    expect(msg.text).toBe("Fix the widget");
+    expect(msg.meta.bucketId).toBe("500");
+    expect(msg.meta.recordingId).toBe("100");
+    expect(msg.meta.recordableType).toBe("Todo");
+    expect(msg.meta.eventKind).toBe("assigned");
+    expect(msg.meta.assignedToAgent).toBe(true);
+    expect(msg.meta.sources).toEqual(["assignments"]);
+    expect(msg.meta.assignees).toEqual(["999"]);
+    expect(msg.peer).toEqual({ kind: "group", id: "recording:100" });
+    expect(msg.parentPeer).toEqual({ kind: "group", id: "bucket:500" });
+    expect(msg.sender.id).toBe("42");
+    expect(msg.sender.name).toBe("Alice");
+    expect(msg.dedupKey).toMatch(/^direct:/);
+  });
+
+  it("uses updated_at for createdAt timestamp", () => {
+    const todo = makeTodo({ updated_at: "2025-02-01T00:00:00Z" });
+    const msg = normalizeAssignmentTodo(todo, mockAccount);
+    expect(msg.createdAt).toBe("2025-02-01T00:00:00Z");
+  });
+
+  it("falls back to created_at when updated_at is absent", () => {
+    const todo = makeTodo({ updated_at: undefined });
+    const msg = normalizeAssignmentTodo(todo, mockAccount);
+    expect(msg.createdAt).toBe("2025-01-15T10:00:00Z");
+  });
+
+  it("handles missing creator gracefully", () => {
+    const todo = makeTodo({ creator: undefined });
+    const msg = normalizeAssignmentTodo(todo, mockAccount);
+    expect(msg.sender.id).toBe("unknown");
+    expect(msg.sender.name).toBe("Unknown");
+  });
+
+  it("includes due_on when present", () => {
+    const todo = makeTodo({ due_on: "2025-03-01" });
+    const msg = normalizeAssignmentTodo(todo, mockAccount);
+    expect(msg.meta.dueOn).toBe("2025-03-01");
+  });
+
+  it("omits due_on when null", () => {
+    const todo = makeTodo({ due_on: null });
+    const msg = normalizeAssignmentTodo(todo, mockAccount);
+    expect(msg.meta.dueOn).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pollAssignments
+// ---------------------------------------------------------------------------
+
+describe("pollAssignments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("bootstraps on first poll — records IDs, emits nothing", async () => {
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: {
+        priorities: [makeTodo({ id: 1 }), makeTodo({ id: 2 })],
+        non_priorities: [makeTodo({ id: 3 })],
+      },
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(),
+      isBootstrap: true,
+      log,
+    });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.knownIds).toEqual(new Set(["1", "2", "3"]));
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("bootstrap: recording 3 existing assignments"),
+    );
+  });
+
+  it("emits events for newly assigned todos", async () => {
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: {
+        priorities: [makeTodo({ id: 1 }), makeTodo({ id: 2 })],
+        non_priorities: [makeTodo({ id: 3 })],
+      },
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(["1"]), // already knew about todo 1
+      isBootstrap: false,
+      log,
+    });
+
+    expect(result.events).toHaveLength(2); // todos 2 and 3 are new
+    expect(result.events[0].meta.recordingId).toBe("2");
+    expect(result.events[1].meta.recordingId).toBe("3");
+    expect(result.knownIds).toEqual(new Set(["1", "2", "3"]));
+  });
+
+  it("emits nothing when all todos are already known", async () => {
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: {
+        priorities: [makeTodo({ id: 1 })],
+        non_priorities: [],
+      },
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(["1"]),
+      isBootstrap: false,
+      log,
+    });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.knownIds).toEqual(new Set(["1"]));
+  });
+
+  it("removes completed/unassigned IDs from knownIds", async () => {
+    // Previously knew about 1, 2, 3 — now only 1 remains
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: {
+        priorities: [makeTodo({ id: 1 })],
+        non_priorities: [],
+      },
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(["1", "2", "3"]),
+      isBootstrap: false,
+      log,
+    });
+
+    expect(result.events).toHaveLength(0); // no new assignments
+    expect(result.knownIds).toEqual(new Set(["1"])); // 2 and 3 dropped
+  });
+
+  it("handles empty response (no assignments)", async () => {
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: { priorities: [], non_priorities: [] },
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(["1"]),
+      isBootstrap: false,
+      log,
+    });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.knownIds).toEqual(new Set());
+  });
+
+  it("handles flat array response shape", async () => {
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: [makeTodo({ id: 10 }), makeTodo({ id: 20 })],
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(),
+      isBootstrap: false,
+      log,
+    });
+
+    expect(result.events).toHaveLength(2);
+    expect(result.knownIds).toEqual(new Set(["10", "20"]));
+  });
+
+  it("continues processing when individual normalization fails", async () => {
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: {
+        priorities: [
+          { id: 1 } as any, // missing bucket — will throw
+          makeTodo({ id: 2 }),
+        ],
+        non_priorities: [],
+      },
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(),
+      isBootstrap: false,
+      log,
+    });
+
+    // One failed, one succeeded
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].meta.recordingId).toBe("2");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("failed to normalize assignment todo id=1"),
+    );
+  });
+
+  it("all events have assignedToAgent=true", async () => {
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: {
+        priorities: [makeTodo({ id: 1 }), makeTodo({ id: 2 })],
+        non_priorities: [],
+      },
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(),
+      isBootstrap: false,
+      log,
+    });
+
+    for (const event of result.events) {
+      expect(event.meta.assignedToAgent).toBe(true);
+      expect(event.meta.eventKind).toBe("assigned");
+    }
+  });
+
+  it("flattens nested children into top-level assignments", async () => {
+    vi.mocked(bcqAssignments).mockResolvedValue({
+      data: {
+        priorities: [
+          makeTodo({
+            id: 10,
+            children: [
+              makeTodo({ id: 11 }),
+              makeTodo({ id: 12, children: [makeTodo({ id: 13 })] }),
+            ],
+          }),
+        ],
+        non_priorities: [],
+      },
+      raw: "",
+    });
+
+    const result = await pollAssignments({
+      account: mockAccount,
+      knownIds: new Set(),
+      isBootstrap: false,
+      log,
+    });
+
+    // Parent (10) + child (11) + child (12) + grandchild (13)
+    expect(result.events).toHaveLength(4);
+    const ids = result.events.map((e) => e.meta.recordingId).sort();
+    expect(ids).toEqual(["10", "11", "12", "13"]);
+    expect(result.knownIds).toEqual(new Set(["10", "11", "12", "13"]));
+  });
+
+  it("uses actual type field from API response", async () => {
+    const todo = makeTodo({ id: 50, type: "ScheduleEntry" });
+    const msg = normalizeAssignmentTodo(todo, mockAccount);
+    expect(msg.meta.recordableType).toBe("Schedule::Entry");
+  });
+
+  it("dedup key includes updated_at to handle reassignment", async () => {
+    const todo1 = makeTodo({ id: 100, updated_at: "2025-01-15T12:00:00Z" });
+    const todo2 = makeTodo({ id: 100, updated_at: "2025-01-16T08:00:00Z" });
+    const msg1 = normalizeAssignmentTodo(todo1, mockAccount);
+    const msg2 = normalizeAssignmentTodo(todo2, mockAccount);
+    // Same recording ID but different updated_at → different dedup keys
+    expect(msg1.dedupKey).not.toBe(msg2.dedupKey);
+  });
+});

--- a/tests/config-adapter.test.ts
+++ b/tests/config-adapter.test.ts
@@ -255,4 +255,14 @@ describe("configSchema.uiHints", () => {
       expect(hint.help, `${key} missing help`).toBeTruthy();
     }
   });
+
+  it("dmPolicy help text matches SDK vocabulary", () => {
+    const hints = basecampChannel.configSchema!.uiHints!;
+    const help = hints["dmPolicy"]?.help ?? "";
+    expect(help).toContain("pairing");
+    expect(help).toContain("allowlist");
+    expect(help).toContain("open");
+    expect(help).toContain("disabled");
+    expect(help).not.toContain("closed");
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -419,7 +419,7 @@ describe("resolvePollingIntervals", () => {
     expect(result).toEqual({
       activityIntervalMs: 120_000,
       readingsIntervalMs: 60_000,
-      directPollIntervalMs: 300_000,
+      assignmentsIntervalMs: 300_000,
     });
   });
 
@@ -428,7 +428,7 @@ describe("resolvePollingIntervals", () => {
     expect(result).toEqual({
       activityIntervalMs: 120_000,
       readingsIntervalMs: 60_000,
-      directPollIntervalMs: 300_000,
+      assignmentsIntervalMs: 300_000,
     });
   });
 
@@ -438,7 +438,7 @@ describe("resolvePollingIntervals", () => {
     );
     expect(result.activityIntervalMs).toBe(30_000);
     expect(result.readingsIntervalMs).toBe(60_000);
-    expect(result.directPollIntervalMs).toBe(300_000);
+    expect(result.assignmentsIntervalMs).toBe(300_000);
   });
 
   it("overrides readingsIntervalMs", () => {
@@ -448,27 +448,20 @@ describe("resolvePollingIntervals", () => {
     expect(result.readingsIntervalMs).toBe(10_000);
   });
 
-  it("overrides directPollIntervalMs", () => {
-    const result = resolvePollingIntervals(
-      cfg({ polling: { directPollIntervalMs: 500_000 } }),
-    );
-    expect(result.directPollIntervalMs).toBe(500_000);
-  });
-
   it("overrides all intervals at once", () => {
     const result = resolvePollingIntervals(
       cfg({
         polling: {
           activityIntervalMs: 1000,
           readingsIntervalMs: 2000,
-          directPollIntervalMs: 3000,
+          assignmentsIntervalMs: 4000,
         },
       }),
     );
     expect(result).toEqual({
       activityIntervalMs: 1000,
       readingsIntervalMs: 2000,
-      directPollIntervalMs: 3000,
+      assignmentsIntervalMs: 4000,
     });
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -478,16 +478,16 @@ describe("resolvePollingIntervals", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveBasecampDmPolicy", () => {
-  it("defaults to 'open' when config is empty", () => {
-    expect(resolveBasecampDmPolicy({} as any)).toBe("open");
+  it("defaults to 'pairing' when config is empty", () => {
+    expect(resolveBasecampDmPolicy({} as any)).toBe("pairing");
   });
 
-  it("defaults to 'open' when dmPolicy is not set", () => {
-    expect(resolveBasecampDmPolicy(cfg({}))).toBe("open");
+  it("defaults to 'pairing' when dmPolicy is not set", () => {
+    expect(resolveBasecampDmPolicy(cfg({}))).toBe("pairing");
   });
 
-  it("returns 'closed' when configured", () => {
-    expect(resolveBasecampDmPolicy(cfg({ dmPolicy: "closed" }))).toBe("closed");
+  it("returns 'disabled' when configured", () => {
+    expect(resolveBasecampDmPolicy(cfg({ dmPolicy: "disabled" }))).toBe("disabled");
   });
 
   it("returns 'pairing' when configured", () => {

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -7,6 +7,7 @@ import type {
 import { getBasecampRuntime } from "../src/runtime.js";
 import { resolvePersonaAccountId } from "../src/config.js";
 import { postReplyToEvent } from "../src/outbound/send.js";
+import { markdownToBasecampHtml } from "../src/outbound/format.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -18,6 +19,8 @@ vi.mock("../src/runtime.js", () => ({
 vi.mock("../src/config.js", () => ({
   resolvePersonaAccountId: vi.fn(),
   resolveBasecampAccount: vi.fn(),
+  resolveBasecampDmPolicy: vi.fn(() => "open"),
+  resolveBasecampAllowFrom: vi.fn(() => []),
 }));
 vi.mock("../src/outbound/send.js", () => ({
   postReplyToEvent: vi.fn(),
@@ -93,6 +96,7 @@ beforeEach(() => {
   mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(
     undefined,
   );
+  vi.mocked(postReplyToEvent).mockResolvedValue({ ok: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -209,5 +213,113 @@ describe("dispatch outbound reliability", () => {
     );
     expect(deliveryLog).toBeUndefined();
     expect(logError).toHaveBeenCalled();
+  });
+
+  it("deliver callback throws when postReplyToEvent returns ok: false", async () => {
+    vi.mocked(postReplyToEvent).mockResolvedValue({
+      ok: false,
+      error: "403 Forbidden",
+    });
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    const deliver = call.dispatcherOptions.deliver;
+
+    await expect(deliver({ text: "Reply" }, {})).rejects.toThrow("403 Forbidden");
+  });
+
+  it("chunks long text and sends multiple postReplyToEvent calls", async () => {
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    const deliver = call.dispatcherOptions.deliver;
+
+    // Generate text with sentence breaks that exceeds the 10K chunk limit.
+    // "Hello world. " is 14 chars × 1000 = 14,000 chars → 2 chunks.
+    const longText = "Hello world. ".repeat(1000);
+    await deliver({ text: longText }, {});
+
+    expect(postReplyToEvent).toHaveBeenCalledTimes(2);
+    expect(markdownToBasecampHtml).toHaveBeenCalledTimes(2);
+
+    // Each call should have the correct routing params
+    for (const postCall of vi.mocked(postReplyToEvent).mock.calls) {
+      expect(postCall[0]).toMatchObject({
+        bucketId: "456",
+        recordingId: "123",
+        accountId: "12345",
+        retries: 2,
+      });
+    }
+  });
+
+  it("sends single postReplyToEvent call for text under chunk limit", async () => {
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    const deliver = call.dispatcherOptions.deliver;
+
+    await deliver({ text: "Short reply" }, {});
+
+    expect(postReplyToEvent).toHaveBeenCalledTimes(1);
+    expect(markdownToBasecampHtml).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops sending chunks when postReplyToEvent fails mid-sequence", async () => {
+    let callCount = 0;
+    vi.mocked(postReplyToEvent).mockImplementation(async () => {
+      callCount++;
+      if (callCount >= 2) return { ok: false, error: "rate limited", channel: "basecamp" };
+      return { ok: true, channel: "basecamp" };
+    });
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    const deliver = call.dispatcherOptions.deliver;
+
+    // ~35K chars with sentence breaks → 3+ chunks
+    const longText = "Hello world. ".repeat(2500);
+    await expect(deliver({ text: longText }, {})).rejects.toThrow("rate limited");
+
+    // First chunk succeeded, second failed, remaining never attempted
+    expect(callCount).toBe(2);
+  });
+
+  it("routes replies using peerId from inbound message", async () => {
+    // Use a message where peerId (parent transcript) differs from recordingId (child line)
+    const childMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      peer: { kind: "group", id: "recording:TRANSCRIPT_42" },
+      meta: {
+        ...mockMsg.meta,
+        recordingId: "LINE_99",
+        recordableType: "Chat::Line",
+      },
+    };
+
+    await dispatchBasecampEvent(childMsg, { account: mockAccount });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    const deliver = call.dispatcherOptions.deliver;
+    await deliver({ text: "Reply to thread" }, {});
+
+    expect(postReplyToEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peerId: "recording:TRANSCRIPT_42",
+        recordingId: "LINE_99",
+      }),
+    );
   });
 });

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -5,7 +5,7 @@ import type {
   ResolvedBasecampAccount,
 } from "../src/types.js";
 import { getBasecampRuntime } from "../src/runtime.js";
-import { resolvePersonaAccountId, resolveBasecampAccount } from "../src/config.js";
+import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom } from "../src/config.js";
 import { postReplyToEvent } from "../src/outbound/send.js";
 import { markdownToBasecampHtml } from "../src/outbound/format.js";
 
@@ -19,6 +19,8 @@ vi.mock("../src/runtime.js", () => ({
 vi.mock("../src/config.js", () => ({
   resolvePersonaAccountId: vi.fn(),
   resolveBasecampAccount: vi.fn(),
+  resolveBasecampDmPolicy: vi.fn(() => "open"),
+  resolveBasecampAllowFrom: vi.fn(() => []),
 }));
 vi.mock("../src/outbound/send.js", () => ({
   postReplyToEvent: vi.fn(),
@@ -86,6 +88,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getBasecampRuntime).mockReturnValue(mockRuntime as any);
   vi.mocked(resolvePersonaAccountId).mockReturnValue(undefined);
+  vi.mocked(postReplyToEvent).mockResolvedValue({ ok: true });
   mockRuntime.channel.routing.resolveAgentRoute.mockReturnValue({
     agentId: "agent-1",
     matchedBy: "peer",
@@ -494,6 +497,104 @@ describe("dispatchBasecampEvent", () => {
     };
 
     const result = await dispatchBasecampEvent(cardMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // DM policy enforcement
+  // -----------------------------------------------------------------------
+
+  it("drops DMs when dmPolicy is 'disabled'", async () => {
+    vi.mocked(resolveBasecampDmPolicy).mockReturnValue("disabled");
+
+    const dmMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      peer: { kind: "dm", id: "ping:789" },
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(dmMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("drops DMs when dmPolicy is 'pairing' and sender not in allowFrom", async () => {
+    vi.mocked(resolveBasecampDmPolicy).mockReturnValue("pairing");
+    vi.mocked(resolveBasecampAllowFrom).mockReturnValue(["111", "222"]);
+
+    const dmMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      peer: { kind: "dm", id: "ping:789" },
+      sender: { id: "777", name: "Stranger" },
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(dmMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("allows DMs when dmPolicy is 'pairing' and sender in allowFrom", async () => {
+    vi.mocked(resolveBasecampDmPolicy).mockReturnValue("pairing");
+    vi.mocked(resolveBasecampAllowFrom).mockReturnValue(["777"]);
+
+    const dmMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      peer: { kind: "dm", id: "ping:789" },
+      sender: { id: "777", name: "Paired User" },
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(dmMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("allows DMs when dmPolicy is 'open'", async () => {
+    vi.mocked(resolveBasecampDmPolicy).mockReturnValue("open");
+
+    const dmMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      peer: { kind: "dm", id: "ping:789" },
+      sender: { id: "777", name: "Anyone" },
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(dmMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("defaults dmPolicy to 'open' when unset (allows DMs)", async () => {
+    // Default mock returns "open"
+    const dmMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      peer: { kind: "dm", id: "ping:789" },
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(dmMsg, { account: mockAccount });
     expect(result).toBe(true);
   });
 });

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -581,8 +581,8 @@ describe("dispatchBasecampEvent", () => {
     expect(result).toBe(true);
   });
 
-  it("defaults dmPolicy to 'open' when unset (allows DMs)", async () => {
-    // Default mock returns "open"
+  it("allows DMs when mock dmPolicy defaults to 'open'", async () => {
+    // Default mock returns "open" — production default is "pairing"
     const dmMsg: BasecampInboundMessage = {
       ...mockMsg,
       peer: { kind: "dm", id: "ping:789" },

--- a/tests/mentions-adapter.test.ts
+++ b/tests/mentions-adapter.test.ts
@@ -28,6 +28,7 @@ describe("mentions.stripPatterns", () => {
       cfg: cfg({
         accounts: { main: { personId: "42", displayName: "Coworker" } },
       }),
+      agentId: "main",
     });
     expect(patterns).toHaveLength(1);
     expect(patterns[0]).toContain("Coworker");
@@ -46,6 +47,23 @@ describe("mentions.stripPatterns", () => {
     });
     expect(patterns).toHaveLength(1);
     expect(patterns[0]).toContain("Bob");
+  });
+
+  it("resolves persona mapping: agentId → accountId → displayName", () => {
+    const patterns = basecampMentionAdapter.stripPatterns!({
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: {
+          "service-acct": { personId: "1", displayName: "Helper Bot" },
+        },
+        personas: {
+          "my-agent": "service-acct",
+        },
+      }),
+      agentId: "my-agent",
+    });
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0]).toContain("Helper Bot");
   });
 
   it("returns empty array when no displayName configured", () => {
@@ -70,6 +88,7 @@ describe("mentions.stripPatterns", () => {
       cfg: cfg({
         accounts: { main: { personId: "42", displayName: "Agent (v2.0)" } },
       }),
+      agentId: "main",
     });
     expect(patterns).toHaveLength(1);
     expect(patterns[0]).toContain("\\(");
@@ -90,6 +109,7 @@ describe("mentions.stripMentions", () => {
       cfg: cfg({
         accounts: { main: { personId: "42", displayName: "Coworker" } },
       }),
+      agentId: "main",
     });
     expect(result).toBe("can you review this?");
   });
@@ -101,6 +121,7 @@ describe("mentions.stripMentions", () => {
       cfg: cfg({
         accounts: { main: { personId: "42", displayName: "Coworker" } },
       }),
+      agentId: "main",
     });
     expect(result).toBe("please help");
   });
@@ -112,6 +133,7 @@ describe("mentions.stripMentions", () => {
       cfg: cfg({
         accounts: { main: { personId: "42", displayName: "Coworker" } },
       }),
+      agentId: "main",
     });
     expect(result).toBe("what do you think?");
   });
@@ -123,6 +145,7 @@ describe("mentions.stripMentions", () => {
       cfg: cfg({
         accounts: { main: { personId: "42", displayName: "Coworker" } },
       }),
+      agentId: "main",
     });
     expect(result).toBe("can you review?");
   });
@@ -165,5 +188,22 @@ describe("mentions.stripMentions", () => {
       }),
     });
     expect(result).toBe("");
+  });
+
+  it("strips persona-mapped display name via agentId → accountId", () => {
+    const result = basecampMentionAdapter.stripMentions!({
+      text: "Helper Bot can you help?",
+      ctx: mockCtx,
+      cfg: cfg({
+        accounts: {
+          "service-acct": { personId: "1", displayName: "Helper Bot" },
+        },
+        personas: {
+          "my-agent": "service-acct",
+        },
+      }),
+      agentId: "my-agent",
+    });
+    expect(result).toBe("can you help?");
   });
 });

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -371,14 +371,14 @@ describe("basecampOnboardingAdapter", () => {
       expect(dp.allowFromKey).toBe("channels.basecamp.allowFrom");
     });
 
-    it("getCurrent returns 'open' by default", () => {
+    it("getCurrent returns 'pairing' by default", () => {
       const dp = basecampOnboardingAdapter.dmPolicy!;
-      expect(dp.getCurrent({} as any)).toBe("open");
+      expect(dp.getCurrent({} as any)).toBe("pairing");
     });
 
     it("getCurrent returns configured policy", () => {
       const dp = basecampOnboardingAdapter.dmPolicy!;
-      expect(dp.getCurrent(cfg({ dmPolicy: "closed" }))).toBe("closed");
+      expect(dp.getCurrent(cfg({ dmPolicy: "disabled" }))).toBe("disabled");
     });
 
     it("setPolicy applies the policy to config", () => {

--- a/tests/outbound.test.ts
+++ b/tests/outbound.test.ts
@@ -9,22 +9,24 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("outbound.resolveTarget", () => {
-  it("accepts recording:<id>", () => {
+  it("rejects recording:<id> — direct send not supported", () => {
     const result = resolveOutboundTarget("recording:123");
-    expect(result.ok).toBe(true);
-    expect(result.to).toBe("recording:123");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("bucket context");
+    expect(result.error).toContain("dispatch bridge");
   });
 
-  it("rejects bucket:<id> with helpful error", () => {
+  it("rejects bucket:<id> with project scope error", () => {
     const result = resolveOutboundTarget("bucket:456");
     expect(result.ok).toBe(false);
     expect(result.error).toContain("project scope");
   });
 
-  it("accepts ping:<id>", () => {
+  it("rejects ping:<id> — direct send not supported", () => {
     const result = resolveOutboundTarget("ping:789");
-    expect(result.ok).toBe(true);
-    expect(result.to).toBe("ping:789");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("bucket context");
+    expect(result.error).toContain("dispatch bridge");
   });
 
   it("rejects empty string", () => {

--- a/tests/project-scoping.test.ts
+++ b/tests/project-scoping.test.ts
@@ -56,7 +56,7 @@ describe("resolveProjectScope", () => {
 // ---------------------------------------------------------------------------
 
 describe("listBasecampAccountIds (with virtual accounts)", () => {
-  it("includes virtual account keys alongside real account keys", () => {
+  it("excludes virtual account keys (they are routing aliases, not workers)", () => {
     const result = listBasecampAccountIds(
       cfg({
         accounts: { primary: { personId: "1" } },
@@ -67,10 +67,10 @@ describe("listBasecampAccountIds (with virtual accounts)", () => {
     );
 
     expect(result).toContain("primary");
-    expect(result).toContain("design-project");
+    expect(result).not.toContain("design-project");
   });
 
-  it("sorts all IDs alphabetically", () => {
+  it("returns only concrete account IDs sorted alphabetically", () => {
     const result = listBasecampAccountIds(
       cfg({
         accounts: { zulu: { personId: "1" } },
@@ -80,7 +80,7 @@ describe("listBasecampAccountIds (with virtual accounts)", () => {
       }),
     );
 
-    expect(result).toEqual(["alpha", "zulu"]);
+    expect(result).toEqual(["zulu"]);
   });
 });
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -45,14 +45,14 @@ describe("security.resolveDmPolicy", () => {
     expect(result.allowFromPath).toBe("channels.basecamp.");
   });
 
-  it("uses account-level path for named account", () => {
+  it("uses channel-level path for named account (dmPolicy is channel-wide)", () => {
     const result = basecampSecurityAdapter.resolveDmPolicy({
       cfg: cfg({}),
       accountId: "work",
       account: stubAccount,
     });
-    expect(result.policyPath).toBe("channels.basecamp.accounts.work.dmPolicy");
-    expect(result.allowFromPath).toBe("channels.basecamp.accounts.work.");
+    expect(result.policyPath).toBe("channels.basecamp.dmPolicy");
+    expect(result.allowFromPath).toBe("channels.basecamp.");
   });
 
   it("returns allowFrom entries", () => {

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -45,7 +45,7 @@ vi.mock("../src/inbound/normalize.js", () => ({
       html: "<p>hi</p>",
       meta: { bucketId: "1", recordingId: String(seq), recordableType: "Chat::Line", eventKind: "line_created", mentions: [], mentionsAgent: false, attachments: [], sources: ["webhook"] },
       dedupKey: `webhook:${seq}`,
-      createdAt: `2025-01-01T00:00:0${seq}Z`,
+      createdAt: `2025-01-01T00:00:${String(seq).padStart(2, "0")}Z`,
     };
   }),
   isSelfMessage: vi.fn(() => false),

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -27,6 +27,7 @@ vi.mock("../src/config.js", () => ({
     tokenSource: "none",
     config: { personId: "1" },
   })),
+  resolveDefaultBasecampAccountId: vi.fn(() => "default"),
   resolveWebhookSecret: vi.fn(() => "test-secret-123"),
   resolveAccountForBucket: vi.fn(() => undefined),
   listBasecampAccountIds: vi.fn(() => ["default"]),
@@ -51,7 +52,7 @@ vi.mock("../src/inbound/normalize.js", () => ({
 }));
 
 import { Semaphore, handleBasecampWebhook } from "../src/inbound/webhooks.js";
-import { resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../src/config.js";
+import { resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../src/config.js";
 import { dispatchBasecampEvent } from "../src/dispatch.js";
 
 beforeEach(() => {
@@ -304,5 +305,39 @@ describe("handleBasecampWebhook — hardening", () => {
 
     expect(res.status).toBe(200);
     expect(dispatchBasecampEvent).toHaveBeenCalled();
+  });
+
+  it("routes to sole non-default account when bucket is unmapped", async () => {
+    // Single account named "work" (not "default") — should resolve via
+    // resolveDefaultBasecampAccountId instead of falling to DEFAULT_ACCOUNT_ID.
+    vi.mocked(resolveAccountForBucket).mockReturnValue(undefined);
+    vi.mocked(listBasecampAccountIds).mockReturnValue(["work"]);
+    vi.mocked(resolveDefaultBasecampAccountId).mockReturnValue("work");
+    const { resolveBasecampAccount } = await import("../src/config.js");
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      accountId: "work",
+      enabled: true,
+      personId: "1",
+      token: "",
+      tokenSource: "none",
+      config: { personId: "1" },
+    });
+
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    expect(res.status).toBe(200);
+    expect(dispatchBasecampEvent).toHaveBeenCalled();
+    expect(resolveBasecampAccount).toHaveBeenCalledWith(
+      expect.anything(),
+      "work",
+    );
   });
 });

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,11 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 vi.mock("../src/dispatch.js", () => ({
   dispatchBasecampEvent: vi.fn().mockResolvedValue(true),
 }));
 vi.mock("../src/runtime.js", () => ({
   getBasecampRuntime: vi.fn(() => ({
-    config: { loadConfig: () => ({ channels: { basecamp: { accounts: { default: { personId: "1" } } } } }) },
+    config: {
+      loadConfig: () => ({
+        channels: {
+          basecamp: {
+            accounts: { default: { personId: "1" } },
+            webhookSecret: "test-secret-123",
+          },
+        },
+      }),
+    },
   })),
 }));
 vi.mock("../src/config.js", () => ({
@@ -17,23 +27,37 @@ vi.mock("../src/config.js", () => ({
     tokenSource: "none",
     config: { personId: "1" },
   })),
+  resolveWebhookSecret: vi.fn(() => "test-secret-123"),
+  resolveAccountForBucket: vi.fn(() => undefined),
+  listBasecampAccountIds: vi.fn(() => ["default"]),
 }));
+let webhookDedupSeq = 0;
 vi.mock("../src/inbound/normalize.js", () => ({
-  normalizeWebhookPayload: vi.fn(() => ({
-    channel: "basecamp",
-    accountId: "default",
-    peer: { kind: "group", id: "recording:1" },
-    sender: { id: "2", name: "Tester" },
-    text: "hi",
-    html: "<p>hi</p>",
-    meta: { bucketId: "1", recordingId: "1", recordableType: "Chat::Line", eventKind: "line_created", mentions: [], mentionsAgent: false, attachments: [], sources: ["webhook"] },
-    dedupKey: "webhook:1",
-    createdAt: "2025-01-01T00:00:00Z",
-  })),
+  normalizeWebhookPayload: vi.fn(() => {
+    const seq = ++webhookDedupSeq;
+    return {
+      channel: "basecamp",
+      accountId: "default",
+      peer: { kind: "group", id: `recording:${seq}` },
+      sender: { id: "2", name: "Tester" },
+      text: "hi",
+      html: "<p>hi</p>",
+      meta: { bucketId: "1", recordingId: String(seq), recordableType: "Chat::Line", eventKind: "line_created", mentions: [], mentionsAgent: false, attachments: [], sources: ["webhook"] },
+      dedupKey: `webhook:${seq}`,
+      createdAt: `2025-01-01T00:00:0${seq}Z`,
+    };
+  }),
   isSelfMessage: vi.fn(() => false),
 }));
 
-import { Semaphore } from "../src/inbound/webhooks.js";
+import { Semaphore, handleBasecampWebhook } from "../src/inbound/webhooks.js";
+import { resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../src/config.js";
+import { dispatchBasecampEvent } from "../src/dispatch.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolveWebhookSecret).mockReturnValue("test-secret-123");
+});
 
 // ---------------------------------------------------------------------------
 // L3: Semaphore concurrency limiter
@@ -144,5 +168,141 @@ describe("Semaphore", () => {
     const sem = new Semaphore(2);
 
     expect(() => sem.release()).toThrow("release() called without matching acquire()");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Webhook handler hardening
+// ---------------------------------------------------------------------------
+
+function mockReq(
+  method: string,
+  url: string,
+  body?: string,
+): IncomingMessage {
+  const { Readable } = require("node:stream");
+  const req = new Readable({
+    read() {
+      if (body) this.push(body);
+      this.push(null);
+    },
+  }) as IncomingMessage;
+  req.method = method;
+  req.url = url;
+  req.headers = { host: "localhost:18789" };
+  return req;
+}
+
+function mockRes(): ServerResponse & { status: number; body: string } {
+  const res = {
+    status: 0,
+    body: "",
+    writeHead(code: number, _headers?: Record<string, string>) {
+      res.status = code;
+    },
+    end(data?: string) {
+      res.body = data ?? "";
+    },
+  } as any;
+  return res;
+}
+
+describe("handleBasecampWebhook — hardening", () => {
+  it("rejects GET requests with 405", async () => {
+    const req = mockReq("GET", "/webhooks/basecamp?token=test-secret-123");
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(405);
+  });
+
+  it("rejects requests when no webhookSecret configured", async () => {
+    vi.mocked(resolveWebhookSecret).mockReturnValue(undefined);
+    const req = mockReq("POST", "/webhooks/basecamp", "{}");
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(403);
+    expect(res.body).toContain("webhookSecret");
+  });
+
+  it("rejects requests with wrong token", async () => {
+    const req = mockReq("POST", "/webhooks/basecamp?token=wrong", "{}");
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(403);
+    expect(res.body).toContain("Invalid webhook token");
+  });
+
+  it("rejects requests with no token", async () => {
+    const req = mockReq("POST", "/webhooks/basecamp", "{}");
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts requests with correct token and valid payload", async () => {
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects invalid JSON body with 400", async () => {
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", "not json");
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects payload missing required fields with 422", async () => {
+    const payload = JSON.stringify({ kind: "comment_created" });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(422);
+  });
+
+  it("drops unmapped bucket in multi-account mode instead of falling to default", async () => {
+    // Multi-account: resolveAccountForBucket returns undefined (unmapped),
+    // listBasecampAccountIds returns multiple accounts → should drop.
+    vi.mocked(resolveAccountForBucket).mockReturnValue(undefined);
+    vi.mocked(listBasecampAccountIds).mockReturnValue(["acct-a", "acct-b"]);
+
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 999, name: "Unknown" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    // Returns 200 (webhook acknowledged) but dispatch is NOT called
+    expect(res.status).toBe(200);
+    expect(dispatchBasecampEvent).not.toHaveBeenCalled();
+  });
+
+  it("allows unmapped bucket in single-account mode (unambiguous)", async () => {
+    vi.mocked(resolveAccountForBucket).mockReturnValue(undefined);
+    vi.mocked(listBasecampAccountIds).mockReturnValue(["default"]);
+
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    expect(res.status).toBe(200);
+    expect(dispatchBasecampEvent).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Config cleanup**: exclude virtual accounts from account listing, fix sectionKey (SDK prepends `channels.` internally)
- **DM policy alignment**: adopt SDK vocabulary (`pairing | allowlist | open | disabled`), enforce policy in dispatch before agent routing
- **Outbound delivery**: chunked dispatch bridge (10K char limit), peer-based reply routing, error propagation from `postReplyToEvent`
- **Mention adapter**: persona-aware display name resolution via `agentId → accountId → displayName` mapping
- **Webhook hardening**: secret verification (403 when unconfigured or wrong token), bucket-to-account routing with multi-account safety (drops unmapped buckets)
- **Assignments poller**: set-diff source polling `GET /my/assignments.json`, ID-set cursors with bootstrap on first poll, recursive child flattening

## Test plan

- [x] All 591 tests pass (32 test files, 11 smoke tests skipped)
- [ ] Manual test: DM policy enforcement blocks Pings when set to `disabled`
- [ ] Manual test: webhook endpoint returns 403 without valid `?token=` query param
- [ ] Manual test: assignments poller bootstraps without flooding agents on first run