### PR TITLE
Structured logging: consistent format across poller, dispatch, and webhooks

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -19,6 +19,7 @@ import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolic
 import { postReplyToEvent } from "./outbound/send.js";
 import { markdownToBasecampHtml } from "./outbound/format.js";
 import { chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
+import { createStructuredLog } from "./logging.js";
 
 export type DispatchOptions = {
   /** The resolved account that received this event. */
@@ -40,11 +41,12 @@ export async function dispatchBasecampEvent(
   const runtime = getBasecampRuntime();
   const cfg = runtime.config.loadConfig();
   const { account, log } = options;
+  const slog = createStructuredLog(log, { accountId: account.accountId, source: "dispatch" });
 
   // ----- Self-message filtering -----
   // Skip messages from our own service account to avoid loops.
   if (msg.sender.id === account.personId) {
-    log?.debug?.(`[${account.accountId}] skipping self-message from personId=${msg.sender.id}`);
+    slog.debug("self_message_skipped", { personId: msg.sender.id });
     return false;
   }
 
@@ -63,7 +65,7 @@ export async function dispatchBasecampEvent(
   });
 
   if (!route) {
-    log?.debug?.(`[${account.accountId}] no agent route for peer=${msg.peer.id}`);
+    slog.debug("no_route", { peer: msg.peer.id });
     return false;
   }
 
@@ -74,11 +76,13 @@ export async function dispatchBasecampEvent(
   const engagement = classifyEngagement(msg);
   const engagePolicy = resolveEngagePolicy(cfg, msg.meta.bucketId);
   if (!engagePolicy.includes(engagement)) {
-    log?.debug?.(
-      `[${account.accountId}] engagement gate: dropping ` +
-      `engagement=${engagement} event=${msg.meta.eventKind} type=${msg.meta.recordableType} ` +
-      `peer=${msg.peer.id} policy=[${engagePolicy.join(",")}]`,
-    );
+    slog.debug("engagement_gate_dropped", {
+      engagement,
+      event: msg.meta.eventKind,
+      type: msg.meta.recordableType,
+      peer: msg.peer.id,
+      policy: engagePolicy.join(","),
+    });
     return false;
   }
 
@@ -89,28 +93,29 @@ export async function dispatchBasecampEvent(
   if (engagement === "dm") {
     const dmPolicy = resolveBasecampDmPolicy(cfg);
     if (dmPolicy === "disabled") {
-      log?.debug?.(
-        `[${account.accountId}] dm policy: dropping dm from sender=${msg.sender.id} (policy=disabled)`,
-      );
+      slog.debug("dm_policy_dropped", { sender: msg.sender.id, policy: "disabled" });
       return false;
     }
     if (dmPolicy === "pairing" || dmPolicy === "allowlist") {
       const allowFrom = resolveBasecampAllowFrom(cfg);
       if (!allowFrom.includes(msg.sender.id)) {
-        log?.debug?.(
-          `[${account.accountId}] dm policy: dropping dm from sender=${msg.sender.id} ` +
-          `(policy=${dmPolicy}, not in allowFrom=[${allowFrom.join(",")}])`,
-        );
+        slog.debug("dm_policy_dropped", {
+          sender: msg.sender.id,
+          policy: dmPolicy,
+          allowFrom: allowFrom.join(","),
+        });
         return false;
       }
     }
     // dmPolicy === "open" → allow all DMs through
   }
 
-  log?.info?.(
-    `[${account.accountId}] dispatching to agent=${route.agentId} via ${route.matchedBy} ` +
-    `peer=${msg.peer.kind}:${msg.peer.id} recordableType=${msg.meta.recordableType}`,
-  );
+  slog.info("dispatching", {
+    agent: route.agentId,
+    matchedBy: route.matchedBy,
+    peer: `${msg.peer.kind}:${msg.peer.id}`,
+    recordableType: msg.meta.recordableType,
+  });
 
   // ----- Resolve persona for outbound -----
   // The agent may have a dedicated Basecamp persona (service account).
@@ -126,10 +131,10 @@ export async function dispatchBasecampEvent(
     outboundAccount.config.bcqAccountId ??
     (/^\d+$/.test(outboundAccount.accountId) ? outboundAccount.accountId : undefined);
   if (!outboundBcqAccountId) {
-    log?.error(
-      `[${account.accountId}] outbound dispatch: unable to resolve bcq account id for outbound account ` +
-      `"${outboundAccount.accountId}". Set config.bcqAccountId to a valid Basecamp account id.`,
-    );
+    slog.error("outbound_account_id_missing", {
+      outboundAccount: outboundAccount.accountId,
+      hint: "Set config.bcqAccountId to a valid Basecamp account id",
+    });
     return false;
   }
 
@@ -198,26 +203,24 @@ export async function dispatchBasecampEvent(
       onError: (err) => {
         dispatchHadError = true;
         const errorType = classifyDispatchError(err);
-        log?.error?.(
-          `[basecamp:dispatch] failed — ` +
-          `agent=${route.agentId} ` +
-          `event=${msg.meta.eventKind} ` +
-          `recording=${msg.meta.recordingId} ` +
-          `account=${account.accountId} ` +
-          `sender=${msg.sender.id} ` +
-          `type=${errorType} ` +
-          `error=${String(err)}`,
-        );
+        slog.error("delivery_failed", {
+          agent: route.agentId,
+          event: msg.meta.eventKind,
+          recording: msg.meta.recordingId,
+          sender: msg.sender.id,
+          type: errorType,
+          error: String(err),
+        });
       },
     },
   });
 
   if (!dispatchHadError) {
-    log?.info?.(
-      `[basecamp:dispatch] delivered — ` +
-      `agent=${route.agentId} event=${msg.meta.eventKind} ` +
-      `account=${account.accountId} recording=${msg.meta.recordingId}`,
-    );
+    slog.info("delivered", {
+      agent: route.agentId,
+      event: msg.meta.eventKind,
+      recording: msg.meta.recordingId,
+    });
   }
 
   return true;

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -27,6 +27,7 @@ import { pollReadings } from "./readings.js";
 import { pollAssignments } from "./assignments.js";
 import { bcqMarkReadingsRead } from "../bcq.js";
 import { isSelfMessage } from "./normalize.js";
+import { createStructuredLog } from "../logging.js";
 
 export interface CompositePollerOptions {
   account: ResolvedBasecampAccount;
@@ -60,18 +61,17 @@ function clamp(value: number, min: number, max: number): number {
 /** Save cursors with one retry after 1s delay on failure. */
 async function saveCursorsWithRetry(
   cursors: CursorStore,
-  accountId: string,
-  log?: CompositePollerOptions["log"],
+  slog: ReturnType<typeof createStructuredLog>,
 ): Promise<void> {
   try {
     await cursors.save();
   } catch (err) {
-    log?.warn?.(`[${accountId}] cursor save failed, retrying in 1s: ${String(err)}`);
+    slog.warn("cursor_save_failed", { error: String(err), retrying: true });
     await new Promise((r) => setTimeout(r, 1000));
     try {
       await cursors.save();
     } catch (retryErr) {
-      log?.error?.(`[${accountId}] cursor save retry failed, continuing: ${String(retryErr)}`);
+      slog.error("cursor_save_retry_failed", { error: String(retryErr) });
     }
   }
 }
@@ -83,6 +83,7 @@ export async function startCompositePoller(
   opts: CompositePollerOptions,
 ): Promise<void> {
   const { account, cfg, abortSignal, onEvent, log } = opts;
+  const slog = createStructuredLog(log, { accountId: account.accountId, source: "poller" });
 
   const intervals = resolvePollingIntervals(cfg);
   const activityIntervalMs = intervals.activityIntervalMs;
@@ -98,27 +99,25 @@ export async function startCompositePoller(
   try {
     await mkdir(stateDir, { recursive: true });
     await access(stateDir, constants.W_OK);
-    log?.info?.(`[${account.accountId}] state directory: ${stateDir}`);
+    slog.info("state_directory", { path: stateDir });
   } catch (err) {
-    log?.error?.(`[${account.accountId}] state directory not writable: ${stateDir}: ${String(err)}`);
+    slog.error("state_directory_not_writable", { path: stateDir, error: String(err) });
     throw err;
   }
 
   // Persistent dedup store — survives gateway restarts
   const dedupStore = new JsonFileDedupStore(join(stateDir, `dedup-${account.accountId}.json`));
   const dedup = new EventDedup({ store: dedupStore });
-  log?.info?.(`[${account.accountId}] dedup store: ${dedup.size} entries loaded`);
+  slog.info("dedup_loaded", { entries: dedup.size });
 
   const cursors = new CursorStore(stateDir, account.accountId);
 
   try {
     await cursors.load();
     const c = cursors.get();
-    log?.info?.(
-      "[" + account.accountId + "] loaded cursors: activity=" + (c.activitySince ?? "none") + " readings=" + (c.readingsSince ?? "none"),
-    );
+    slog.info("cursors_loaded", { activity: c.activitySince ?? "none", readings: c.readingsSince ?? "none" });
   } catch (err) {
-    log?.warn?.("[" + account.accountId + "] failed to load cursors, starting fresh: " + String(err));
+    slog.warn("cursors_load_failed", { error: String(err) });
   }
 
   let activityBackoff = 0;
@@ -143,13 +142,11 @@ export async function startCompositePoller(
         assignmentsBootstrapped = true;
       }
     } catch {
-      log?.warn?.(`[${account.accountId}] corrupt assignment cursor — will re-bootstrap`);
+      slog.warn("corrupt_assignment_cursor");
     }
   }
 
-  log?.info?.(
-    "[" + account.accountId + "] composite poller started (activity=" + activityIntervalMs + "ms, readings=" + readingsIntervalMs + "ms, assignments=" + assignmentsIntervalMs + "ms)",
-  );
+  slog.info("started", { activityMs: activityIntervalMs, readingsMs: readingsIntervalMs, assignmentsMs: assignmentsIntervalMs });
 
   while (!abortSignal?.aborted) {
     const now = Date.now();
@@ -179,17 +176,17 @@ export async function startCompositePoller(
             await onEvent(event);
             dispatched++;
           } catch (err) {
-            log?.error?.("[" + account.accountId + "] dispatch error for " + event.dedupKey + ": " + String(err));
+            slog.error("dispatch_error", { feed: "activity", key: event.dedupKey, error: String(err) });
           }
         }
 
         if (result.newestAt) {
           cursors.setActivitySince(result.newestAt);
-          await saveCursorsWithRetry(cursors, account.accountId, log);
+          await saveCursorsWithRetry(cursors, slog);
         }
 
         if (dispatched > 0) {
-          log?.info?.("[" + account.accountId + "] activity: " + result.events.length + " events, " + dispatched + " dispatched");
+          slog.info("poll_dispatched", { feed: "activity", total: result.events.length, dispatched });
         }
 
         activityBackoff = 0;
@@ -199,7 +196,7 @@ export async function startCompositePoller(
           activityIntervalMs,
           MAX_BACKOFF_MS,
         );
-        log?.error?.("[" + account.accountId + "] activity feed error (backoff=" + activityBackoff + "ms): " + String(err));
+        slog.error("poll_error", { feed: "activity", backoff: activityBackoff, error: String(err) });
       }
     }
 
@@ -226,7 +223,7 @@ export async function startCompositePoller(
             await onEvent(event);
             dispatched++;
           } catch (err) {
-            log?.error?.("[" + account.accountId + "] dispatch error for reading " + event.dedupKey + ": " + String(err));
+            slog.error("dispatch_error", { feed: "readings", key: event.dedupKey, error: String(err) });
           }
         }
 
@@ -237,19 +234,19 @@ export async function startCompositePoller(
               accountId: account.config.bcqAccountId,
               profile: account.bcqProfile,
             });
-            log?.debug?.("[" + account.accountId + "] marked " + result.processedSgids.length + " readings as read");
+            slog.debug("readings_marked_read", { count: result.processedSgids.length });
           } catch (err) {
-            log?.warn?.("[" + account.accountId + "] failed to mark readings as read: " + String(err));
+            slog.warn("readings_mark_read_failed", { error: String(err) });
           }
         }
 
         if (result.newestAt) {
           cursors.setReadingsSince(result.newestAt);
-          await saveCursorsWithRetry(cursors, account.accountId, log);
+          await saveCursorsWithRetry(cursors, slog);
         }
 
         if (dispatched > 0) {
-          log?.info?.("[" + account.accountId + "] readings: " + result.events.length + " unreads, " + dispatched + " dispatched");
+          slog.info("poll_dispatched", { feed: "readings", total: result.events.length, dispatched });
         }
 
         readingsBackoff = 0;
