### PR TITLE
Rich text: table conversion and code block language hints

### DIFF
--- a/src/outbound/format.ts
+++ b/src/outbound/format.ts
@@ -31,8 +31,61 @@ export function markdownToBasecampHtml(md: string): string {
 
   // --- Fenced code blocks (``` ... ```) ---
   // Must run before inline transforms to avoid mangling code contents.
-  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, _lang, code) => {
-    return `<pre>${escapeHtml(code.replace(/\n$/, ""))}</pre>`;
+  // Collect code block positions so table parsing can skip them.
+  const codeBlockRanges: Array<{ start: number; end: number }> = [];
+  html = html.replace(/```([\w.+#/-]*)\n([\s\S]*?)```/g, (_match, lang, code, offset) => {
+    const langAttr = lang ? ` class="language-${lang}"` : "";
+    const replacement = `<pre${langAttr}>${escapeHtml(code.replace(/\n$/, ""))}</pre>`;
+    codeBlockRanges.push({ start: offset, end: offset + _match.length });
+    return replacement;
+  });
+
+  // --- Tables (pipe tables) ---
+  // Must run after fenced code blocks but before inline transforms.
+  // Skip matches inside <pre> blocks (already converted from fenced code blocks).
+  html = html.replace(/(?:^|\n)((?:\|[^\n]+\|(?:\n|$))+)/g, (_match, block: string, offset: number) => {
+    // Check if this match falls inside a <pre> block
+    const matchStart = offset;
+    const matchEnd = offset + _match.length;
+    const preOpenRegex = /<pre[^>]*>/g;
+    let preMatch;
+    let insidePre = false;
+    const tempHtml = html;
+    while ((preMatch = preOpenRegex.exec(tempHtml)) !== null) {
+      const preStart = preMatch.index;
+      const preCloseIdx = tempHtml.indexOf("</pre>", preStart);
+      if (preCloseIdx !== -1 && matchStart >= preStart && matchEnd <= preCloseIdx + 6) {
+        insidePre = true;
+        break;
+      }
+    }
+    if (insidePre) return _match;
+    const rows = block.trim().split("\n");
+    if (rows.length < 2) return _match;
+    // Check if the second row is a separator (contains only |, -, :, spaces)
+    if (!/^[\s|:-]+$/.test(rows[1]!)) return _match;
+
+    const parseRow = (row: string) =>
+      row
+        .replace(/^\|/, "")
+        .replace(/\|$/, "")
+        .split("|")
+        .map((cell) => cell.trim());
+
+    const headerCells = parseRow(rows[0]!);
+    const thead = `<thead><tr>${headerCells.map((c) => `<th>${c}</th>`).join("")}</tr></thead>`;
+
+    const bodyRows = rows.slice(2);
+    const tbody = bodyRows.length
+      ? `<tbody>${bodyRows.map((row) => {
+          const cells = parseRow(row);
+          return `<tr>${cells.map((c) => `<td>${c}</td>`).join("")}</tr>`;
+        }).join("")}</tbody>`
+      : "";
+
+    return tbody
+      ? `\n<table>\n${thead}\n${tbody}\n</table>\n`
+      : `\n<table>\n${thead}\n</table>\n`;
   });
 
   // --- Inline code (`...`) ---
@@ -110,7 +163,7 @@ export function markdownToBasecampHtml(md: string): string {
       const trimmed = p.trim();
       if (!trimmed) return "";
       // Don't add <br> inside block-level elements
-      if (/^<(pre|ul|ol|blockquote|h[1-6]|hr)/i.test(trimmed)) {
+      if (/^<(pre|ul|ol|blockquote|h[1-6]|hr|table)/i.test(trimmed)) {
         return trimmed;
       }
       return trimmed.replace(/\n/g, "<br>\n");
@@ -127,7 +180,7 @@ export function markdownToBasecampHtml(md: string): string {
 export function stripHtml(html: string): string {
   return html
     .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<\/?(p|div|h[1-6]|blockquote|pre|ul|ol|li|hr)[^>]*>/gi, "\n")
+    .replace(/<\/?(p|div|h[1-6]|blockquote|pre|ul|ol|li|hr|table|thead|tbody|tr|th|td)[^>]*>/gi, "\n")
     .replace(/<[^>]+>/g, "")
     .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -71,7 +71,7 @@ describe("markdownToBasecampHtml", () => {
   it("converts fenced code blocks to <pre>", () => {
     const md = "```js\nconst x = 1;\n```";
     const result = markdownToBasecampHtml(md);
-    expect(result).toContain("<pre>");
+    expect(result).toContain('<pre class="language-js">');
     expect(result).toContain("const x = 1;");
     expect(result).toContain("</pre>");
   });
@@ -154,6 +154,86 @@ describe("markdownToBasecampHtml", () => {
     expect(result).toContain("<hr>");
   });
 
+  // Fenced code block language attribute
+  it("adds language class to code block when language is specified", () => {
+    const md = "```typescript\nconst x = 1;\n```";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain('<pre class="language-typescript">');
+    expect(result).toContain("const x = 1;");
+    expect(result).toContain("</pre>");
+  });
+
+  it("handles code block languages with special chars (c++, objective-c)", () => {
+    const md = "```c++\nint main() {}\n```";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain('<pre class="language-c++">');
+  });
+
+  it("produces plain <pre> when no language is specified", () => {
+    const md = "```\nconst x = 1;\n```";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toBe("<pre>const x = 1;</pre>");
+  });
+
+  // Tables
+  it("converts a simple 2-column table", () => {
+    const md = "| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain("<table>");
+    expect(result).toContain("<thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>");
+    expect(result).toContain("<tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody>");
+    expect(result).toContain("</table>");
+  });
+
+  it("converts a table with 3+ columns", () => {
+    const md = "| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |\n| 4 | 5 | 6 |";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain("<th>A</th><th>B</th><th>C</th>");
+    expect(result).toContain("<tr><td>1</td><td>2</td><td>3</td></tr>");
+    expect(result).toContain("<tr><td>4</td><td>5</td><td>6</td></tr>");
+  });
+
+  it("converts table cells containing inline formatting", () => {
+    const md = "| Name | Status |\n|------|--------|\n| **bold** | `code` |";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain("<table>");
+    // Inline transforms run after table conversion, so bold/code are converted
+    expect(result).toContain("<strong>bold</strong>");
+    expect(result).toContain("<code>code</code>");
+  });
+
+  it("converts a table with empty cells", () => {
+    const md = "| A | B |\n|---|---|\n|   | x |";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain("<td></td><td>x</td>");
+  });
+
+  it("handles a table mixed with other markdown content", () => {
+    const md = "# Title\n\n| H1 | H2 |\n|----|----|\n| a  | b  |\n\nSome text after.";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain("<h1>Title</h1>");
+    expect(result).toContain("<table>");
+    expect(result).toContain("<th>H1</th>");
+    expect(result).toContain("<td>a</td>");
+    expect(result).toContain("Some text after.");
+  });
+
+  it("does not convert pipe-table-like text inside a fenced code block", () => {
+    const md = "```\n| A | B |\n|---|---|\n| x | y |\n```";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain("<pre>");
+    expect(result).not.toContain("<table>");
+    expect(result).not.toContain("<th>");
+  });
+
+  it("handles a table with header only (no body rows)", () => {
+    const md = "| H1 | H2 |\n|---|---|";
+    const result = markdownToBasecampHtml(md);
+    expect(result).toContain("<table>");
+    expect(result).toContain("<thead>");
+    expect(result).not.toContain("<tbody>");
+  });
+
   // Nested formatting
   it("handles nested bold and italic", () => {
     const result = markdownToBasecampHtml("**bold and *italic***");
@@ -200,6 +280,16 @@ describe("stripHtml", () => {
 
   it("decodes &quot; entity", () => {
     expect(stripHtml("say &quot;hello&quot;")).toBe('say "hello"');
+  });
+
+  it("strips table elements to plain text", () => {
+    const html = "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>";
+    const result = stripHtml(html);
+    expect(result).toContain("A");
+    expect(result).toContain("B");
+    expect(result).toContain("1");
+    expect(result).toContain("2");
+    expect(result).not.toContain("<");
   });
 
   it("collapses three or more consecutive newlines to two", () => {


### PR DESCRIPTION
## Summary
- Add markdown pipe-table to HTML table conversion (thead/tbody) in `src/outbound/format.ts`
- Emit `class="language-{lang}"` on fenced code blocks for syntax highlighting
- 7 new tests (43 total format tests)

## Test plan
- [x] `npx vitest run tests/format.test.ts` — 43 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Send agent reply with table and code block, verify rendering in Basecamp