### PR TITLE
Webhook dedup persistence: restart-safe dedup for webhook handler

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -35,6 +35,7 @@ import { resolveOutboundTarget, chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } f
 import { basecampMentionAdapter } from "./adapters/mentions.js";
 import { basecampActionsAdapter } from "./adapters/actions.js";
 import { basecampAgentTools } from "./adapters/agent-tools.js";
+import { setWebhookStateDir, flushWebhookDedup } from "./inbound/webhooks.js";
 
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   id: "basecamp",
@@ -237,6 +238,9 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         stateDir = "/tmp/openclaw-basecamp-state";
       }
 
+      // Share state directory with webhook handler for persistent dedup
+      setWebhookStateDir(stateDir);
+
       // Event handler: filter self-messages, then dispatch to OpenClaw agents
       const onEvent = async (msg: BasecampInboundMessage) => {
         // Self-message filtering: skip events from our own service account
@@ -276,6 +280,8 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           },
         });
       } finally {
+        // Flush webhook dedup stores before marking as stopped
+        flushWebhookDedup();
         ctx.setStatus({
           accountId: account.accountId,
           running: false,

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -11,9 +11,11 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { join } from "node:path";
 import type { BasecampWebhookPayload, ResolvedBasecampAccount } from "../types.js";
 import { normalizeWebhookPayload, isSelfMessage } from "./normalize.js";
 import { EventDedup } from "./dedup.js";
+import { JsonFileDedupStore } from "./dedup-store.js";
 import { dispatchBasecampEvent } from "../dispatch.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount, resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
@@ -69,13 +71,44 @@ export const dispatchSemaphore = new Semaphore(MAX_CONCURRENT_DISPATCHES);
 /** Per-account dedup instances for webhook events. */
 const dedupRegistry = new Map<string, EventDedup>();
 
+/** State directory for persistent dedup stores. Set via setWebhookStateDir(). */
+let webhookStateDir: string | undefined;
+
+/**
+ * Configure the state directory for persistent webhook dedup stores.
+ * Must be called before webhooks are processed to enable restart-safe dedup.
+ * Idempotent: if the directory hasn't changed, this is a no-op.
+ */
+export function setWebhookStateDir(dir: string): void {
+  const normalized = dir || undefined;
+  if (normalized === webhookStateDir) return;
+  // Flush existing instances before switching directories
+  for (const dedup of dedupRegistry.values()) {
+    dedup.flush();
+  }
+  dedupRegistry.clear();
+  webhookStateDir = normalized;
+}
+
 function getDedup(accountId: string): EventDedup {
   let dedup = dedupRegistry.get(accountId);
   if (!dedup) {
-    dedup = new EventDedup();
+    const store = webhookStateDir
+      ? new JsonFileDedupStore(join(webhookStateDir, `webhook-dedup-${accountId}.json`))
+      : undefined;
+    dedup = new EventDedup(store ? { store } : undefined);
     dedupRegistry.set(accountId, dedup);
   }
   return dedup;
+}
+
+/**
+ * Flush all webhook dedup stores to disk. Call on graceful shutdown.
+ */
+export function flushWebhookDedup(): void {
+  for (const dedup of dedupRegistry.values()) {
+    dedup.flush();
+  }
 }
 
 /** Maximum allowed webhook request body size (1 MiB). */

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 vi.mock("../src/dispatch.js", () => ({
@@ -51,7 +51,7 @@ vi.mock("../src/inbound/normalize.js", () => ({
   isSelfMessage: vi.fn(() => false),
 }));
 
-import { Semaphore, handleBasecampWebhook } from "../src/inbound/webhooks.js";
+import { Semaphore, handleBasecampWebhook, setWebhookStateDir, flushWebhookDedup } from "../src/inbound/webhooks.js";
 import { resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../src/config.js";
 import { dispatchBasecampEvent } from "../src/dispatch.js";
 
@@ -339,5 +339,67 @@ describe("handleBasecampWebhook — hardening", () => {
       expect.anything(),
       "work",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Webhook dedup persistence
+// ---------------------------------------------------------------------------
+
+describe("webhook dedup persistence", () => {
+  afterEach(() => {
+    // Reset state dir for other tests (idempotent no-op if already empty)
+    setWebhookStateDir("");
+  });
+
+  it("setWebhookStateDir and flushWebhookDedup are exported functions", () => {
+    expect(typeof setWebhookStateDir).toBe("function");
+    expect(typeof flushWebhookDedup).toBe("function");
+  });
+
+  it("setWebhookStateDir is idempotent (same dir does not flush)", () => {
+    // Setting the same dir twice should not clear existing dedup instances
+    setWebhookStateDir("/tmp/test-dir");
+    setWebhookStateDir("/tmp/test-dir");
+    // No throw, no clearing — second call is a no-op
+    setWebhookStateDir("");
+  });
+
+  it("flushWebhookDedup does not throw when no state dir is set", () => {
+    expect(() => flushWebhookDedup()).not.toThrow();
+  });
+
+  it("creates persistent dedup when state dir is configured", async () => {
+    const { mkdtempSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const dir = mkdtempSync(join(tmpdir(), "webhook-dedup-test-"));
+
+    setWebhookStateDir(dir);
+
+    // Process a webhook to trigger dedup creation
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(200);
+
+    // Flush to disk
+    flushWebhookDedup();
+
+    // Verify a dedup file was created
+    const { readdirSync } = await import("node:fs");
+    const files = readdirSync(dir);
+    const dedupFiles = files.filter((f: string) => f.startsWith("webhook-dedup-"));
+    expect(dedupFiles.length).toBeGreaterThan(0);
+
+    // Clean up temp directory
+    const { rmSync } = await import("node:fs");
+    rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- Wire `JsonFileDedupStore` into the webhook handler's per-account dedup instances
- Add `setWebhookStateDir()` to configure state directory and `flushWebhookDedup()` for shutdown
- Gateway start shares state directory with webhook handler; shutdown flushes to disk
- Closes the restart-safety gap from PR #16 (which only covered the poller)

## Test plan
- [x] `npx vitest run tests/webhooks.test.ts` — 19 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Restart gateway after webhook receipt, verify no duplicate dispatch