### PR TITLE
Boosts support: agent reactions via Basecamp Boosts API

### DIFF
--- a/src/adapters/actions.ts
+++ b/src/adapters/actions.ts
@@ -1,12 +1,11 @@
 /**
  * Basecamp message actions adapter — agent write operations.
  *
- * Implements ChannelMessageActionAdapter for Basecamp. The "send" action
- * lets agents post campfire lines and comments via bcq. Additional write
- * actions (createTodo, completeTodo, etc.) will be added in future PRs.
+ * Implements ChannelMessageActionAdapter for Basecamp.
  *
  * Supported actions:
- *   send — Post a campfire line or comment to a Basecamp recording.
+ *   send  — Post a campfire line or comment to a Basecamp recording.
+ *   react — Add a boost (reaction) to any Basecamp recording.
  */
 
 import type {
@@ -19,13 +18,14 @@ import { jsonResult, readStringParam } from "openclaw/plugin-sdk";
 import { postCampfireLine, postComment } from "../outbound/send.js";
 import { markdownToBasecampHtml } from "../outbound/format.js";
 import { resolveBasecampAccount } from "../config.js";
+import { bcqApiPost } from "../bcq.js";
 
 // ---------------------------------------------------------------------------
 // Supported action set
 // ---------------------------------------------------------------------------
 
 /** Actions this adapter handles. */
-const SUPPORTED_ACTIONS: ChannelMessageActionName[] = ["send"];
+const SUPPORTED_ACTIONS: ChannelMessageActionName[] = ["send", "react"];
 
 // ---------------------------------------------------------------------------
 // Adapter
@@ -51,11 +51,28 @@ export const basecampActionsAdapter: ChannelMessageActionAdapter = {
     switch (ctx.action) {
       case "send":
         return handleSend(ctx);
+      case "react":
+        return handleReact(ctx);
       default:
         return jsonResult({ ok: false, error: `Unsupported action: ${ctx.action}` });
     }
   },
 };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the bcq numeric account ID for API calls.
+ * Prefers explicit bcqAccountId config, falls back to accountId only if numeric.
+ */
+function resolveBcqAccountId(account: ReturnType<typeof resolveBasecampAccount>): string | undefined {
+  return (
+    account.config.bcqAccountId ??
+    (/^\d+$/.test(account.accountId) ? account.accountId : undefined)
+  );
+}
 
 // ---------------------------------------------------------------------------
 // send — post a campfire line or comment
@@ -92,12 +109,7 @@ async function handleSend(ctx: ChannelMessageActionContext) {
 
   const content = markdownToBasecampHtml(text);
   const account = resolveBasecampAccount(cfg, accountId);
-
-  // Resolve bcq account ID — NOT the OpenClaw account key.
-  // Prefer explicit bcqAccountId config, fall back to accountId only if numeric.
-  const bcqAccountId =
-    account.config.bcqAccountId ??
-    (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
+  const bcqAccountId = resolveBcqAccountId(account);
 
   // Enforce virtual-account bucket scoping: if the account is scoped to a
   // specific bucket, reject sends targeting a different bucket.
@@ -151,4 +163,41 @@ async function handleSend(ctx: ChannelMessageActionContext) {
     commentId: result.commentId,
     error: result.error,
   });
+}
+
+// ---------------------------------------------------------------------------
+// react — add a boost (reaction) to any recording
+// ---------------------------------------------------------------------------
+
+async function handleReact(ctx: ChannelMessageActionContext) {
+  const { params, cfg, accountId, dryRun } = ctx;
+
+  const bucketId = readStringParam(params, "bucketId", { required: true, label: "Bucket ID" });
+  const recordingId = readStringParam(params, "recordingId", { required: true, label: "Recording ID" });
+  const emoji = readStringParam(params, "emoji") || "👍";
+
+  const account = resolveBasecampAccount(cfg, accountId);
+  const bcqAccountId = resolveBcqAccountId(account);
+
+  // Enforce virtual-account bucket scoping
+  if (account.scopedBucketId && bucketId !== String(account.scopedBucketId)) {
+    return jsonResult({
+      ok: false,
+      error: `Account "${account.accountId}" is scoped to bucket ${account.scopedBucketId}, cannot react in bucket ${bucketId}`,
+    });
+  }
+
+  if (dryRun) {
+    return jsonResult({ ok: true, dryRun: true, target: "boost", bucketId, recordingId, emoji });
+  }
+
+  const path = `/buckets/${bucketId}/recordings/${recordingId}/boosts.json`;
+  const body = JSON.stringify({ content: emoji });
+  try {
+    const result = await bcqApiPost<{ id?: number }>(path, body, bcqAccountId, account.bcqProfile);
+    return jsonResult({ ok: true, target: "boost", boostId: result?.id });
+  } catch (err) {
+    console.error(`[basecamp:${accountId}] react error: bucket=${bucketId} recording=${recordingId}`, err);
+    return jsonResult({ ok: false, error: String(err) });
+  }
 }

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -8,6 +8,7 @@
  *   basecamp_create_todo   — Create a new to-do in a to-do list
  *   basecamp_complete_todo — Mark a to-do as complete
  *   basecamp_reopen_todo   — Mark a to-do as incomplete