@@ -259,7 +256,7 @@ export async function startCompositePoller(
           readingsIntervalMs,
           MAX_BACKOFF_MS,
         );
-        log?.error?.("[" + account.accountId + "] readings error (backoff=" + readingsBackoff + "ms): " + String(err));
+        slog.error("poll_error", { feed: "readings", backoff: readingsBackoff, error: String(err) });
       }
     }
 
@@ -284,7 +281,7 @@ export async function startCompositePoller(
             await onEvent(event);
             dispatched++;
           } catch (err) {
-            log?.error?.("[" + account.accountId + "] dispatch error for assignment " + event.dedupKey + ": " + String(err));
+            slog.error("dispatch_error", { feed: "assignments", key: event.dedupKey, error: String(err) });
           }
         }
 
@@ -292,10 +289,10 @@ export async function startCompositePoller(
         assignmentKnownIds = result.knownIds;
         assignmentsBootstrapped = true;
         cursors.setCustom("assignmentIds", JSON.stringify([...result.knownIds]));
-        await saveCursorsWithRetry(cursors, account.accountId, log);
+        await saveCursorsWithRetry(cursors, slog);
 
         if (dispatched > 0) {
-          log?.info?.("[" + account.accountId + "] assignments: " + result.events.length + " new, " + dispatched + " dispatched");
+          slog.info("poll_dispatched", { feed: "assignments", total: result.events.length, dispatched });
         }
 
         assignmentsBackoff = 0;
@@ -305,7 +302,7 @@ export async function startCompositePoller(
           assignmentsIntervalMs,
           MAX_BACKOFF_MS,
         );
-        log?.error?.("[" + account.accountId + "] assignments error (backoff=" + assignmentsBackoff + "ms): " + String(err));
+        slog.error("poll_error", { feed: "assignments", backoff: assignmentsBackoff, error: String(err) });
       }
     }
 
