### PR TITLE
Agent prompt hook: surface-specific system prompts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { basecampChannel } from "./src/channel.js";
 import { setBasecampRuntime } from "./src/runtime.js";
 import { handleBasecampWebhook } from "./src/inbound/webhooks.js";
+import { getSurfacePrompt } from "./src/hooks/agent-prompt-context.js";
 
 const plugin = {
   id: "openclaw-basecamp",
@@ -17,6 +18,13 @@ const plugin = {
     api.registerHttpRoute({
       path: "/webhooks/basecamp",
       handler: handleBasecampWebhook,
+    });
+    api.on("before_agent_start", (event) => {
+      const lines = event.prompt.split(/\r?\n/).filter((l) => l.startsWith("[basecamp] "));
+      const surfacePrompt = getSurfacePrompt(lines);
+      if (surfacePrompt) {
+        return { prependContext: surfacePrompt };
+      }
     });
   },
 };

--- a/src/hooks/agent-prompt-context.ts
+++ b/src/hooks/agent-prompt-context.ts
@@ -1,0 +1,80 @@
+/**
+ * Surface-specific prompt context for Basecamp.
+ * Maps Basecamp recordable types to prompt style hints.
+ */
+
+/** Map of recordable type strings to prompt hints. */
+const SURFACE_PROMPTS: Record<string, string> = {
+  "Chat::Transcript": [
+    "You are responding in a Basecamp Campfire chat room.",
+    "Keep responses concise and conversational — this is a real-time group chat.",
+    "Use short paragraphs. Avoid walls of text.",
+    "Match the casual tone of chat. No formal greetings or sign-offs.",
+  ].join(" "),
+
+  "Chat::Line": [
+    "You are responding to a Campfire chat message.",
+    "Keep responses concise and conversational.",
+    "Use short paragraphs. Match the casual chat tone.",
+  ].join(" "),
+
+  "Todo": [
+    "You are commenting on a Basecamp to-do.",
+    "Be detailed and actionable. Reference specific tasks and steps.",
+    "Structure your response clearly — use lists for action items.",
+    "Focus on helping the assignee complete the to-do.",
+  ].join(" "),
+
+  "Kanban::Card": [
+    "You are commenting on a Basecamp Card Table card.",
+    "Focus on the card's context, including its current column position.",
+    "Be concise but thorough. Structure feedback clearly.",
+  ].join(" "),
+
+  "Kanban::Triage": [
+    "You are commenting on a Basecamp Card Table card.",
+    "Focus on the card's context and triage status.",
+    "Be concise but thorough.",
+  ].join(" "),
+
+  "Question": [
+    "You are answering a Basecamp check-in question.",
+    "Be direct and structured. Match the question format.",
+    "Keep your answer focused on what was asked.",
+  ].join(" "),
+
+  "Message": [
+    "You are commenting on a Basecamp Message Board post.",
+    "Be thorough and well-structured. Use headings and lists where appropriate.",
+    "This is a longer-form discussion context.",
+  ].join(" "),
+
+  "Circle": [
+    "You are in a direct Basecamp Ping conversation.",
+    "Be helpful and personal. This is a private conversation.",
+    "You can be more detailed since it's a focused 1:1 or small group chat.",
+  ].join(" "),
+
+  "Comment": [
+    "You are responding to a comment on a Basecamp recording.",
+    "Be concise and relevant to the discussion thread.",
+    "Reference the parent context when appropriate.",
+  ].join(" "),
+};
+
+/**
+ * Extract surface-specific prompt context from dispatch metadata.
+ *
+ * Parses the UntrustedContext entries to find the recordableType,
+ * then returns the matching surface prompt.
+ */
+export function getSurfacePrompt(untrustedContext: string[]): string | undefined {
+  for (const line of untrustedContext) {
+    const match = line.match(/\[basecamp\] recordableType=(.+)/);
+    if (match) {
+      const recordableType = match[1]!.trim();
+      return SURFACE_PROMPTS[recordableType];
+    }
+  }
+  return undefined;
+}

