### PR TITLE
Dedup persistence: JSON file-backed store for restart safety

### DIFF
--- a/src/inbound/dedup-store.ts
+++ b/src/inbound/dedup-store.ts
@@ -9,8 +9,8 @@
  *   { primary: { [key]: { seenAt, source } }, secondary: { [key]: primaryKey } }
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { readFileSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 export interface DedupStoreEntry {
   seenAt: number;
@@ -43,12 +43,12 @@ export class JsonFileDedupStore implements DedupStore {
     try {
       const raw = readFileSync(this.filePath, "utf-8");
       const data = JSON.parse(raw);
-      // Validate shape
+      // Validate shape — guard against null (typeof null === "object") and arrays
       if (
         data &&
         typeof data === "object" &&
-        typeof data.primary === "object" &&
-        typeof data.secondary === "object"
+        data.primary !== null && typeof data.primary === "object" && !Array.isArray(data.primary) &&
+        data.secondary !== null && typeof data.secondary === "object" && !Array.isArray(data.secondary)
       ) {
         return data as DedupSnapshot;
       }
@@ -60,8 +60,13 @@ export class JsonFileDedupStore implements DedupStore {
 
   save(snapshot: DedupSnapshot): void {
     try {
-      mkdirSync(dirname(this.filePath), { recursive: true });
-      writeFileSync(this.filePath, JSON.stringify(snapshot), "utf-8");
+      const dir = dirname(this.filePath);
+      mkdirSync(dir, { recursive: true });
+      // Atomic write: write to temp file then rename into place.
+      // Prevents partial writes from corrupting the store on crash.
+      const tmp = join(dir, `.dedup-${Date.now()}.tmp`);
+      writeFileSync(tmp, JSON.stringify(snapshot), "utf-8");
+      renameSync(tmp, this.filePath);
     } catch {
       // Best-effort persistence — if the write fails (e.g., read-only fs),
       // the in-memory state is still authoritative.

--- a/src/inbound/dedup-store.ts
+++ b/src/inbound/dedup-store.ts
@@ -1,0 +1,70 @@
+/**
+ * Persistent dedup store backed by a JSON file.
+ *
+ * Provides restart-safe event deduplication by flushing the in-memory
+ * state to disk periodically and on shutdown. Loads existing state on
+ * construction so events processed before a restart are still recognized.
+ *
+ * The file format is a JSON object with primary and secondary maps:
+ *   { primary: { [key]: { seenAt, source } }, secondary: { [key]: primaryKey } }
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface DedupStoreEntry {
+  seenAt: number;
+  source: string;
+}
+
+export interface DedupSnapshot {
+  primary: Record<string, DedupStoreEntry>;
+  secondary: Record<string, string>;
+}
+
+export interface DedupStore {
+  /** Load persisted state. Returns empty maps if no state exists. */
+  load(): DedupSnapshot;
+  /** Save current state to persistent storage. */
+  save(snapshot: DedupSnapshot): void;
+}
+
+/**
+ * JSON file-backed dedup store.
+ *
+ * Reads/writes a single JSON file containing the full dedup state.
+ * Not suitable for high-concurrency scenarios, but adequate for a
+ * single-process gateway with periodic flush.
+ */
+export class JsonFileDedupStore implements DedupStore {
+  constructor(private readonly filePath: string) {}
+
+  load(): DedupSnapshot {
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw);
+      // Validate shape
+      if (
+        data &&
+        typeof data === "object" &&
+        typeof data.primary === "object" &&
+        typeof data.secondary === "object"
+      ) {
+        return data as DedupSnapshot;
+      }
+    } catch {
+      // File doesn't exist, is empty, or is malformed — start fresh
+    }
+    return { primary: {}, secondary: {} };
+  }
+
+  save(snapshot: DedupSnapshot): void {
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true });
+      writeFileSync(this.filePath, JSON.stringify(snapshot), "utf-8");
+    } catch {
+      // Best-effort persistence — if the write fails (e.g., read-only fs),
+      // the in-memory state is still authoritative.
+    }
+  }
+}

--- a/src/inbound/dedup.ts
+++ b/src/inbound/dedup.ts
@@ -5,8 +5,12 @@
  * secondary keys for cross-source collapse (e.g., same recording+action+ts
  * from both activity feed and readings).
  *
- * Phase 1 uses in-memory Map. Sqlite persistence can be added later if needed.
+ * Supports an optional DedupStore backend for restart-safe persistence.
+ * When a store is provided, state is loaded on construction and flushed
+ * periodically (every pruneInterval insertions) and on explicit flush().
  */
+
+import type { DedupStore, DedupStoreEntry } from "./dedup-store.js";
 
 /** Default TTL: 24 hours in milliseconds. */
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
@@ -26,6 +30,8 @@ export interface DedupOptions {
   ttlMs?: number;
   /** How often to prune expired entries (every N insertions). Default: 1000. */
   pruneInterval?: number;
+  /** Optional persistent store for restart-safe dedup. */
+  store?: DedupStore;
 }
 
 export type DedupSource = "activity" | "reading" | "webhook" | "direct";
@@ -35,11 +41,30 @@ export class EventDedup {
   private readonly secondary = new Map<string, string>(); // secondary → primary key
   private readonly ttlMs: number;
   private readonly pruneInterval: number;
+  private readonly store?: DedupStore;
   private insertionCount = 0;
 
   constructor(opts: DedupOptions = {}) {
     this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
     this.pruneInterval = opts.pruneInterval ?? DEFAULT_PRUNE_INTERVAL;
+    this.store = opts.store;
+
+    // Hydrate from persistent store if available
+    if (this.store) {
+      const snapshot = this.store.load();
+      const now = Date.now();
+      for (const [key, entry] of Object.entries(snapshot.primary)) {
+        // Skip expired entries during load
+        if (now - entry.seenAt < this.ttlMs) {
+          this.primary.set(key, entry);
+        }
+      }
+      for (const [secKey, priKey] of Object.entries(snapshot.secondary)) {
+        if (this.primary.has(priKey)) {
+          this.secondary.set(secKey, priKey);
+        }
+      }
+    }
   }
 
   /**
@@ -116,6 +141,7 @@ export class EventDedup {
     this.insertionCount++;
     if (this.insertionCount % this.pruneInterval === 0) {
       this.prune();
+      this.flush();
     }
   }
 
@@ -139,6 +165,23 @@ export class EventDedup {
         this.secondary.delete(secKey);
       }
     }
+  }
+
+  /**
+   * Flush current state to the persistent store (if configured).
+   * Call this on graceful shutdown to ensure all recent events are persisted.
+   */
+  flush(): void {
+    if (!this.store) return;
+    const primary: Record<string, DedupStoreEntry> = {};
+    for (const [key, entry] of this.primary) {
+      primary[key] = entry;
+    }
+    const secondary: Record<string, string> = {};
+    for (const [key, value] of this.secondary) {
+      secondary[key] = value;
+    }
+    this.store.save({ primary, secondary });
   }
 
   /** Number of entries currently tracked. */

--- a/src/inbound/dedup.ts
+++ b/src/inbound/dedup.ts
@@ -173,15 +173,19 @@ export class EventDedup {
    */
   flush(): void {
     if (!this.store) return;
-    const primary: Record<string, DedupStoreEntry> = {};
-    for (const [key, entry] of this.primary) {
-      primary[key] = entry;
+    try {
+      const primary: Record<string, DedupStoreEntry> = {};
+      for (const [key, entry] of this.primary) {
+        primary[key] = entry;
+      }
+      const secondary: Record<string, string> = {};
+      for (const [key, value] of this.secondary) {
+        secondary[key] = value;
+      }
+      this.store.save({ primary, secondary });
+    } catch {
+      // Best-effort — in-memory state is authoritative.
     }
-    const secondary: Record<string, string> = {};
-    for (const [key, value] of this.secondary) {
-      secondary[key] = value;
-    }
-    this.store.save({ primary, secondary });
   }
 
   /** Number of entries currently tracked. */

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -20,6 +20,7 @@
 import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../types.js";
 import { resolvePollingIntervals } from "../config.js";
 import { EventDedup } from "./dedup.js";
+import { JsonFileDedupStore } from "./dedup-store.js";
 import { CursorStore } from "./cursors.js";
 import { pollActivityFeed } from "./activity.js";
 import { pollReadings } from "./readings.js";
@@ -88,12 +89,12 @@ export async function startCompositePoller(
   const readingsIntervalMs = intervals.readingsIntervalMs;
   const assignmentsIntervalMs = intervals.assignmentsIntervalMs;
 
-  const dedup = new EventDedup();
   const stateDir = opts.stateDir ?? "/tmp/openclaw-basecamp-state";
 
   // Validate state directory
   const { mkdir, access } = await import("node:fs/promises");
   const { constants } = await import("node:fs");
+  const { join } = await import("node:path");
   try {
     await mkdir(stateDir, { recursive: true });
     await access(stateDir, constants.W_OK);
@@ -102,6 +103,11 @@ export async function startCompositePoller(
     log?.error?.(`[${account.accountId}] state directory not writable: ${stateDir}: ${String(err)}`);
     throw err;
   }
+
+  // Persistent dedup store — survives gateway restarts
+  const dedupStore = new JsonFileDedupStore(join(stateDir, `dedup-${account.accountId}.json`));
+  const dedup = new EventDedup({ store: dedupStore });
+  log?.info?.(`[${account.accountId}] dedup store: ${dedup.size} entries loaded`);
 
   const cursors = new CursorStore(stateDir, account.accountId);
 
@@ -313,9 +319,10 @@ export async function startCompositePoller(
   }
 
   try {
+    dedup.flush();
     await saveCursorsWithRetry(cursors, account.accountId, log);
-    log?.info?.("[" + account.accountId + "] composite poller stopped, cursors saved");
+    log?.info?.("[" + account.accountId + "] composite poller stopped, cursors and dedup state saved");
   } catch (err) {
-    log?.warn?.("[" + account.accountId + "] failed to save final cursors: " + String(err));
+    log?.warn?.("[" + account.accountId + "] failed to save final state: " + String(err));
   }
 }

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -321,7 +321,7 @@ export async function startCompositePoller(
   try {
     dedup.flush();
     await saveCursorsWithRetry(cursors, account.accountId, log);
-    log?.info?.("[" + account.accountId + "] composite poller stopped, cursors and dedup state saved");
+    log?.info?.("[" + account.accountId + "] composite poller stopped, cursors saved, dedup flush attempted");
   } catch (err) {
     log?.warn?.("[" + account.accountId + "] failed to save final state: " + String(err));
   }

--- a/tests/dedup-store.test.ts
+++ b/tests/dedup-store.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { EventDedup } from "../src/inbound/dedup.js";
 import type { DedupStore, DedupSnapshot } from "../src/inbound/dedup-store.js";
 import { JsonFileDedupStore } from "../src/inbound/dedup-store.js";
-import { writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -181,6 +181,22 @@ describe("JsonFileDedupStore", () => {
 
   it("handles missing shape fields gracefully on load", () => {
     writeFileSync(testFile, JSON.stringify({ foo: "bar" }), "utf-8");
+    const store = new JsonFileDedupStore(testFile);
+    const snapshot = store.load();
+    expect(snapshot.primary).toEqual({});
+    expect(snapshot.secondary).toEqual({});
+  });
+
+  it("handles null primary gracefully on load", () => {
+    writeFileSync(testFile, JSON.stringify({ primary: null, secondary: {} }), "utf-8");
+    const store = new JsonFileDedupStore(testFile);
+    const snapshot = store.load();
+    expect(snapshot.primary).toEqual({});
+    expect(snapshot.secondary).toEqual({});
+  });
+
+  it("handles null secondary gracefully on load", () => {
+    writeFileSync(testFile, JSON.stringify({ primary: {}, secondary: null }), "utf-8");
     const store = new JsonFileDedupStore(testFile);
     const snapshot = store.load();
     expect(snapshot.primary).toEqual({});

--- a/tests/dedup-store.test.ts
+++ b/tests/dedup-store.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventDedup } from "../src/inbound/dedup.js";
+import type { DedupStore, DedupSnapshot } from "../src/inbound/dedup-store.js";
+import { JsonFileDedupStore } from "../src/inbound/dedup-store.js";
+import { writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// In-memory mock store for unit tests
+// ---------------------------------------------------------------------------
+
+function mockStore(initial?: DedupSnapshot): DedupStore & { saved: DedupSnapshot | null } {
+  const store = {
+    saved: null as DedupSnapshot | null,
+    _data: initial ?? { primary: {}, secondary: {} },
+    load(): DedupSnapshot {
+      return this._data;
+    },
+    save(snapshot: DedupSnapshot): void {
+      this.saved = snapshot;
+      this._data = snapshot;
+    },
+  };
+  return store;
+}
+
+// ---------------------------------------------------------------------------
+// EventDedup with persistent store
+// ---------------------------------------------------------------------------
+
+describe("EventDedup — persistent store integration", () => {
+  it("hydrates state from store on construction", () => {
+    const store = mockStore({
+      primary: { "activity:1": { seenAt: Date.now(), source: "activity" } },
+      secondary: { "100:created:2025-01-01": "activity:1" },
+    });
+
+    const dedup = new EventDedup({ ttlMs: 5000, store });
+    expect(dedup.size).toBe(1);
+    // The hydrated entry should be recognized as a duplicate
+    expect(dedup.isDuplicate("activity:1")).toBe(true);
+  });
+
+  it("skips expired entries during hydration", () => {
+    const store = mockStore({
+      primary: { "activity:1": { seenAt: Date.now() - 10000, source: "activity" } },
+      secondary: {},
+    });
+
+    const dedup = new EventDedup({ ttlMs: 5000, store });
+    expect(dedup.size).toBe(0);
+    // Expired entry should not be treated as duplicate
+    expect(dedup.isDuplicate("activity:1")).toBe(false);
+  });
+
+  it("cleans up orphaned secondary keys during hydration", () => {
+    const store = mockStore({
+      primary: {},
+      secondary: { "100:created:2025-01-01": "activity:1" },
+    });
+
+    const dedup = new EventDedup({ ttlMs: 5000, store });
+    expect(dedup.size).toBe(0);
+    // The orphaned secondary key should not cause false positives
+    expect(dedup.isDuplicate("reading:99", "100:created:2025-01-01")).toBe(false);
+  });
+
+  it("flushes to store on prune interval", () => {
+    const store = mockStore();
+    const dedup = new EventDedup({ ttlMs: 5000, pruneInterval: 3, store });
+
+    dedup.record("activity:1");
+    dedup.record("activity:2");
+    expect(store.saved).toBeNull(); // Not flushed yet
+
+    dedup.record("activity:3"); // Triggers prune + flush
+    expect(store.saved).not.toBeNull();
+    expect(Object.keys(store.saved!.primary)).toHaveLength(3);
+  });
+
+  it("explicit flush() saves current state", () => {
+    const store = mockStore();
+    const dedup = new EventDedup({ ttlMs: 5000, store });
+
+    dedup.record("activity:1");
+    dedup.record("activity:2", "sec:key");
+    dedup.flush();
+
+    expect(store.saved).not.toBeNull();
+    expect(store.saved!.primary["activity:1"]).toBeDefined();
+    expect(store.saved!.primary["activity:2"]).toBeDefined();
+    expect(store.saved!.secondary["sec:key"]).toBe("activity:2");
+  });
+
+  it("flush() is a no-op without a store", () => {
+    const dedup = new EventDedup({ ttlMs: 5000 });
+    dedup.record("activity:1");
+    // Should not throw
+    dedup.flush();
+  });
+
+  it("survives a simulated restart via store", () => {
+    const store = mockStore();
+
+    // First instance: record some events
+    const dedup1 = new EventDedup({ ttlMs: 5000, store });
+    dedup1.isDuplicate("activity:1");
+    dedup1.isDuplicate("reading:2", "100:created:ts");
+    dedup1.flush();
+
+    // Second instance: hydrate from store (simulates restart)
+    const dedup2 = new EventDedup({ ttlMs: 5000, store });
+    expect(dedup2.size).toBe(2);
+    expect(dedup2.isDuplicate("activity:1")).toBe(true);
+    expect(dedup2.isDuplicate("webhook:99", "100:created:ts")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JsonFileDedupStore
+// ---------------------------------------------------------------------------
+
+describe("JsonFileDedupStore", () => {
+  const testDir = join(tmpdir(), `dedup-test-${Date.now()}`);
+  const testFile = join(testDir, "dedup.json");
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("returns empty snapshot when file does not exist", () => {
+    const store = new JsonFileDedupStore(join(testDir, "missing.json"));
+    const snapshot = store.load();
+    expect(snapshot.primary).toEqual({});
+    expect(snapshot.secondary).toEqual({});
+  });
+
+  it("saves and loads a snapshot", () => {
+    const store = new JsonFileDedupStore(testFile);
+    const snapshot: DedupSnapshot = {
+      primary: { "activity:1": { seenAt: 123456, source: "activity" } },
+      secondary: { "sec:key": "activity:1" },
+    };
+
+    store.save(snapshot);
+    const loaded = store.load();
+
+    expect(loaded.primary["activity:1"]).toEqual({ seenAt: 123456, source: "activity" });
+    expect(loaded.secondary["sec:key"]).toBe("activity:1");
+  });
+
+  it("creates parent directories on save", () => {
+    const nestedFile = join(testDir, "a", "b", "c", "dedup.json");
+    const store = new JsonFileDedupStore(nestedFile);
+    const snapshot: DedupSnapshot = {
+      primary: { "x:1": { seenAt: 1, source: "x" } },
+      secondary: {},
+    };
+
+    store.save(snapshot);
+    const loaded = store.load();
+    expect(loaded.primary["x:1"]).toEqual({ seenAt: 1, source: "x" });
+  });
+
+  it("handles malformed JSON gracefully on load", () => {
+    writeFileSync(testFile, "not valid json", "utf-8");
+    const store = new JsonFileDedupStore(testFile);
+    const snapshot = store.load();
+    expect(snapshot.primary).toEqual({});
+    expect(snapshot.secondary).toEqual({});
+  });
+
+  it("handles missing shape fields gracefully on load", () => {
+    writeFileSync(testFile, JSON.stringify({ foo: "bar" }), "utf-8");
+    const store = new JsonFileDedupStore(testFile);
+    const snapshot = store.load();
+    expect(snapshot.primary).toEqual({});
+    expect(snapshot.secondary).toEqual({});
+  });
+
+  it("end-to-end: dedup survives restart via file store", () => {
+    const store = new JsonFileDedupStore(testFile);
+
+    // First lifecycle
+    const d1 = new EventDedup({ ttlMs: 60_000, store });
+    d1.isDuplicate("activity:100");
+    d1.isDuplicate("reading:200", "rec:key");
+    d1.flush();
+
+    // Second lifecycle — fresh EventDedup, same file
+    const store2 = new JsonFileDedupStore(testFile);
+    const d2 = new EventDedup({ ttlMs: 60_000, store: store2 });
+
+    expect(d2.size).toBe(2);
+    expect(d2.isDuplicate("activity:100")).toBe(true);
+    expect(d2.isDuplicate("webhook:300", "rec:key")).toBe(true);
+    // Genuinely new event
+    expect(d2.isDuplicate("activity:999")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds restart-safe event deduplication via a JSON file-backed store. Before this change, the in-memory dedup map reset on every gateway restart, causing re-dispatch of recent events. With write actions landing in #14/#15, duplicate dispatches can now cause real harm (duplicate todos, double completions).

**Architecture:**
- New `DedupStore` interface with `load()` and `save()` methods
- `JsonFileDedupStore` implementation that reads/writes a JSON file
- `EventDedup` accepts an optional `store` in its constructor options
- State hydrates on construction (expired entries are filtered)
- State flushes on every prune cycle and on explicit `flush()` call
- Fully backward compatible — no store means pure in-memory (existing behavior)

**Gateway wiring:**
- Composite poller creates a `JsonFileDedupStore` in the state directory (`dedup-{accountId}.json`)
- Dedup state is flushed on graceful shutdown alongside cursor state
- Logs loaded entry count on startup

**New files:**
- `src/inbound/dedup-store.ts` — DedupStore interface + JsonFileDedupStore
- `tests/dedup-store.test.ts` — 13 tests

**Modified files:**
- `src/inbound/dedup.ts` — store integration, flush() method, hydration logic
- `src/inbound/poller.ts` — wire persistent store into composite poller

## Test plan

- [x] `npx tsc --noEmit` — types clean
- [x] `npx vitest run` — 605 tests passing (13 new), 0 failures
- [x] Existing dedup tests still pass (14 tests unchanged)
- [ ] Gateway smoke: start gateway, process events, restart gateway, verify no duplicate dispatches