@@ -320,9 +317,9 @@ export async function startCompositePoller(
 
   try {
     dedup.flush();
-    await saveCursorsWithRetry(cursors, account.accountId, log);
-    log?.info?.("[" + account.accountId + "] composite poller stopped, cursors saved, dedup flush attempted");
+    await saveCursorsWithRetry(cursors, slog);
+    slog.info("stopped");
   } catch (err) {
-    log?.warn?.("[" + account.accountId + "] failed to save final state: " + String(err));
+    slog.warn("final_state_save_failed", { error: String(err) });
   }
 }

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -17,6 +17,7 @@ import { EventDedup } from "./dedup.js";
 import { dispatchBasecampEvent } from "../dispatch.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount, resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
+import { createConsoleStructuredLog } from "../logging.js";
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter
@@ -198,30 +199,36 @@ export async function handleBasecampWebhook(
       // this is ambiguous — reject rather than guess wrong identity.
       const accountIds = listBasecampAccountIds(cfg);
       if (accountIds.length > 1) {
-        console.warn(
-          `[basecamp:webhook] unmapped bucket ${bucketId} with ${accountIds.length} accounts configured, dropping ` +
-          `(add a virtualAccounts entry to route this bucket to an account)`,
-        );
+        const preslog = createConsoleStructuredLog({ accountId: "unknown", source: "webhook" });
+        preslog.warn("unmapped_bucket", {
+          bucketId,
+          accountCount: accountIds.length,
+          hint: "add a virtualAccounts entry to route this bucket to an account",
+        });
         return;
       }
     }
     const effectiveAccountId = scopeAccountId ?? resolveDefaultBasecampAccountId(cfg);
     account = resolveBasecampAccount(cfg, effectiveAccountId);
     if (!account.enabled) {
-      console.warn(`[basecamp:webhook] resolved account "${account.accountId}" is disabled, dropping`);
+      const preslog = createConsoleStructuredLog({ accountId: effectiveAccountId, source: "webhook" });
+      preslog.warn("account_disabled");
       return;
     }
   } catch (err) {
-    console.error("[basecamp:webhook] failed to resolve account:", err);
+    const errlog = createConsoleStructuredLog({ accountId: "unknown", source: "webhook" });
+    errlog.error("account_resolution_failed", { error: String(err), stack: err instanceof Error ? err.stack : undefined });
     return;
   }