--- a/tests/agent-prompt-context.test.ts
+++ b/tests/agent-prompt-context.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { getSurfacePrompt } from "../src/hooks/agent-prompt-context.js";
+
+describe("getSurfacePrompt", () => {
+  it("returns campfire prompt for Chat::Transcript", () => {
+    const ctx = ["[basecamp] recordableType=Chat::Transcript", "[basecamp] eventKind=line_created"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("Campfire");
+    expect(prompt).toContain("concise");
+  });
+
+  it("returns campfire prompt for Chat::Line", () => {
+    const ctx = ["[basecamp] recordableType=Chat::Line"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("Campfire");
+    expect(prompt).toContain("concise");
+  });
+
+  it("returns todo prompt for Todo", () => {
+    const ctx = ["[basecamp] recordableType=Todo"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("to-do");
+    expect(prompt).toContain("actionable");
+  });
+
+  it("returns card prompt for Kanban::Card", () => {
+    const ctx = ["[basecamp] recordableType=Kanban::Card"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("Card Table");
+    expect(prompt).toContain("column");
+  });
+
+  it("returns card prompt for Kanban::Triage", () => {
+    const ctx = ["[basecamp] recordableType=Kanban::Triage"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("Card Table");
+    expect(prompt).toContain("triage");
+  });
+
+  it("returns check-in prompt for Question", () => {
+    const ctx = ["[basecamp] recordableType=Question"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("check-in");
+    expect(prompt).toContain("direct");
+  });
+
+  it("returns message board prompt for Message", () => {
+    const ctx = ["[basecamp] recordableType=Message"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("Message Board");
+    expect(prompt).toContain("thorough");
+  });
+
+  it("returns DM prompt for Circle", () => {
+    const ctx = ["[basecamp] recordableType=Circle"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("Ping");
+    expect(prompt).toContain("private");
+  });
+
+  it("returns undefined when no recordableType in context", () => {
+    const ctx = ["[basecamp] eventKind=line_created", "[basecamp] bucketId=123 recordingId=456"];
+    expect(getSurfacePrompt(ctx)).toBeUndefined();
+  });
+
+  it("returns undefined for unknown recordableType", () => {
+    const ctx = ["[basecamp] recordableType=SomeUnknownType"];
+    expect(getSurfacePrompt(ctx)).toBeUndefined();
+  });
+
+  it("handles empty array", () => {
+    expect(getSurfacePrompt([])).toBeUndefined();
+  });
+
+  it("handles context with other non-basecamp entries", () => {
+    const ctx = ["some random context line", "another line", "[basecamp] recordableType=Todo"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("to-do");
+  });
+
+  it("uses first recordableType match", () => {
+    const ctx = [
+      "[basecamp] recordableType=Chat::Line",
+      "[basecamp] recordableType=Todo",
+    ];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("Campfire");
+  });
+
+  it("returns comment prompt for Comment", () => {
+    const ctx = ["[basecamp] recordableType=Comment"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("comment");
+    expect(prompt).toContain("thread");
+  });
+
+  it("handles trailing whitespace and \\r in recordableType value", () => {
+    const ctx = ["[basecamp] recordableType=Todo\r"];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("to-do");
+  });
+
+  it("handles trailing spaces in recordableType value", () => {
+    const ctx = ["[basecamp] recordableType=Todo  "];
+    const prompt = getSurfacePrompt(ctx);
+    expect(prompt).toContain("to-do");
+  });
+});


### PR DESCRIPTION
## Summary
- Wire SDK `before_agent_start` hook to inject surface-specific prompt hints
- Campfire chat gets concise/conversational guidance; todos and cards get structured/actionable guidance
- Covers 8 Basecamp recordable types (Chat::Transcript, Chat::Line, Todo, Kanban::Card, etc.)
- 13 new tests in `tests/agent-prompt-context.test.ts`

## Test plan
- [x] `npx vitest run tests/agent-prompt-context.test.ts` — 13 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Trigger agent on Campfire vs todo comment, verify prompt differences in agent behavior