### PR TITLE
Agent tools: todo operations and conversation history

### DIFF
--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -2,18 +2,22 @@
  * Basecamp agent tools — channel-specific tools agents can invoke.
  *
  * These are registered via the `agentTools` slot on ChannelPlugin and let
- * agents perform Basecamp-specific write operations during response generation.
+ * agents perform Basecamp-specific operations during response generation.
  *
- * Tools:
+ * Write tools:
  *   basecamp_create_todo   — Create a new to-do in a to-do list
  *   basecamp_complete_todo — Mark a to-do as complete
  *   basecamp_reopen_todo   — Mark a to-do as incomplete
+ *
+ * Read tools:
+ *   basecamp_read_history  — Fetch recent messages/comments for a recording
  */
 
 import type { ChannelAgentTool } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
-import { bcqApiPost, bcqPut, bcqDelete } from "../bcq.js";
+import { bcqApiGet, bcqApiPost, bcqPut, bcqDelete } from "../bcq.js";
+import { basecampHtmlToPlainText } from "../outbound/format.js";
 
 // ---------------------------------------------------------------------------
 // Tool parameter schemas
@@ -37,6 +41,20 @@ const CompleteTodoParams = Type.Object({
 const ReopenTodoParams = Type.Object({
   bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
   todoId: Type.String({ description: "To-do recording ID to reopen" }),
+});
+
+const ReadHistoryParams = Type.Object({
+  bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
+  recordingId: Type.String({ description: "Recording ID (chat transcript, todo, card, message, etc.)" }),
+  type: Type.Union([
+    Type.Literal("comments"),
+    Type.Literal("campfire"),
+  ], { description: "Type of history: 'comments' for recording comments, 'campfire' for chat lines" }),
+  limit: Type.Optional(Type.Number({
+    description: "Maximum number of messages to return (default 20, max 50)",
+    minimum: 1,
+    maximum: 50,
+  })),
 });
 
 // ---------------------------------------------------------------------------
@@ -124,6 +142,60 @@ async function executeReopenTodo(
 }
 
 // ---------------------------------------------------------------------------
+// readHistory — fetch recent messages/comments for context
+// ---------------------------------------------------------------------------
+
+/** Raw comment/line shape from the Basecamp API. */
+type BasecampCommentOrLine = {
+  id?: number;
+  content?: string;
+  created_at?: string;
+  creator?: { id?: number; name?: string };
+};
+
+type ReadHistoryInput = Static<typeof ReadHistoryParams>;
+
+const DEFAULT_HISTORY_LIMIT = 20;
+
+async function executeReadHistory(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const { bucketId, recordingId, type, limit } = rawParams as ReadHistoryInput;
+  const effectiveLimit = Math.min(limit ?? DEFAULT_HISTORY_LIMIT, 50);
+
+  const path = type === "campfire"
+    ? `/buckets/${bucketId}/chats/${recordingId}/lines.json`
+    : `/buckets/${bucketId}/recordings/${recordingId}/comments.json`;
+
+  try {
+    const entries = await bcqApiGet<BasecampCommentOrLine[]>(path, bucketId);
+    const items = Array.isArray(entries) ? entries : [];
+
+    // Take the most recent N entries (API returns oldest-first for comments)
+    const recent = items.slice(-effectiveLimit);
+
+    const messages = recent.map((entry) => ({
+      id: entry.id,
+      sender: entry.creator?.name ?? "unknown",
+      senderId: entry.creator?.id,
+      text: basecampHtmlToPlainText(entry.content ?? ""),
+      timestamp: entry.created_at,
+    }));
+
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, count: messages.length, messages }) }],
+      details: { ok: true, count: messages.length },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Exported tools array
 // ---------------------------------------------------------------------------
 
@@ -148,5 +220,15 @@ export const basecampAgentTools: ChannelAgentTool[] = [
     description: "Reopen a completed Basecamp to-do (mark as incomplete). Requires the project (bucket) ID and to-do ID.",
     parameters: ReopenTodoParams,
     execute: executeReopenTodo,
+  },
+  {
+    name: "basecamp_read_history",
+    label: "Read Basecamp History",
+    description:
+      "Fetch recent messages or comments from a Basecamp recording. " +
+      "Use type 'campfire' for chat transcripts or 'comments' for comments on any recording (todo, card, message, etc.). " +
+      "Returns up to 50 entries with sender, text, and timestamp.",
+    parameters: ReadHistoryParams,
+    execute: executeReadHistory,
   },
 ];

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -16,7 +16,7 @@
 import type { ChannelAgentTool } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