+
+  const slog = createConsoleStructuredLog({ accountId: account.accountId, source: "webhook" });
 
   // Normalize
   let msg;
   try {
     msg = normalizeWebhookPayload(payload, account);
   } catch (err) {
-    console.error("[basecamp:webhook] normalization error:", err);
+    slog.error("normalization_error", { error: String(err), stack: err instanceof Error ? err.stack : undefined });
     return;
   }
 
@@ -241,11 +248,11 @@ export async function handleBasecampWebhook(
 
   // Check backpressure before processing
   if (dispatchSemaphore.pending >= MAX_QUEUED_DISPATCHES) {
-    console.error("[basecamp:webhook] dispatch queue full, dropping event");
+    slog.error("queue_full");
     return;
   }
   if (dispatchSemaphore.pending > 0) {
-    console.warn(`[basecamp:webhook] backpressure: ${dispatchSemaphore.pending} queued dispatches`);
+    slog.warn("backpressure", { queued: dispatchSemaphore.pending });
   }
 
   // Dispatch with concurrency limit
@@ -253,7 +260,7 @@ export async function handleBasecampWebhook(
   try {
     await dispatchBasecampEvent(msg, { account });
   } catch (err) {
-    console.error("[basecamp:webhook] dispatch error:", err);
+    slog.error("dispatch_error", { error: String(err), stack: err instanceof Error ? err.stack : undefined });
   } finally {
     dispatchSemaphore.release();
   }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,79 @@
+/**
+ * Structured logging for the Basecamp channel plugin.
+ *
+ * Wraps the SDK log object (or console) with a consistent prefix format:
+ *   [basecamp:${source}:${accountId}] ${event} ${JSON.stringify(detail)}
+ */
+
+export interface StructuredLog {
+  info(event: string, detail?: Record<string, unknown>): void;
+  warn(event: string, detail?: Record<string, unknown>): void;
+  error(event: string, detail?: Record<string, unknown>): void;
+  debug(event: string, detail?: Record<string, unknown>): void;
+}
+
+export type SdkLog = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+  debug?: (msg: string) => void;
+};
+
+function formatMessage(
+  prefix: string,
+  event: string,
+  detail?: Record<string, unknown>,
+): string {
+  return detail
+    ? `${prefix} ${event} ${JSON.stringify(detail)}`
+    : `${prefix} ${event}`;
+}
+
+/**
+ * Create a structured logger that delegates to the SDK log object.
+ * If sdkLog is undefined, all calls are no-ops.
+ */
+export function createStructuredLog(
+  sdkLog: SdkLog | undefined,
+  context: { accountId: string; source: string },
+): StructuredLog {
+  const prefix = `[basecamp:${context.source}:${context.accountId}]`;
+  return {
+    info(event, detail) {
+      sdkLog?.info(formatMessage(prefix, event, detail));
+    },
+    warn(event, detail) {
+      sdkLog?.warn(formatMessage(prefix, event, detail));
+    },
+    error(event, detail) {
+      sdkLog?.error(formatMessage(prefix, event, detail));
+    },
+    debug(event, detail) {
+      sdkLog?.debug?.(formatMessage(prefix, event, detail));
+    },
+  };
+}
+
+/**
+ * Create a structured logger that delegates to console methods.
+ * Useful in contexts where the SDK log object is not available (e.g. webhook handlers).
+ */
+export function createConsoleStructuredLog(
+  context: { accountId: string; source: string },
+): StructuredLog {
+  const prefix = `[basecamp:${context.source}:${context.accountId}]`;
+  return {
+    info(event, detail) {
+      console.info(formatMessage(prefix, event, detail));
+    },
+    warn(event, detail) {
+      console.warn(formatMessage(prefix, event, detail));
+    },
+    error(event, detail) {
+      console.error(formatMessage(prefix, event, detail));
+    },
+    debug(event, detail) {
+      console.debug(formatMessage(prefix, event, detail));
+    },
+  };
+}

--- a/tests/dispatch-enhanced.test.ts
+++ b/tests/dispatch-enhanced.test.ts
@@ -120,11 +120,11 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
 
     expect(log.error).toHaveBeenCalledTimes(1);
     const errorMsg = log.error.mock.calls[0][0];
-    expect(errorMsg).toContain("agent=agent-1");
-    expect(errorMsg).toContain("recording=123");
-    expect(errorMsg).toContain("event=created");
-    expect(errorMsg).toContain("sender=777");
-    expect(errorMsg).toContain("type=network");
+    expect(errorMsg).toContain('"agent":"agent-1"');
+    expect(errorMsg).toContain('"recording":"123"');
+    expect(errorMsg).toContain('"event":"created"');
+    expect(errorMsg).toContain('"sender":"777"');
+    expect(errorMsg).toContain('"type":"network"');
   });
 
   it("classifies auth errors correctly", async () => {
@@ -145,7 +145,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     onError(new Error("401 Unauthorized"));
 
     const errorMsg = log.error.mock.calls[0][0];
-    expect(errorMsg).toContain("type=auth");
+    expect(errorMsg).toContain('"type":"auth"');
   });
 
   it("classifies routing errors correctly", async () => {
@@ -166,7 +166,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     onError(new Error("no route matched"));
 
     const errorMsg = log.error.mock.calls[0][0];
-    expect(errorMsg).toContain("type=routing");
+    expect(errorMsg).toContain('"type":"routing"');
   });
 
   it("classifies unknown errors correctly", async () => {
@@ -187,7 +187,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     onError(new Error("something unexpected happened"));
 
     const errorMsg = log.error.mock.calls[0][0];
-    expect(errorMsg).toContain("type=unknown");
+    expect(errorMsg).toContain('"type":"unknown"');
   });
 
   it("classifies 403 Forbidden as auth", async () => {
@@ -195,7 +195,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
     const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     call.dispatcherOptions.onError(new Error("403 Forbidden"));
-    expect(log.error.mock.calls[0][0]).toContain("type=auth");
+    expect(log.error.mock.calls[0][0]).toContain('"type":"auth"');
   });
 
   it("classifies ECONNRESET as network", async () => {
@@ -203,7 +203,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
     const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     call.dispatcherOptions.onError(new Error("ECONNRESET"));
-    expect(log.error.mock.calls[0][0]).toContain("type=network");
+    expect(log.error.mock.calls[0][0]).toContain('"type":"network"');
   });
 
   it("classifies errors with structured status property as auth", async () => {
@@ -213,7 +213,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     const err = new Error("request failed") as any;
     err.status = 401;
     call.dispatcherOptions.onError(err);
-    expect(log.error.mock.calls[0][0]).toContain("type=auth");
+    expect(log.error.mock.calls[0][0]).toContain('"type":"auth"');
   });
 
   it("classifies HTTP 404 as unknown (not routing)", async () => {
@@ -221,6 +221,6 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
     const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     call.dispatcherOptions.onError(new Error("HTTP 404 Not Found"));
-    expect(log.error.mock.calls[0][0]).toContain("type=unknown");
+    expect(log.error.mock.calls[0][0]).toContain('"type":"unknown"');
   });
 });

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -139,13 +139,12 @@ describe("dispatch outbound reliability", () => {
 
     expect(logError).toHaveBeenCalledTimes(1);
     const logged = logError.mock.calls[0][0];
-    expect(logged).toContain("[basecamp:dispatch] failed");
-    expect(logged).toContain("agent=agent-1");
-    expect(logged).toContain("event=created");
-    expect(logged).toContain("recording=123");
-    expect(logged).toContain("account=test-acct");
-    expect(logged).toContain("sender=777");
-    expect(logged).toContain("type=network");
+    expect(logged).toContain("delivery_failed");
+    expect(logged).toContain('"agent":"agent-1"');
+    expect(logged).toContain('"event":"created"');
+    expect(logged).toContain('"recording":"123"');
+    expect(logged).toContain('"sender":"777"');
+    expect(logged).toContain('"type":"network"');
     expect(logged).toContain("ETIMEDOUT");
   });
 
