### PR TITLE
Channel actions adapter: send campfire lines and comments

### DIFF
--- a/src/adapters/actions.ts
+++ b/src/adapters/actions.ts
@@ -15,7 +15,7 @@ import type {
   ChannelMessageActionContext,
   ChannelToolSend,
 } from "openclaw/plugin-sdk";
-import { jsonResult, readStringParam, readNumberParam } from "openclaw/plugin-sdk";
+import { jsonResult, readStringParam } from "openclaw/plugin-sdk";
 import { postCampfireLine, postComment } from "../outbound/send.js";
 import { markdownToBasecampHtml } from "../outbound/format.js";
 import { resolveBasecampAccount } from "../config.js";
@@ -93,6 +93,21 @@ async function handleSend(ctx: ChannelMessageActionContext) {
   const content = markdownToBasecampHtml(text);
   const account = resolveBasecampAccount(cfg, accountId);
 
+  // Resolve bcq account ID — NOT the OpenClaw account key.
+  // Prefer explicit bcqAccountId config, fall back to accountId only if numeric.
+  const bcqAccountId =
+    account.config.bcqAccountId ??
+    (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
+
+  // Enforce virtual-account bucket scoping: if the account is scoped to a
+  // specific bucket, reject sends targeting a different bucket.
+  if (account.scopedBucketId && bucketId !== String(account.scopedBucketId)) {
+    return jsonResult({
+      ok: false,
+      error: `Account "${account.accountId}" is scoped to bucket ${account.scopedBucketId}, cannot send to bucket ${bucketId}`,
+    });
+  }
+
   if (dryRun) {
     return jsonResult({
       ok: true,
@@ -111,7 +126,7 @@ async function handleSend(ctx: ChannelMessageActionContext) {
       bucketId,
       transcriptId,
       content,
-      accountId: account.config.bcqAccountId ?? account.accountId,
+      accountId: bcqAccountId,
       profile: account.bcqProfile,
     });
     return jsonResult({
@@ -127,7 +142,7 @@ async function handleSend(ctx: ChannelMessageActionContext) {
     bucketId,
     recordingId: recordingId!,
     content,
-    accountId: account.config.bcqAccountId ?? account.accountId,
+    accountId: bcqAccountId,
     profile: account.bcqProfile,
   });
   return jsonResult({

--- a/src/adapters/actions.ts
+++ b/src/adapters/actions.ts
@@ -1,0 +1,139 @@
+/**
+ * Basecamp message actions adapter — agent write operations.
+ *
+ * Implements ChannelMessageActionAdapter for Basecamp. The "send" action
+ * lets agents post campfire lines and comments via bcq. Additional write
+ * actions (createTodo, completeTodo, etc.) will be added in future PRs.
+ *
+ * Supported actions:
+ *   send — Post a campfire line or comment to a Basecamp recording.
+ */
+
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionName,
+  ChannelMessageActionContext,
+  ChannelToolSend,
+} from "openclaw/plugin-sdk";
+import { jsonResult, readStringParam, readNumberParam } from "openclaw/plugin-sdk";
+import { postCampfireLine, postComment } from "../outbound/send.js";
+import { markdownToBasecampHtml } from "../outbound/format.js";
+import { resolveBasecampAccount } from "../config.js";
+
+// ---------------------------------------------------------------------------
+// Supported action set
+// ---------------------------------------------------------------------------
+
+/** Actions this adapter handles. */
+const SUPPORTED_ACTIONS: ChannelMessageActionName[] = ["send"];
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export const basecampActionsAdapter: ChannelMessageActionAdapter = {
+  listActions: () => SUPPORTED_ACTIONS,
+
+  supportsAction: ({ action }) => SUPPORTED_ACTIONS.includes(action),
+
+  supportsButtons: () => false,
+
+  supportsCards: () => false,
+
+  extractToolSend: ({ args }) => {
+    const to = args.to;
+    if (typeof to !== "string" || !to) return null;
+    const accountId = typeof args.accountId === "string" ? args.accountId : undefined;
+    return { to, accountId } satisfies ChannelToolSend;
+  },
+
+  handleAction: async (ctx: ChannelMessageActionContext) => {
+    switch (ctx.action) {
+      case "send":
+        return handleSend(ctx);
+      default:
+        return jsonResult({ ok: false, error: `Unsupported action: ${ctx.action}` });
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// send — post a campfire line or comment
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle the "send" action.
+ *
+ * Required params:
+ *   bucketId     — Basecamp project (bucket) ID
+ *   text         — Message content (markdown, converted to Basecamp HTML)
+ *
+ * Plus one of:
+ *   transcriptId — Chat transcript ID → posts a campfire line
+ *   recordingId  — Recording ID → posts a comment
+ *
+ * When both transcriptId and recordingId are provided, transcriptId wins
+ * (campfire line takes precedence over comment).
+ */
+async function handleSend(ctx: ChannelMessageActionContext) {
+  const { params, cfg, accountId, dryRun } = ctx;
+
+  const bucketId = readStringParam(params, "bucketId", { required: true, label: "Bucket ID" });
+  const text = readStringParam(params, "text", { required: true, label: "Message text" });
+  const transcriptId = readStringParam(params, "transcriptId");
+  const recordingId = readStringParam(params, "recordingId");
+
+  if (!transcriptId && !recordingId) {
+    return jsonResult({
+      ok: false,
+      error: "Either transcriptId (for campfire) or recordingId (for comment) is required",
+    });
+  }
+
+  const content = markdownToBasecampHtml(text);
+  const account = resolveBasecampAccount(cfg, accountId);
+
+  if (dryRun) {
+    return jsonResult({
+      ok: true,
+      dryRun: true,
+      target: transcriptId ? "campfire" : "comment",
+      bucketId,
+      transcriptId,
+      recordingId,
+      contentPreview: content.slice(0, 200),
+    });
+  }
+
+  // Campfire line
+  if (transcriptId) {
+    const result = await postCampfireLine({
+      bucketId,
+      transcriptId,
+      content,
+      accountId: account.config.bcqAccountId ?? account.accountId,
+      profile: account.bcqProfile,
+    });
+    return jsonResult({
+      ok: result.ok,
+      target: "campfire",
+      recordingId: result.recordingId,
+      error: result.error,
+    });
+  }
+
+  // Comment
+  const result = await postComment({
+    bucketId,
+    recordingId: recordingId!,
+    content,
+    accountId: account.config.bcqAccountId ?? account.accountId,
+    profile: account.bcqProfile,
+  });
+  return jsonResult({
+    ok: result.ok,
+    target: "comment",
+    commentId: result.commentId,
+    error: result.error,
+  });
+}

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -33,6 +33,7 @@ import { basecampAgentPromptAdapter } from "./adapters/agent-prompt.js";
 import { basecampSecurityAdapter } from "./adapters/security.js";
 import { resolveOutboundTarget, chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
 import { basecampMentionAdapter } from "./adapters/mentions.js";
+import { basecampActionsAdapter } from "./adapters/actions.js";
 
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   id: "basecamp",
@@ -94,6 +95,8 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
   },
 
   mentions: basecampMentionAdapter,
+
+  actions: basecampActionsAdapter,
 
   reload: { configPrefixes: ["channels.basecamp"] },
 

--- a/tests/actions.test.ts
+++ b/tests/actions.test.ts
@@ -11,13 +11,6 @@ vi.mock("openclaw/plugin-sdk", () => ({
     }
     return typeof val === "string" ? val : undefined;
   },
-  readNumberParam: (params: Record<string, unknown>, key: string, opts?: { required?: boolean; label?: string }) => {
-    const val = params[key];
-    if (opts?.required && val === undefined) {
-      throw new Error(`Missing required parameter: ${opts.label ?? key}`);
-    }
-    return typeof val === "number" ? val : undefined;
-  },
 }));
 
 vi.mock("../src/outbound/send.js", () => ({
@@ -158,7 +151,7 @@ describe("actions.handleAction — send campfire line", () => {
       bucketId: "1",
       transcriptId: "2",
       content: "<p>Hello campfire</p>",
-      accountId: "test-acct",
+      accountId: undefined,
       profile: "test-profile",
     });
     expect(markdownToBasecampHtml).toHaveBeenCalledWith("Hello campfire");
@@ -215,7 +208,7 @@ describe("actions.handleAction — send comment", () => {
       bucketId: "1",
       recordingId: "3",
       content: "<p>A comment</p>",
-      accountId: "test-acct",
+      accountId: undefined,
       profile: "test-profile",
     });
   });

--- a/tests/actions.test.ts
+++ b/tests/actions.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (v: string | undefined | null) => (v ?? "").trim() || "default",
+  jsonResult: (payload: unknown) => ({ ok: true, result: payload }),
+  readStringParam: (params: Record<string, unknown>, key: string, opts?: { required?: boolean; label?: string }) => {
+    const val = params[key];
+    if (opts?.required && (val === undefined || val === null || val === "")) {
+      throw new Error(`Missing required parameter: ${opts.label ?? key}`);
+    }
+    return typeof val === "string" ? val : undefined;
+  },
+  readNumberParam: (params: Record<string, unknown>, key: string, opts?: { required?: boolean; label?: string }) => {
+    const val = params[key];
+    if (opts?.required && val === undefined) {
+      throw new Error(`Missing required parameter: ${opts.label ?? key}`);
+    }
+    return typeof val === "number" ? val : undefined;
+  },
+}));
+
+vi.mock("../src/outbound/send.js", () => ({
+  postCampfireLine: vi.fn(),
+  postComment: vi.fn(),
+}));
+
+vi.mock("../src/outbound/format.js", () => ({
+  markdownToBasecampHtml: vi.fn((t: string) => `<p>${t}</p>`),
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(() => ({
+    accountId: "test-acct",
+    enabled: true,
+    personId: "999",
+    token: "tok-test",
+    tokenSource: "config",
+    bcqProfile: "test-profile",
+    config: { personId: "999", bcqAccountId: undefined },
+  })),
+}));
+
+import { basecampActionsAdapter } from "../src/adapters/actions.js";
+import { postCampfireLine, postComment } from "../src/outbound/send.js";
+import { markdownToBasecampHtml } from "../src/outbound/format.js";
+import { resolveBasecampAccount } from "../src/config.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function actionCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    channel: "basecamp" as const,
+    action: "send" as const,
+    cfg: { channels: { basecamp: { accounts: { "test-acct": { personId: "999" } } } } },
+    params: {},
+    accountId: "test-acct",
+    ...overrides,
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// listActions
+// ---------------------------------------------------------------------------
+
+describe("actions.listActions", () => {
+  it("returns supported action names", () => {
+    const actions = basecampActionsAdapter.listActions!({ cfg: {} as any });
+    expect(actions).toEqual(["send"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// supportsAction
+// ---------------------------------------------------------------------------
+
+describe("actions.supportsAction", () => {
+  it("returns true for send", () => {
+    expect(basecampActionsAdapter.supportsAction!({ action: "send" })).toBe(true);
+  });
+
+  it("returns false for unsupported actions", () => {
+    expect(basecampActionsAdapter.supportsAction!({ action: "react" })).toBe(false);
+    expect(basecampActionsAdapter.supportsAction!({ action: "delete" })).toBe(false);
+    expect(basecampActionsAdapter.supportsAction!({ action: "edit" })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// supportsButtons / supportsCards
+// ---------------------------------------------------------------------------
+
+describe("actions.supportsButtons", () => {
+  it("returns false", () => {
+    expect(basecampActionsAdapter.supportsButtons!({ cfg: {} as any })).toBe(false);
+  });
+});
+
+describe("actions.supportsCards", () => {
+  it("returns false", () => {
+    expect(basecampActionsAdapter.supportsCards!({ cfg: {} as any })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractToolSend
+// ---------------------------------------------------------------------------
+
+describe("actions.extractToolSend", () => {
+  it("extracts to and accountId from args", () => {
+    const result = basecampActionsAdapter.extractToolSend!({
+      args: { to: "recording:123", accountId: "acct-1" },
+    });
+    expect(result).toEqual({ to: "recording:123", accountId: "acct-1" });
+  });
+
+  it("extracts to without accountId", () => {
+    const result = basecampActionsAdapter.extractToolSend!({
+      args: { to: "ping:456" },
+    });
+    expect(result).toEqual({ to: "ping:456", accountId: undefined });
+  });
+
+  it("returns null when to is missing", () => {
+    expect(basecampActionsAdapter.extractToolSend!({ args: {} })).toBeNull();
+  });
+
+  it("returns null when to is empty string", () => {
+    expect(basecampActionsAdapter.extractToolSend!({ args: { to: "" } })).toBeNull();
+  });
+
+  it("returns null when to is not a string", () => {
+    expect(basecampActionsAdapter.extractToolSend!({ args: { to: 123 } })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — send (campfire line)
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — send campfire line", () => {
+  it("posts a campfire line when transcriptId is provided", async () => {
+    vi.mocked(postCampfireLine).mockResolvedValue({ ok: true, recordingId: "42" });
+
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        params: { bucketId: "1", transcriptId: "2", text: "Hello campfire" },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { ok: true, target: "campfire", recordingId: "42", error: undefined },
+    });
+    expect(postCampfireLine).toHaveBeenCalledWith({
+      bucketId: "1",
+      transcriptId: "2",
+      content: "<p>Hello campfire</p>",
+      accountId: "test-acct",
+      profile: "test-profile",
+    });
+    expect(markdownToBasecampHtml).toHaveBeenCalledWith("Hello campfire");
+  });
+
+  it("prefers transcriptId over recordingId when both provided", async () => {
+    vi.mocked(postCampfireLine).mockResolvedValue({ ok: true, recordingId: "50" });
+
+    await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        params: { bucketId: "1", transcriptId: "2", recordingId: "3", text: "Hello" },
+      }),
+    );
+
+    expect(postCampfireLine).toHaveBeenCalled();
+    expect(postComment).not.toHaveBeenCalled();
+  });
+
+  it("returns error from failed campfire post", async () => {
+    vi.mocked(postCampfireLine).mockResolvedValue({ ok: false, error: "bcq timeout" });
+
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        params: { bucketId: "1", transcriptId: "2", text: "Hello" },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { ok: false, target: "campfire", recordingId: undefined, error: "bcq timeout" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — send (comment)
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — send comment", () => {
+  it("posts a comment when recordingId is provided (no transcriptId)", async () => {
+    vi.mocked(postComment).mockResolvedValue({ ok: true, commentId: "77" });
+
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        params: { bucketId: "1", recordingId: "3", text: "A comment" },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { ok: true, target: "comment", commentId: "77", error: undefined },
+    });
+    expect(postComment).toHaveBeenCalledWith({
+      bucketId: "1",
+      recordingId: "3",
+      content: "<p>A comment</p>",
+      accountId: "test-acct",
+      profile: "test-profile",
+    });
+  });
+
+  it("returns error from failed comment post", async () => {
+    vi.mocked(postComment).mockResolvedValue({ ok: false, error: "403 Forbidden" });
+
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        params: { bucketId: "1", recordingId: "3", text: "A comment" },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { ok: false, target: "comment", commentId: undefined, error: "403 Forbidden" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — send validation errors
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — send validation", () => {
+  it("throws when bucketId is missing", async () => {
+    await expect(
+      basecampActionsAdapter.handleAction!(
+        actionCtx({ params: { transcriptId: "2", text: "Hello" } }),
+      ),
+    ).rejects.toThrow(/Bucket ID/);
+  });
+
+  it("throws when text is missing", async () => {
+    await expect(
+      basecampActionsAdapter.handleAction!(
+        actionCtx({ params: { bucketId: "1", transcriptId: "2" } }),
+      ),
+    ).rejects.toThrow(/Message text/);
+  });
+
+  it("returns error when neither transcriptId nor recordingId is provided", async () => {
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({ params: { bucketId: "1", text: "Hello" } }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { ok: false, error: expect.stringContaining("transcriptId") },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — send dry run
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — send dryRun", () => {
+  it("returns preview without posting for campfire", async () => {
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        params: { bucketId: "1", transcriptId: "2", text: "Hello" },
+        dryRun: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: expect.objectContaining({
+        ok: true,
+        dryRun: true,
+        target: "campfire",
+        bucketId: "1",
+        transcriptId: "2",
+      }),
+    });
+    expect(postCampfireLine).not.toHaveBeenCalled();
+    expect(postComment).not.toHaveBeenCalled();
+  });
+
+  it("returns preview without posting for comment", async () => {
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        params: { bucketId: "1", recordingId: "3", text: "Hello" },
+        dryRun: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: expect.objectContaining({
+        ok: true,
+        dryRun: true,
+        target: "comment",
+        bucketId: "1",
+        recordingId: "3",
+      }),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — unsupported action
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — unsupported action", () => {
+  it("returns error for unsupported action", async () => {
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({ action: "react" }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { ok: false, error: "Unsupported action: react" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — account resolution with bcqAccountId
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — bcqAccountId override", () => {
+  it("uses bcqAccountId when set on account config", async () => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      accountId: "test-acct",
+      enabled: true,
+      personId: "999",
+      token: "tok-test",
+      tokenSource: "config",
+      bcqProfile: "test-profile",
+      config: { personId: "999", bcqAccountId: "override-id" },
+    } as any);
+
+    vi.mocked(postCampfireLine).mockResolvedValue({ ok: true, recordingId: "88" });
+
+    await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        params: { bucketId: "1", transcriptId: "2", text: "Hello" },
+      }),
+    );
+
+    expect(postCampfireLine).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "override-id" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `ChannelMessageActionAdapter` with the **send** action, enabling agents to post campfire lines and comments to Basecamp recordings via bcq
- Wires `listActions`, `supportsAction`, `supportsButtons`, `supportsCards`, `extractToolSend`, and `handleAction` — the full adapter interface
- The `send` action accepts `bucketId` + `transcriptId` (campfire line) or `recordingId` (comment), converts markdown to Basecamp HTML, and posts via the existing `postCampfireLine`/`postComment` helpers
- Supports `dryRun` mode for previewing without posting
- Respects `bcqAccountId` override on the resolved account

**New files:**
- `src/adapters/actions.ts` — the adapter implementation
- `tests/actions.test.ts` — 22 tests covering all methods, validation, error paths, dry-run, and bcqAccountId override

**Modified files:**
- `src/channel.ts` — import + wire `actions: basecampActionsAdapter`

## Test plan

- [x] `npx tsc --noEmit` — types clean
- [x] `npx vitest run` — 614 tests passing (22 new), 0 failures
- [ ] Gateway smoke: start gateway, trigger agent that uses `send` action, verify campfire line / comment appears in Basecamp