+ *   basecamp_add_boost     — Add a boost (reaction) to any recording
  *
  * Read tools:
  *   basecamp_read_history  — Fetch recent messages/comments for a recording
@@ -55,6 +56,12 @@ const ReadHistoryParams = Type.Object({
     minimum: 1,
     maximum: 50,
   })),
+});
+
+const AddBoostParams = Type.Object({
+  bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
+  recordingId: Type.String({ description: "Recording ID to boost (any recording: comment, todo, campfire line, etc.)" }),
+  content: Type.Optional(Type.String({ description: "Boost content — an emoji or short celebratory text (e.g., '👍', '🎉', 'Congrats!'). Defaults to '👍'." })),
 });
 
 // ---------------------------------------------------------------------------
@@ -131,6 +138,38 @@ async function executeReopenTodo(
     return {
       content: [{ type: "text" as const, text: JSON.stringify({ ok: true, todoId }) }],
       details: { ok: true, todoId },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// addBoost — react to any recording with an emoji or text
+// ---------------------------------------------------------------------------
+
+type AddBoostInput = Static<typeof AddBoostParams>;
+
+async function executeAddBoost(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const params = rawParams as AddBoostInput;
+  const { bucketId, recordingId } = params;
+  const content = params.content || "👍";
+  const path = `/buckets/${bucketId}/recordings/${recordingId}/boosts.json`;
+
+  try {
+    const result = await bcqApiPost<{ id?: number }>(
+      path,
+      JSON.stringify({ content }),
+    );
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, boostId: result?.id }) }],
+      details: { ok: true, boostId: result?.id },
     };
   } catch (err) {
     return {
@@ -229,5 +268,14 @@ export const basecampAgentTools: ChannelAgentTool[] = [
       "Returns up to 50 entries with sender, text, and timestamp.",
     parameters: ReadHistoryParams,
     execute: executeReadHistory,
+  },
+  {
+    name: "basecamp_add_boost",
+    label: "Add Basecamp Boost",
+    description:
+      "Add a boost (reaction) to any Basecamp recording — comment, to-do, campfire line, message, etc. " +
+      "Content can be an emoji or short celebratory text. Defaults to '👍' if not specified.",
+    parameters: AddBoostParams,
+    execute: executeAddBoost,
   },
 ];

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -52,7 +52,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
   capabilities: {
     chatTypes: ["direct", "group"],
     threads: false,
-    reactions: false,
+    reactions: true,
     media: false,
     nativeCommands: false,
     blockStreaming: false,

--- a/tests/actions.test.ts
+++ b/tests/actions.test.ts
@@ -13,6 +13,10 @@ vi.mock("openclaw/plugin-sdk", () => ({
   },
 }));
 
+vi.mock("../src/bcq.js", () => ({
+  bcqApiPost: vi.fn(),
+}));
+
 vi.mock("../src/outbound/send.js", () => ({
   postCampfireLine: vi.fn(),
   postComment: vi.fn(),
@@ -38,6 +42,7 @@ import { basecampActionsAdapter } from "../src/adapters/actions.js";
 import { postCampfireLine, postComment } from "../src/outbound/send.js";
 import { markdownToBasecampHtml } from "../src/outbound/format.js";
 import { resolveBasecampAccount } from "../src/config.js";
+import { bcqApiPost } from "../src/bcq.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -61,7 +66,7 @@ function actionCtx(overrides: Record<string, unknown> = {}) {
 describe("actions.listActions", () => {
   it("returns supported action names", () => {
     const actions = basecampActionsAdapter.listActions!({ cfg: {} as any });
-    expect(actions).toEqual(["send"]);
+    expect(actions).toEqual(["send", "react"]);
   });
 });
 
@@ -74,8 +79,11 @@ describe("actions.supportsAction", () => {
     expect(basecampActionsAdapter.supportsAction!({ action: "send" })).toBe(true);
   });
 
+  it("returns true for react", () => {
+    expect(basecampActionsAdapter.supportsAction!({ action: "react" })).toBe(true);
+  });
+
   it("returns false for unsupported actions", () => {
-    expect(basecampActionsAdapter.supportsAction!({ action: "react" })).toBe(false);
     expect(basecampActionsAdapter.supportsAction!({ action: "delete" })).toBe(false);
     expect(basecampActionsAdapter.supportsAction!({ action: "edit" })).toBe(false);
   });
@@ -317,12 +325,12 @@ describe("actions.handleAction — send dryRun", () => {
 describe("actions.handleAction — unsupported action", () => {
   it("returns error for unsupported action", async () => {
     const result = await basecampActionsAdapter.handleAction!(
-      actionCtx({ action: "react" }),
+      actionCtx({ action: "delete" }),
     );
 
     expect(result).toEqual({
       ok: true,
-      result: { ok: false, error: "Unsupported action: react" },
+      result: { ok: false, error: "Unsupported action: delete" },
     });
   });
 });
@@ -354,5 +362,178 @@ describe("actions.handleAction — bcqAccountId override", () => {
     expect(postCampfireLine).toHaveBeenCalledWith(
       expect.objectContaining({ accountId: "override-id" }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — react (boost)
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — react", () => {
+  beforeEach(() => {
+    // Reset to default account (no bcqAccountId override, no scoping)
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      accountId: "test-acct",
+      enabled: true,
+      personId: "999",
+      token: "tok-test",
+      tokenSource: "config",
+      bcqProfile: "test-profile",
+      config: { personId: "999", bcqAccountId: undefined },
+    } as any);
+  });
+
+  it("posts a boost with emoji", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 55 });
+
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        action: "react",
+        params: { bucketId: "1", recordingId: "500", emoji: "🎉" },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { ok: true, target: "boost", boostId: 55 },
+    });
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/1/recordings/500/boosts.json",
+      JSON.stringify({ content: "🎉" }),
+      undefined,
+      "test-profile",
+    );
+  });
+
+  it("defaults emoji to thumbs up", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 56 });
+
+    await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        action: "react",
+        params: { bucketId: "1", recordingId: "500" },
+      }),
+    );
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/1/recordings/500/boosts.json",
+      JSON.stringify({ content: "👍" }),
+      undefined,
+      "test-profile",
+    );
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqApiPost).mockRejectedValue(new Error("503 Unavailable"));
+
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        action: "react",
+        params: { bucketId: "1", recordingId: "500", emoji: "👍" },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { ok: false, error: "Error: 503 Unavailable" },
+    });
+  });
+
+  it("throws on missing bucketId", async () => {
+    await expect(
+      basecampActionsAdapter.handleAction!(
+        actionCtx({
+          action: "react",
+          params: { recordingId: "500" },
+        }),
+      ),
+    ).rejects.toThrow(/Bucket ID/i);
+  });
+
+  it("throws on missing recordingId", async () => {
+    await expect(
+      basecampActionsAdapter.handleAction!(
+        actionCtx({
+          action: "react",
+          params: { bucketId: "1" },
+        }),
+      ),
+    ).rejects.toThrow(/Recording ID/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — react bucket scoping
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — react bucket scoping", () => {
+  it("rejects react when bucket does not match scoped account", async () => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      accountId: "scoped-acct",
+      enabled: true,
+      personId: "999",
+      token: "tok-test",
+      tokenSource: "config",
+      bcqProfile: "test-profile",
+      scopedBucketId: 42,
+      config: { personId: "999", bcqAccountId: undefined },
+    } as any);
+
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        action: "react",
+        params: { bucketId: "99", recordingId: "500", emoji: "👍" },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: {
+        ok: false,
+        error: expect.stringContaining("scoped to bucket 42"),
+      },
+    });
+    expect(bcqApiPost).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAction — react dry run
+// ---------------------------------------------------------------------------
+
+describe("actions.handleAction — react dryRun", () => {
+  beforeEach(() => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      accountId: "test-acct",
+      enabled: true,
+      personId: "999",
+      token: "tok-test",
+      tokenSource: "config",
+      bcqProfile: "test-profile",
+      config: { personId: "999", bcqAccountId: undefined },
+    } as any);
+  });
+
+  it("returns preview without posting boost", async () => {
+    const result = await basecampActionsAdapter.handleAction!(
+      actionCtx({
+        action: "react",
+        params: { bucketId: "1", recordingId: "500", emoji: "🎉" },
+        dryRun: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: expect.objectContaining({
+        ok: true,
+        dryRun: true,
+        target: "boost",
+        bucketId: "1",
+        recordingId: "500",
+        emoji: "🎉",
+      }),
+    });
+    expect(bcqApiPost).not.toHaveBeenCalled();
   });
 });

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -28,8 +28,8 @@ function findTool(name: string) {
 // ---------------------------------------------------------------------------
 
 describe("basecampAgentTools", () => {
-  it("exports four tools", () => {
-    expect(basecampAgentTools).toHaveLength(4);
+  it("exports five tools", () => {
+    expect(basecampAgentTools).toHaveLength(5);
   });
 
   it("has correct tool names", () => {
@@ -39,6 +39,7 @@ describe("basecampAgentTools", () => {
       "basecamp_complete_todo",
       "basecamp_reopen_todo",
       "basecamp_read_history",
+      "basecamp_add_boost",
     ]);
   });
 
@@ -380,5 +381,61 @@ describe("basecamp_read_history", () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.messages[0].sender).toBe("unknown");
     expect(parsed.messages[0].senderId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_add_boost
+// ---------------------------------------------------------------------------
+
+describe("basecamp_add_boost", () => {
+  const tool = findTool("basecamp_add_boost");
+
+  it("boosts a recording with default content", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 99 });
+
+    const result = await tool.execute("call-18", {
+      bucketId: "100",
+      recordingId: "500",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/recordings/500/boosts.json",
+      JSON.stringify({ content: "👍" }),
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, boostId: 99 });
+    expect(result.details).toEqual({ ok: true, boostId: 99 });
+  });
+
+  it("boosts a recording with custom emoji", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 101 });
+
+    const result = await tool.execute("call-19", {
+      bucketId: "100",
+      recordingId: "500",
+      content: "🎉",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/recordings/500/boosts.json",
+      JSON.stringify({ content: "🎉" }),
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, boostId: 101 });
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqApiPost).mockRejectedValue(new Error("422 Unprocessable"));
+
+    const result = await tool.execute("call-20", {
+      bucketId: "100",
+      recordingId: "500",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("422 Unprocessable");
+    expect(result.details).toEqual({ ok: false, error: expect.stringContaining("422 Unprocessable") });
   });
 });


### PR DESCRIPTION
## Summary
- Add `basecamp_add_boost` agent tool for posting emoji reactions to any recording
- Add `react` action in the actions adapter with bucket scoping and dry-run support
- Enable `reactions: true` capability on the channel plugin
- 8 new tests across actions and agent-tools test files

## Test plan
- [x] `npx vitest run tests/actions.test.ts tests/agent-tools.test.ts` — 51 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Agent reacts with Boost to a Campfire message, verify Boost appears in Basecamp