@@ -160,7 +159,7 @@ describe("dispatch outbound reliability", () => {
         .calls[0][0];
     call.dispatcherOptions.onError(new Error("401 Unauthorized"));
 
-    expect(logError.mock.calls[0][0]).toContain("type=auth");
+    expect(logError.mock.calls[0][0]).toContain('"type":"auth"');
   });
 
   it("onError classifies unknown errors", async () => {
@@ -174,7 +173,7 @@ describe("dispatch outbound reliability", () => {
         .calls[0][0];
     call.dispatcherOptions.onError(new Error("something unexpected"));
 
-    expect(logError.mock.calls[0][0]).toContain("type=unknown");
+    expect(logError.mock.calls[0][0]).toContain('"type":"unknown"');
   });
 
   it("logs delivery confirmation after successful dispatch", async () => {
@@ -185,13 +184,12 @@ describe("dispatch outbound reliability", () => {
 
     // The delivery log should be the last info call
     const deliveryLog = logInfo.mock.calls.find((c: string[]) =>
-      c[0].includes("[basecamp:dispatch] delivered"),
+      c[0].includes("delivered"),
     );
     expect(deliveryLog).toBeDefined();
-    expect(deliveryLog![0]).toContain("agent=agent-1");
-    expect(deliveryLog![0]).toContain("event=created");
-    expect(deliveryLog![0]).toContain("account=test-acct");
-    expect(deliveryLog![0]).toContain("recording=123");
+    expect(deliveryLog![0]).toContain('"agent":"agent-1"');
+    expect(deliveryLog![0]).toContain('"event":"created"');
+    expect(deliveryLog![0]).toContain('"recording":"123"');
   });
 
   it("does not log 'delivered' when onError was called", async () => {
@@ -209,7 +207,7 @@ describe("dispatch outbound reliability", () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
     const deliveryLog = logInfo.mock.calls.find((c: string[]) =>
-      c[0].includes("[basecamp:dispatch] delivered"),
+      c[0].includes("delivered") && !c[0].includes("delivery_failed"),
     );
     expect(deliveryLog).toBeUndefined();
     expect(logError).toHaveBeenCalled();

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -194,7 +194,7 @@ describe("dispatchBasecampEvent", () => {
 
     expect(result).toBe(false);
     expect(log.error).toHaveBeenCalledTimes(1);
-    expect(log.error.mock.calls[0][0]).toContain("unable to resolve bcq account id");
+    expect(log.error.mock.calls[0][0]).toContain("outbound_account_id_missing");
     expect(
       mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
     ).not.toHaveBeenCalled();

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createStructuredLog, createConsoleStructuredLog } from "../src/logging.js";
+import type { SdkLog } from "../src/logging.js";
+
+describe("createStructuredLog", () => {
+  let sdkLog: SdkLog;
+
+  beforeEach(() => {
+    sdkLog = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+  });
+
+  it("formats info messages with prefix and event", () => {
+    const slog = createStructuredLog(sdkLog, { accountId: "123", source: "activity" });
+    slog.info("poll_dispatched");
+    expect(sdkLog.info).toHaveBeenCalledWith("[basecamp:activity:123] poll_dispatched");
+  });
+
+  it("includes JSON-stringified detail", () => {
+    const slog = createStructuredLog(sdkLog, { accountId: "456", source: "dispatch" });
+    slog.info("dispatching", { agent: "bot-1", peer: "campfire:99" });
+    expect(sdkLog.info).toHaveBeenCalledWith(
+      '[basecamp:dispatch:456] dispatching {"agent":"bot-1","peer":"campfire:99"}',
+    );
+  });
+
+  it("delegates warn to sdkLog.warn", () => {
+    const slog = createStructuredLog(sdkLog, { accountId: "7", source: "poller" });
+    slog.warn("cursor_save_failed", { error: "ENOENT" });
+    expect(sdkLog.warn).toHaveBeenCalledWith(
+      '[basecamp:poller:7] cursor_save_failed {"error":"ENOENT"}',
+    );
+  });
+
+  it("delegates error to sdkLog.error", () => {
+    const slog = createStructuredLog(sdkLog, { accountId: "8", source: "webhook" });
+    slog.error("normalization_error", { error: "bad payload" });
+    expect(sdkLog.error).toHaveBeenCalledWith(
+      '[basecamp:webhook:8] normalization_error {"error":"bad payload"}',
+    );
+  });
+
+  it("delegates debug to sdkLog.debug", () => {
+    const slog = createStructuredLog(sdkLog, { accountId: "9", source: "gateway" });
+    slog.debug("self_message_skipped", { personId: "42" });
+    expect(sdkLog.debug).toHaveBeenCalledWith(
+      '[basecamp:gateway:9] self_message_skipped {"personId":"42"}',
+    );
+  });
+
+  it("does not throw when sdkLog is undefined (no-op)", () => {
+    const slog = createStructuredLog(undefined, { accountId: "x", source: "test" });
+    expect(() => slog.info("event")).not.toThrow();
+    expect(() => slog.warn("event")).not.toThrow();
+    expect(() => slog.error("event")).not.toThrow();
+    expect(() => slog.debug("event")).not.toThrow();
+  });
+
+  it("does not throw when sdkLog.debug is undefined", () => {
+    const logNoDebug: SdkLog = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const slog = createStructuredLog(logNoDebug, { accountId: "x", source: "test" });
+    expect(() => slog.debug("event")).not.toThrow();
+  });
+
+  it("omits detail suffix when detail is undefined", () => {
+    const slog = createStructuredLog(sdkLog, { accountId: "1", source: "poller" });
+    slog.info("stopped");
+    expect(sdkLog.info).toHaveBeenCalledWith("[basecamp:poller:1] stopped");
+  });
+});
+
+describe("createConsoleStructuredLog", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("formats and delegates info to console.info", () => {
+    const slog = createConsoleStructuredLog({ accountId: "100", source: "webhook" });
+    slog.info("received", { kind: "todo_created" });
+    expect(console.info).toHaveBeenCalledWith(
+      '[basecamp:webhook:100] received {"kind":"todo_created"}',
+    );
+  });
+
+  it("formats and delegates warn to console.warn", () => {
+    const slog = createConsoleStructuredLog({ accountId: "200", source: "webhook" });
+    slog.warn("backpressure", { queued: 5 });
+    expect(console.warn).toHaveBeenCalledWith(
+      '[basecamp:webhook:200] backpressure {"queued":5}',
+    );
+  });
+
+  it("formats and delegates error to console.error", () => {
+    const slog = createConsoleStructuredLog({ accountId: "300", source: "webhook" });
+    slog.error("queue_full");
+    expect(console.error).toHaveBeenCalledWith("[basecamp:webhook:300] queue_full");
+  });
+
+  it("formats and delegates debug to console.debug", () => {
+    const slog = createConsoleStructuredLog({ accountId: "400", source: "webhook" });
+    slog.debug("dedup_hit");
+    expect(console.debug).toHaveBeenCalledWith("[basecamp:webhook:400] dedup_hit");
+  });
+});


### PR DESCRIPTION
## Summary
- Add \`createStructuredLog()\` and \`createConsoleStructuredLog()\` factories in new \`src/logging.ts\`
- Replace ad-hoc string concatenation in poller, dispatch, and webhook handler with structured format
- Every log line includes accountId, source, event name, and JSON detail object
- 12 new tests in \`tests/logging.test.ts\`; update existing dispatch test assertions

## Test plan
- [x] \`npx vitest run\` — 661 tests pass (all)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Structured logs visible in gateway output with consistent format