-import { bcqApiGet, bcqApiPost, bcqPut, bcqDelete } from "../bcq.js";
+import { bcqApiGet, bcqApiPost, bcqDelete } from "../bcq.js";
 import { basecampHtmlToPlainText } from "../outbound/format.js";
 
 // ---------------------------------------------------------------------------
@@ -80,7 +80,6 @@ async function executeCreateTodo(
     const result = await bcqApiPost<{ id?: number; title?: string }>(
       path,
       JSON.stringify(body),
-      bucketId,
     );
     return {
       content: [{ type: "text" as const, text: JSON.stringify({ ok: true, todoId: result?.id, title: result?.title }) }],
@@ -104,7 +103,7 @@ async function executeCompleteTodo(
   const path = `/buckets/${bucketId}/todos/${todoId}/completion.json`;
 
   try {
-    await bcqApiPost(path, undefined, bucketId);
+    await bcqApiPost(path);
     return {
       content: [{ type: "text" as const, text: JSON.stringify({ ok: true, todoId }) }],
       details: { ok: true, todoId },
@@ -128,7 +127,7 @@ async function executeReopenTodo(
 
   try {
     // DELETE /completion.json re-opens a completed todo
-    await bcqDelete(path, { accountId: bucketId });
+    await bcqDelete(path);
     return {
       content: [{ type: "text" as const, text: JSON.stringify({ ok: true, todoId }) }],
       details: { ok: true, todoId },
@@ -169,7 +168,7 @@ async function executeReadHistory(
     : `/buckets/${bucketId}/recordings/${recordingId}/comments.json`;
 
   try {
-    const entries = await bcqApiGet<BasecampCommentOrLine[]>(path, bucketId);
+    const entries = await bcqApiGet<BasecampCommentOrLine[]>(path);
     const items = Array.isArray(entries) ? entries : [];
 
     // Take the most recent N entries (API returns oldest-first for comments)

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -1,0 +1,152 @@
+/**
+ * Basecamp agent tools — channel-specific tools agents can invoke.
+ *
+ * These are registered via the `agentTools` slot on ChannelPlugin and let
+ * agents perform Basecamp-specific write operations during response generation.
+ *
+ * Tools:
+ *   basecamp_create_todo   — Create a new to-do in a to-do list
+ *   basecamp_complete_todo — Mark a to-do as complete
+ *   basecamp_reopen_todo   — Mark a to-do as incomplete
+ */
+
+import type { ChannelAgentTool } from "openclaw/plugin-sdk";
+import { Type } from "@sinclair/typebox";
+import type { Static } from "@sinclair/typebox";
+import { bcqApiPost, bcqPut, bcqDelete } from "../bcq.js";
+
+// ---------------------------------------------------------------------------
+// Tool parameter schemas
+// ---------------------------------------------------------------------------
+
+const CreateTodoParams = Type.Object({
+  bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
+  todolistId: Type.String({ description: "To-do list ID to add the to-do to" }),
+  content: Type.String({ description: "To-do title/content text" }),
+  description: Type.Optional(Type.String({ description: "Rich text description (Basecamp HTML)" })),
+  assigneeIds: Type.Optional(Type.Array(Type.Number(), { description: "Person IDs to assign" })),
+  dueOn: Type.Optional(Type.String({ description: "Due date in YYYY-MM-DD format" })),
+  startsOn: Type.Optional(Type.String({ description: "Start date in YYYY-MM-DD format" })),
+});
+
+const CompleteTodoParams = Type.Object({
+  bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
+  todoId: Type.String({ description: "To-do recording ID to complete" }),
+});
+
+const ReopenTodoParams = Type.Object({
+  bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
+  todoId: Type.String({ description: "To-do recording ID to reopen" }),
+});
+
+// ---------------------------------------------------------------------------
+// Tool implementations
+// ---------------------------------------------------------------------------
+
+type CreateTodoInput = Static<typeof CreateTodoParams>;
+
+async function executeCreateTodo(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const params = rawParams as CreateTodoInput;
+  const { bucketId, todolistId, content, description, assigneeIds, dueOn, startsOn } = params;
+  const path = `/buckets/${bucketId}/todolists/${todolistId}/todos.json`;
+  const body: Record<string, unknown> = { content };
+  if (description) body.description = description;
+  if (assigneeIds?.length) body.assignee_ids = assigneeIds;
+  if (dueOn) body.due_on = dueOn;
+  if (startsOn) body.starts_on = startsOn;
+
+  try {
+    const result = await bcqApiPost<{ id?: number; title?: string }>(
+      path,
+      JSON.stringify(body),
+      bucketId,
+    );
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, todoId: result?.id, title: result?.title }) }],
+      details: { ok: true, todoId: result?.id },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+type CompleteTodoInput = Static<typeof CompleteTodoParams>;
+
+async function executeCompleteTodo(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const { bucketId, todoId } = rawParams as CompleteTodoInput;
+  const path = `/buckets/${bucketId}/todos/${todoId}/completion.json`;
+
+  try {
+    await bcqApiPost(path, undefined, bucketId);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, todoId }) }],
+      details: { ok: true, todoId },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+type ReopenTodoInput = Static<typeof ReopenTodoParams>;
+
+async function executeReopenTodo(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const { bucketId, todoId } = rawParams as ReopenTodoInput;
+  const path = `/buckets/${bucketId}/todos/${todoId}/completion.json`;
+
+  try {
+    // DELETE /completion.json re-opens a completed todo
+    await bcqDelete(path, { accountId: bucketId });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, todoId }) }],
+      details: { ok: true, todoId },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported tools array
+// ---------------------------------------------------------------------------
+
+export const basecampAgentTools: ChannelAgentTool[] = [
+  {
+    name: "basecamp_create_todo",
+    label: "Create Basecamp To-Do",
+    description: "Create a new to-do item in a Basecamp to-do list. Requires the project (bucket) ID and to-do list ID.",
+    parameters: CreateTodoParams,
+    execute: executeCreateTodo,
+  },
+  {
+    name: "basecamp_complete_todo",
+    label: "Complete Basecamp To-Do",
+    description: "Mark a Basecamp to-do as complete. Requires the project (bucket) ID and to-do ID.",
+    parameters: CompleteTodoParams,
+    execute: executeCompleteTodo,
+  },
+  {
+    name: "basecamp_reopen_todo",
+    label: "Reopen Basecamp To-Do",
+    description: "Reopen a completed Basecamp to-do (mark as incomplete). Requires the project (bucket) ID and to-do ID.",
+    parameters: ReopenTodoParams,
+    execute: executeReopenTodo,
+  },
+];

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -34,6 +34,7 @@ import { basecampSecurityAdapter } from "./adapters/security.js";
 import { resolveOutboundTarget, chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
 import { basecampMentionAdapter } from "./adapters/mentions.js";
 import { basecampActionsAdapter } from "./adapters/actions.js";
+import { basecampAgentTools } from "./adapters/agent-tools.js";
 
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   id: "basecamp",
@@ -97,6 +98,8 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
   mentions: basecampMentionAdapter,
 
   actions: basecampActionsAdapter,
+
+  agentTools: basecampAgentTools,
 
   reload: { configPrefixes: ["channels.basecamp"] },
 

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../src/bcq.js", () => ({
+  bcqApiGet: vi.fn(),
   bcqApiPost: vi.fn(),
   bcqPut: vi.fn(),
   bcqDelete: vi.fn(),
 }));
 
+vi.mock("../src/outbound/format.js", () => ({
+  basecampHtmlToPlainText: vi.fn((html: string) => html.replace(/<[^>]+>/g, "")),
+}));
+
 import { basecampAgentTools } from "../src/adapters/agent-tools.js";
-import { bcqApiPost, bcqDelete } from "../src/bcq.js";
+import { bcqApiGet, bcqApiPost, bcqDelete } from "../src/bcq.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -24,8 +29,8 @@ function findTool(name: string) {
 // ---------------------------------------------------------------------------
 
 describe("basecampAgentTools", () => {
-  it("exports three tools", () => {
-    expect(basecampAgentTools).toHaveLength(3);
+  it("exports four tools", () => {
+    expect(basecampAgentTools).toHaveLength(4);
   });
 
   it("has correct tool names", () => {
@@ -34,6 +39,7 @@ describe("basecampAgentTools", () => {
       "basecamp_create_todo",
       "basecamp_complete_todo",
       "basecamp_reopen_todo",
+      "basecamp_read_history",
     ]);
   });
 
@@ -206,5 +212,181 @@ describe("basecamp_reopen_todo", () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("404 Not Found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_read_history
+// ---------------------------------------------------------------------------
+
+describe("basecamp_read_history", () => {
+  const tool = findTool("basecamp_read_history");
+
+  it("fetches campfire lines", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([
+      { id: 1, content: "<p>Hello</p>", created_at: "2025-01-01T10:00:00Z", creator: { id: 10, name: "Alice" } },
+      { id: 2, content: "<p>World</p>", created_at: "2025-01-01T10:01:00Z", creator: { id: 20, name: "Bob" } },
+    ]);
+
+    const result = await tool.execute("call-9", {
+      bucketId: "100",
+      recordingId: "200",
+      type: "campfire",
+    });
+
+    expect(bcqApiGet).toHaveBeenCalledWith(
+      "/buckets/100/chats/200/lines.json",
+      "100",
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(2);
+    expect(parsed.messages).toEqual([
+      { id: 1, sender: "Alice", senderId: 10, text: "Hello", timestamp: "2025-01-01T10:00:00Z" },
+      { id: 2, sender: "Bob", senderId: 20, text: "World", timestamp: "2025-01-01T10:01:00Z" },
+    ]);
+  });
+
+  it("fetches recording comments", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([
+      { id: 5, content: "<strong>Done</strong>", created_at: "2025-01-01T12:00:00Z", creator: { id: 30, name: "Charlie" } },
+    ]);
+
+    const result = await tool.execute("call-10", {
+      bucketId: "100",
+      recordingId: "300",
+      type: "comments",
+    });
+
+    expect(bcqApiGet).toHaveBeenCalledWith(
+      "/buckets/100/recordings/300/comments.json",
+      "100",
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(1);
+    expect(parsed.messages[0].sender).toBe("Charlie");
+    expect(parsed.messages[0].text).toBe("Done");
+  });
+
+  it("respects limit parameter", async () => {
+    const entries = Array.from({ length: 30 }, (_, i) => ({
+      id: i,
+      content: `<p>Message ${i}</p>`,
+      created_at: `2025-01-01T10:${String(i).padStart(2, "0")}:00Z`,
+      creator: { id: 1, name: "Alice" },
+    }));
+    vi.mocked(bcqApiGet).mockResolvedValue(entries);
+
+    const result = await tool.execute("call-11", {
+      bucketId: "100",
+      recordingId: "200",
+      type: "campfire",
+      limit: 5,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.count).toBe(5);
+    // Should return the last 5 entries (most recent)
+    expect(parsed.messages[0].id).toBe(25);
+    expect(parsed.messages[4].id).toBe(29);
+  });
+
+  it("caps limit at 50", async () => {
+    const entries = Array.from({ length: 60 }, (_, i) => ({
+      id: i,
+      content: `<p>M${i}</p>`,
+      created_at: "2025-01-01T10:00:00Z",
+      creator: { id: 1, name: "A" },
+    }));
+    vi.mocked(bcqApiGet).mockResolvedValue(entries);
+
+    const result = await tool.execute("call-12", {
+      bucketId: "100",
+      recordingId: "200",
+      type: "campfire",
+      limit: 100,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.count).toBe(50);
+  });
+
+  it("defaults to 20 entries when limit not specified", async () => {
+    const entries = Array.from({ length: 30 }, (_, i) => ({
+      id: i,
+      content: `<p>M${i}</p>`,
+      created_at: "2025-01-01T10:00:00Z",
+      creator: { id: 1, name: "A" },
+    }));
+    vi.mocked(bcqApiGet).mockResolvedValue(entries);
+
+    const result = await tool.execute("call-13", {
+      bucketId: "100",
+      recordingId: "200",
+      type: "campfire",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.count).toBe(20);
+  });
+
+  it("handles empty results", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([]);
+
+    const result = await tool.execute("call-14", {
+      bucketId: "100",
+      recordingId: "200",
+      type: "comments",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(0);
+    expect(parsed.messages).toEqual([]);
+  });
+
+  it("handles non-array response gracefully", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue(null);
+
+    const result = await tool.execute("call-15", {
+      bucketId: "100",
+      recordingId: "200",
+      type: "campfire",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(0);
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqApiGet).mockRejectedValue(new Error("503 Service Unavailable"));
+
+    const result = await tool.execute("call-16", {
+      bucketId: "100",
+      recordingId: "200",
+      type: "campfire",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("503 Service Unavailable");
+  });
+
+  it("handles entries with missing creator", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([
+      { id: 1, content: "<p>No creator</p>", created_at: "2025-01-01T10:00:00Z" },
+    ]);
+
+    const result = await tool.execute("call-17", {
+      bucketId: "100",
+      recordingId: "200",
+      type: "comments",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.messages[0].sender).toBe("unknown");
+    expect(parsed.messages[0].senderId).toBeUndefined();
   });
 });

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/bcq.js", () => ({
+  bcqApiPost: vi.fn(),
+  bcqPut: vi.fn(),
+  bcqDelete: vi.fn(),
+}));
+
+import { basecampAgentTools } from "../src/adapters/agent-tools.js";
+import { bcqApiPost, bcqDelete } from "../src/bcq.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function findTool(name: string) {
+  const tool = basecampAgentTools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool ${name} not found`);
+  return tool;
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration
+// ---------------------------------------------------------------------------
+
+describe("basecampAgentTools", () => {
+  it("exports three tools", () => {
+    expect(basecampAgentTools).toHaveLength(3);
+  });
+
+  it("has correct tool names", () => {
+    const names = basecampAgentTools.map((t) => t.name);
+    expect(names).toEqual([
+      "basecamp_create_todo",
+      "basecamp_complete_todo",
+      "basecamp_reopen_todo",
+    ]);
+  });
+
+  it("all tools have required fields", () => {
+    for (const tool of basecampAgentTools) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.label).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.parameters).toBeTruthy();
+      expect(tool.execute).toBeTypeOf("function");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_create_todo
+// ---------------------------------------------------------------------------
+
+describe("basecamp_create_todo", () => {
+  const tool = findTool("basecamp_create_todo");
+
+  it("creates a todo with minimal params", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 42, title: "Buy milk" });
+
+    const result = await tool.execute("call-1", {
+      bucketId: "100",
+      todolistId: "200",
+      content: "Buy milk",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/todolists/200/todos.json",
+      JSON.stringify({ content: "Buy milk" }),
+      "100",
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, todoId: 42, title: "Buy milk" });
+    expect(result.details).toEqual({ ok: true, todoId: 42 });
+  });
+
+  it("creates a todo with all optional params", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 43 });
+
+    await tool.execute("call-2", {
+      bucketId: "100",
+      todolistId: "200",
+      content: "Review PR",
+      description: "<p>Check edge cases</p>",
+      assigneeIds: [10, 20],
+      dueOn: "2025-03-01",
+      startsOn: "2025-02-15",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/todolists/200/todos.json",
+      JSON.stringify({
+        content: "Review PR",
+        description: "<p>Check edge cases</p>",
+        assignee_ids: [10, 20],
+        due_on: "2025-03-01",
+        starts_on: "2025-02-15",
+      }),
+      "100",
+    );
+  });
+
+  it("omits optional fields when not provided", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 44 });
+
+    await tool.execute("call-3", {
+      bucketId: "100",
+      todolistId: "200",
+      content: "Simple todo",
+    });
+
+    const bodyArg = vi.mocked(bcqApiPost).mock.calls[0]![1];
+    const body = JSON.parse(bodyArg!);
+    expect(body).toEqual({ content: "Simple todo" });
+    expect(body).not.toHaveProperty("description");
+    expect(body).not.toHaveProperty("assignee_ids");
+    expect(body).not.toHaveProperty("due_on");
+    expect(body).not.toHaveProperty("starts_on");
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqApiPost).mockRejectedValue(new Error("403 Forbidden"));
+
+    const result = await tool.execute("call-4", {
+      bucketId: "100",
+      todolistId: "200",
+      content: "Fail",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("403 Forbidden");
+    expect(result.details).toEqual({ ok: false, error: expect.stringContaining("403 Forbidden") });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_complete_todo
+// ---------------------------------------------------------------------------
+
+describe("basecamp_complete_todo", () => {
+  const tool = findTool("basecamp_complete_todo");
+
+  it("posts to completion endpoint", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue(undefined);
+
+    const result = await tool.execute("call-5", {
+      bucketId: "100",
+      todoId: "300",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/todos/300/completion.json",
+      undefined,
+      "100",
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, todoId: "300" });
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqApiPost).mockRejectedValue(new Error("500 Server Error"));
+
+    const result = await tool.execute("call-6", {
+      bucketId: "100",
+      todoId: "300",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("500 Server Error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_reopen_todo
+// ---------------------------------------------------------------------------
+
+describe("basecamp_reopen_todo", () => {
+  const tool = findTool("basecamp_reopen_todo");
+
+  it("deletes completion endpoint to reopen", async () => {
+    vi.mocked(bcqDelete).mockResolvedValue({ data: undefined, raw: "" });
+
+    const result = await tool.execute("call-7", {
+      bucketId: "100",
+      todoId: "300",
+    });
+
+    expect(bcqDelete).toHaveBeenCalledWith(
+      "/buckets/100/todos/300/completion.json",
+      { accountId: "100" },
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, todoId: "300" });
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqDelete).mockRejectedValue(new Error("404 Not Found"));
+
+    const result = await tool.execute("call-8", {
+      bucketId: "100",
+      todoId: "300",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("404 Not Found");
+  });
+});

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../src/bcq.js", () => ({
   bcqApiGet: vi.fn(),
   bcqApiPost: vi.fn(),
-  bcqPut: vi.fn(),
   bcqDelete: vi.fn(),
 }));
 
@@ -73,7 +72,6 @@ describe("basecamp_create_todo", () => {
     expect(bcqApiPost).toHaveBeenCalledWith(
       "/buckets/100/todolists/200/todos.json",
       JSON.stringify({ content: "Buy milk" }),
-      "100",
     );
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, todoId: 42, title: "Buy milk" });
@@ -102,7 +100,6 @@ describe("basecamp_create_todo", () => {
         due_on: "2025-03-01",
         starts_on: "2025-02-15",
       }),
-      "100",
     );
   });
 
@@ -157,8 +154,6 @@ describe("basecamp_complete_todo", () => {
 
     expect(bcqApiPost).toHaveBeenCalledWith(
       "/buckets/100/todos/300/completion.json",
-      undefined,
-      "100",
     );
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, todoId: "300" });
@@ -195,7 +190,6 @@ describe("basecamp_reopen_todo", () => {
 
     expect(bcqDelete).toHaveBeenCalledWith(
       "/buckets/100/todos/300/completion.json",
-      { accountId: "100" },
     );
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, todoId: "300" });
@@ -236,7 +230,6 @@ describe("basecamp_read_history", () => {
 
     expect(bcqApiGet).toHaveBeenCalledWith(
       "/buckets/100/chats/200/lines.json",
-      "100",
     );
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
@@ -260,7 +253,6 @@ describe("basecamp_read_history", () => {
 
     expect(bcqApiGet).toHaveBeenCalledWith(
       "/buckets/100/recordings/300/comments.json",
-      "100",
     );
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);


### PR DESCRIPTION
## Summary

Stacked on #14 (channel actions adapter).

Adds four `ChannelAgentTool` implementations to the `agentTools` slot, enabling agents to perform Basecamp-specific operations during response generation:

**Write tools:**
- `basecamp_create_todo` — Create a to-do in a to-do list (with optional assignees, dates, description)
- `basecamp_complete_todo` — Mark a to-do as complete
- `basecamp_reopen_todo` — Reopen a completed to-do

**Read tools:**
- `basecamp_read_history` — Fetch recent campfire lines or recording comments for conversation context (configurable limit, default 20, max 50)

All tools use TypeBox schemas for parameter validation and return structured JSON results with error handling.

**New files:**
- `src/adapters/agent-tools.ts` — tool schemas, implementations, and exports
- `tests/agent-tools.test.ts` — 20 tests covering all tools

**Modified files:**
- `src/channel.ts` — import + wire `agentTools: basecampAgentTools`

## Test plan

- [x] `npx tsc --noEmit` — types clean
- [x] `npx vitest run` — 645 tests passing (20 new), 0 failures
- [ ] Gateway smoke: start gateway, verify tools appear in agent tool list
- [ ] Manually invoke each tool via agent interaction and verify Basecamp state changes