### PR TITLE
Operational metrics and status adapter enrichment

### DIFF
--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -13,6 +13,8 @@ import type { ResolvedBasecampAccount, BasecampChannelConfig, BasecampProject } 
 import { bcqAuthStatus, bcqMe, bcqApiGet } from "../bcq.js";
 import type { BcqOptions } from "../bcq.js";
 import { resolveBasecampAccount } from "../config.js";
+import { getAccountMetrics } from "../metrics.js";
+import type { AccountMetrics, PollerSourceMetrics } from "../metrics.js";
 
 export type BasecampProbe = {
   ok: boolean;
@@ -20,6 +22,8 @@ export type BasecampProbe = {
   personName?: string;
   accountCount?: number;
   error?: string;
+  /** Operational metrics snapshot (populated from in-memory metrics registry). */
+  metrics?: AccountMetrics;
 };
 
 export type BasecampAudit = {
@@ -27,7 +31,31 @@ export type BasecampAudit = {
   personasMapped: number;
   personasValid: number;
   errors: string[];
+  /** Poller lag per source (seconds since last successful poll, null if never polled). */
+  pollerLag?: {
+    activity: number | null;
+    readings: number | null;
+    assignments: number | null;
+  };
+  /** Circuit breaker states for outbound delivery. */
+  circuitBreakers?: Record<string, { state: string; failures: number }>;
+  /** Dedup store sizes. */
+  dedupSize?: number;
+  webhookDedupSize?: number;
+  /** Webhook handler stats. */
+  webhookStats?: {
+    received: number;
+    dispatched: number;
+    dropped: number;
+    errors: number;
+  };
 };
+
+/** Seconds since last successful poll, or null if never succeeded. */
+function pollerLagSeconds(source: PollerSourceMetrics): number | null {
+  if (!source.lastSuccessAt) return null;
+  return Math.round((Date.now() - source.lastSuccessAt) / 1000);
+}
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
   return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
@@ -54,7 +82,8 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
     try {
       const result = await bcqAuthStatus(bcqOpts);
       if (!result.data.authenticated) {
-        return { ok: false, authenticated: false };
+        const metrics = getAccountMetrics(account.accountId);
+        return { ok: false, authenticated: false, metrics };
       }
 
       // Also call bcqMe to get identity details
@@ -72,12 +101,15 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
         // Identity fetch is best-effort
       }
 
-      return { ok: true, authenticated: true, personName, accountCount };
+      const metrics = getAccountMetrics(account.accountId);
+      return { ok: true, authenticated: true, personName, accountCount, metrics };
     } catch (err) {
+      const metrics = getAccountMetrics(account.accountId);
       return {
         ok: false,
         authenticated: false,
         error: String(err),
+        metrics,
       };
     }
   },
@@ -121,7 +153,36 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
       }
     }
 
-    return { projectsAccessible, personasMapped, personasValid, errors };
+    // Enrich with operational metrics
+    const metrics = getAccountMetrics(account.accountId);
+    const result: BasecampAudit = { projectsAccessible, personasMapped, personasValid, errors };
+
+    if (metrics) {
+      result.pollerLag = {
+        activity: pollerLagSeconds(metrics.poller.activity),
+        readings: pollerLagSeconds(metrics.poller.readings),
+        assignments: pollerLagSeconds(metrics.poller.assignments),
+      };
+
+      if (Object.keys(metrics.circuitBreaker).length > 0) {
+        result.circuitBreakers = {};
+        for (const [key, cb] of Object.entries(metrics.circuitBreaker)) {
+          result.circuitBreakers[key] = { state: cb.state, failures: cb.failures };
+        }
+      }
+
+      result.dedupSize = metrics.dedupSize;
+      result.webhookDedupSize = metrics.webhookDedupSize;
+
+      result.webhookStats = {
+        received: metrics.webhook.receivedCount,
+        dispatched: metrics.webhook.dispatchedCount,
+        dropped: metrics.webhook.droppedCount,
+        errors: metrics.webhook.errorCount,
+      };
+    }
+
+    return result;
   },
 
   buildAccountSnapshot: ({ account, runtime, probe, audit }) => {
@@ -198,6 +259,36 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
           message: "Account is configured but has never started",
           fix: "Start the channel with `openclaw start` or check gateway logs",
         });
+      }
+
+      // Operational issues from audit metrics
+      const audit = s.audit as BasecampAudit | undefined;
+      if (audit?.pollerLag) {
+        const LAG_THRESHOLD_S = 600; // 10 minutes
+        for (const [source, lag] of Object.entries(audit.pollerLag)) {
+          if (lag !== null && lag > LAG_THRESHOLD_S) {
+            issues.push({
+              channel: "basecamp",
+              accountId: s.accountId,
+              kind: "runtime",
+              message: `Poller source "${source}" is lagging (${lag}s since last success)`,
+              fix: "Check gateway logs for errors or network issues",
+            });
+          }
+        }
+      }
+      if (audit?.circuitBreakers) {
+        for (const [key, cb] of Object.entries(audit.circuitBreakers)) {
+          if (cb.state === "open") {
+            issues.push({
+              channel: "basecamp",
+              accountId: s.accountId,
+              kind: "runtime",
+              message: `Circuit breaker "${key}" is open (${cb.failures} failures)`,
+              fix: "Check Basecamp API availability and authentication",
+            });
+          }
+        }
       }
     }
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -241,14 +241,16 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       // Share state directory with webhook handler for persistent dedup
       setWebhookStateDir(stateDir);
 
-      // Event handler: filter self-messages, then dispatch to OpenClaw agents
-      const onEvent = async (msg: BasecampInboundMessage) => {
+      // Event handler: filter self-messages, then dispatch to OpenClaw agents.
+      // Returns true if dispatched to an agent, false if dropped (no route,
+      // engagement gate, DM policy, etc.).
+      const onEvent = async (msg: BasecampInboundMessage): Promise<boolean> => {
         // Self-message filtering: skip events from our own service account
         if (msg.sender.id === account.personId) {
-          return;
+          return false;
         }
 
-        await dispatchBasecampEvent(msg, {
+        return dispatchBasecampEvent(msg, {
           account,
           log: ctx.log as any,
         });

--- a/src/inbound/activity.ts
+++ b/src/inbound/activity.ts
@@ -12,6 +12,7 @@ import type {
   BasecampInboundMessage,
   ResolvedBasecampAccount,
 } from "../types.js";
+import type { CircuitBreaker } from "../bcq.js";
 import { bcqTimeline } from "../bcq.js";
 import { normalizeActivityEvent } from "./normalize.js";
 
@@ -25,6 +26,8 @@ export interface ActivityPollerOptions {
   account: ResolvedBasecampAccount;
   /** Cursor — only process events created after this timestamp. */
   since?: string;
+  /** Circuit breaker for fail-fast on repeated API failures. */
+  circuitBreaker?: { instance: CircuitBreaker; key: string };
   log?: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -46,6 +49,7 @@ export async function pollActivityFeed(
   const result = await bcqTimeline<BasecampActivityEvent[]>({
     accountId: account.config.bcqAccountId,
     profile: account.bcqProfile,
+    circuitBreaker: opts.circuitBreaker,
   });
 
   const rawEvents = result.data;

--- a/src/inbound/assignments.ts
+++ b/src/inbound/assignments.ts
@@ -17,6 +17,7 @@ import type {
   BasecampInboundMessage,
   ResolvedBasecampAccount,
 } from "../types.js";
+import type { CircuitBreaker } from "../bcq.js";
 import { bcqAssignments } from "../bcq.js";
 import { normalizeAssignmentTodo } from "./normalize.js";
 
@@ -32,6 +33,8 @@ export interface AssignmentsPollerOptions {
   knownIds: Set<string>;
   /** True if this is the first poll (bootstrap — don't emit events). */
   isBootstrap: boolean;
+  /** Circuit breaker for fail-fast on repeated API failures. */
+  circuitBreaker?: { instance: CircuitBreaker; key: string };
   log?: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -95,6 +98,7 @@ export async function pollAssignments(
   const result = await bcqAssignments({
     accountId: account.config.bcqAccountId,
     profile: account.bcqProfile,
+    circuitBreaker: opts.circuitBreaker,
   });
 
   const todos = extractTodos(result.data);

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -18,22 +18,23 @@
  */
 
 import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../types.js";
-import { resolvePollingIntervals } from "../config.js";
+import { resolvePollingIntervals, resolveCircuitBreakerConfig } from "../config.js";
 import { EventDedup } from "./dedup.js";
 import { JsonFileDedupStore } from "./dedup-store.js";
 import { CursorStore } from "./cursors.js";
 import { pollActivityFeed } from "./activity.js";
 import { pollReadings } from "./readings.js";
 import { pollAssignments } from "./assignments.js";
-import { bcqMarkReadingsRead } from "../bcq.js";
+import { CircuitBreaker, bcqMarkReadingsRead } from "../bcq.js";
 import { isSelfMessage } from "./normalize.js";
 import { createStructuredLog } from "../logging.js";
+import { recordPollAttempt, recordPollSuccess, recordPollError, recordDedupSize, recordCircuitBreakerState } from "../metrics.js";
 
 export interface CompositePollerOptions {
   account: ResolvedBasecampAccount;
   cfg: unknown;
   abortSignal?: AbortSignal;
-  onEvent: (msg: BasecampInboundMessage) => Promise<void>;
+  onEvent: (msg: BasecampInboundMessage) => Promise<boolean>;
   log?: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -120,6 +121,26 @@ export async function startCompositePoller(
     slog.warn("cursors_load_failed", { error: String(err) });
   }
 
+  // Circuit breaker: fail fast when Basecamp API is persistently down.
+  // One CB instance per account; separate keys per polling source.
+  const cbConfig = resolveCircuitBreakerConfig(cfg as any);
+  const cb = new CircuitBreaker({ threshold: cbConfig.threshold, cooldownMs: cbConfig.cooldownMs });
+
+  /** Sync a circuit breaker key's state to the metrics registry. */
+  function syncCircuitBreakerMetrics(key: string): void {
+    const state = cb.getState(key);
+    if (!state) return;
+    let derived: "closed" | "open" | "half-open" = "closed";
+    if (state.trippedAt != null) {
+      derived = Date.now() - state.trippedAt >= cbConfig.cooldownMs ? "half-open" : "open";
+    }
+    recordCircuitBreakerState(account.accountId, key, {
+      state: derived,
+      failures: state.failures,
+      trippedAt: state.trippedAt,
+    });
+  }
+
   let activityBackoff = 0;
   let readingsBackoff = 0;
   let assignmentsBackoff = 0;
@@ -156,14 +177,17 @@ export async function startCompositePoller(
     // Poll activity feed
     if (activityDue) {
       lastActivityPoll = now;
+      recordPollAttempt(account.accountId, "activity");
       try {
         const result = await pollActivityFeed({
           account,
           since: cursors.get().activitySince,
+          circuitBreaker: { instance: cb, key: "activity" },
           log,
         });
 
         let dispatched = 0;
+        let dropped = 0;
         for (const event of result.events) {
           const secondaryKey = event.meta.recordingId
             ? EventDedup.secondaryKey(event.meta.recordingId, event.meta.eventKind, event.createdAt)
@@ -173,8 +197,12 @@ export async function startCompositePoller(
           if (isSelfMessage(event.sender.id, account)) continue;
 
           try {
-            await onEvent(event);
-            dispatched++;
+            const delivered = await onEvent(event);
+            if (delivered) {
+              dispatched++;
+            } else {
+              dropped++;
+            }
           } catch (err) {
             slog.error("dispatch_error", { feed: "activity", key: event.dedupKey, error: String(err) });
           }
@@ -185,10 +213,13 @@ export async function startCompositePoller(
           await saveCursorsWithRetry(cursors, slog);
         }
 
-        if (dispatched > 0) {
-          slog.info("poll_dispatched", { feed: "activity", total: result.events.length, dispatched });
+        if (dispatched > 0 || dropped > 0) {
+          slog.info("poll_dispatched", { feed: "activity", total: result.events.length, dispatched, dropped });
         }
 
+        recordPollSuccess(account.accountId, "activity", dispatched, dropped);
+        recordDedupSize(account.accountId, dedup.size);
+        syncCircuitBreakerMetrics("activity");
         activityBackoff = 0;
       } catch (err) {
         activityBackoff = clamp(
@@ -196,6 +227,8 @@ export async function startCompositePoller(
           activityIntervalMs,
           MAX_BACKOFF_MS,
         );
+        recordPollError(account.accountId, "activity", String(err), activityBackoff);
+        syncCircuitBreakerMetrics("activity");
         slog.error("poll_error", { feed: "activity", backoff: activityBackoff, error: String(err) });
       }
     }
@@ -203,14 +236,17 @@ export async function startCompositePoller(
     // Poll readings
     if (readingsDue) {
       lastReadingsPoll = now;
+      recordPollAttempt(account.accountId, "readings");
       try {
         const result = await pollReadings({
           account,
           since: cursors.get().readingsSince,
+          circuitBreaker: { instance: cb, key: "readings" },
           log,
         });
 
         let dispatched = 0;
+        let dropped = 0;
         for (const event of result.events) {
           const secondaryKey = event.meta.recordingId
             ? EventDedup.secondaryKey(event.meta.recordingId, event.meta.eventKind, event.createdAt)
@@ -220,8 +256,12 @@ export async function startCompositePoller(
           if (isSelfMessage(event.sender.id, account)) continue;
 
           try {
-            await onEvent(event);
-            dispatched++;
+            const delivered = await onEvent(event);
+            if (delivered) {
+              dispatched++;
+            } else {
+              dropped++;
+            }
           } catch (err) {
             slog.error("dispatch_error", { feed: "readings", key: event.dedupKey, error: String(err) });
           }
@@ -233,6 +273,7 @@ export async function startCompositePoller(
             await bcqMarkReadingsRead(result.processedSgids, {
               accountId: account.config.bcqAccountId,
               profile: account.bcqProfile,
+              circuitBreaker: { instance: cb, key: "readings:mark-read" },
             });
             slog.debug("readings_marked_read", { count: result.processedSgids.length });
           } catch (err) {
@@ -245,10 +286,13 @@ export async function startCompositePoller(
           await saveCursorsWithRetry(cursors, slog);
         }
 
-        if (dispatched > 0) {
-          slog.info("poll_dispatched", { feed: "readings", total: result.events.length, dispatched });
+        if (dispatched > 0 || dropped > 0) {
+          slog.info("poll_dispatched", { feed: "readings", total: result.events.length, dispatched, dropped });
         }
 
+        recordPollSuccess(account.accountId, "readings", dispatched, dropped);
+        recordDedupSize(account.accountId, dedup.size);
+        syncCircuitBreakerMetrics("readings");
         readingsBackoff = 0;
       } catch (err) {
         readingsBackoff = clamp(
@@ -256,6 +300,8 @@ export async function startCompositePoller(
           readingsIntervalMs,
           MAX_BACKOFF_MS,
         );
+        recordPollError(account.accountId, "readings", String(err), readingsBackoff);
+        syncCircuitBreakerMetrics("readings");
         slog.error("poll_error", { feed: "readings", backoff: readingsBackoff, error: String(err) });
       }
     }
@@ -264,22 +310,29 @@ export async function startCompositePoller(
     const assignmentsDue = now - lastAssignmentsPoll >= assignmentsIntervalMs + assignmentsBackoff;
     if (assignmentsDue) {
       lastAssignmentsPoll = now;
+      recordPollAttempt(account.accountId, "assignments");
       try {
         const result = await pollAssignments({
           account,
           knownIds: assignmentKnownIds,
           isBootstrap: !assignmentsBootstrapped,
+          circuitBreaker: { instance: cb, key: "assignments" },
           log,
         });
 
         let dispatched = 0;
+        let dropped = 0;
         for (const event of result.events) {
           if (dedup.isDuplicate(event.dedupKey)) continue;
           if (isSelfMessage(event.sender.id, account)) continue;
 
           try {
-            await onEvent(event);
-            dispatched++;
+            const delivered = await onEvent(event);
+            if (delivered) {
+              dispatched++;
+            } else {
+              dropped++;
+            }
           } catch (err) {
             slog.error("dispatch_error", { feed: "assignments", key: event.dedupKey, error: String(err) });
           }
@@ -291,10 +344,13 @@ export async function startCompositePoller(
         cursors.setCustom("assignmentIds", JSON.stringify([...result.knownIds]));
         await saveCursorsWithRetry(cursors, slog);
 
-        if (dispatched > 0) {
-          slog.info("poll_dispatched", { feed: "assignments", total: result.events.length, dispatched });
+        if (dispatched > 0 || dropped > 0) {
+          slog.info("poll_dispatched", { feed: "assignments", total: result.events.length, dispatched, dropped });
         }
 
+        recordPollSuccess(account.accountId, "assignments", dispatched, dropped);
+        recordDedupSize(account.accountId, dedup.size);
+        syncCircuitBreakerMetrics("assignments");
         assignmentsBackoff = 0;
       } catch (err) {
         assignmentsBackoff = clamp(
@@ -302,6 +358,8 @@ export async function startCompositePoller(
           assignmentsIntervalMs,
           MAX_BACKOFF_MS,
         );
+        recordPollError(account.accountId, "assignments", String(err), assignmentsBackoff);
+        syncCircuitBreakerMetrics("assignments");
         slog.error("poll_error", { feed: "assignments", backoff: assignmentsBackoff, error: String(err) });
       }
     }

--- a/src/inbound/readings.ts
+++ b/src/inbound/readings.ts
@@ -11,6 +11,7 @@ import type {
   BasecampReadingsEntry,
   ResolvedBasecampAccount,
 } from "../types.js";
+import type { CircuitBreaker } from "../bcq.js";
 import { bcqReadings as bcqReadingsCmd } from "../bcq.js";
 import { normalizeReadingsEvent } from "./normalize.js";
 
@@ -26,6 +27,8 @@ export interface ReadingsPollerOptions {
   account: ResolvedBasecampAccount;
   /** Initial cursor — only process readings newer than this. */
   since?: string;
+  /** Circuit breaker for fail-fast on repeated API failures. */
+  circuitBreaker?: { instance: CircuitBreaker; key: string };
   log?: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -51,6 +54,7 @@ export async function pollReadings(
   }>({
     accountId: account.config.bcqAccountId,
     profile: account.bcqProfile,
+    circuitBreaker: opts.circuitBreaker,
   });
 
   const unreads = result.data?.unreads;

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -20,6 +20,7 @@ import { dispatchBasecampEvent } from "../dispatch.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount, resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
 import { createConsoleStructuredLog } from "../logging.js";
+import { recordWebhookReceived, recordWebhookDispatched, recordWebhookDropped, recordWebhookError, recordWebhookDedupSize } from "../metrics.js";
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter
@@ -255,6 +256,7 @@ export async function handleBasecampWebhook(
   }
 
   const slog = createConsoleStructuredLog({ accountId: account.accountId, source: "webhook" });
+  recordWebhookReceived(account.accountId);
 
   // Normalize
   let msg;
@@ -262,11 +264,13 @@ export async function handleBasecampWebhook(
     msg = normalizeWebhookPayload(payload, account);
   } catch (err) {
     slog.error("normalization_error", { error: String(err), stack: err instanceof Error ? err.stack : undefined });
+    recordWebhookError(account.accountId);
     return;
   }
 
   // Self-message filter
   if (isSelfMessage(msg.sender.id, account)) {
+    recordWebhookDropped(account.accountId);
     return;
   }
 
@@ -276,12 +280,16 @@ export async function handleBasecampWebhook(
     ? EventDedup.secondaryKey(msg.meta.recordingId, msg.meta.eventKind, msg.createdAt)
     : undefined;
   if (dedup.isDuplicate(msg.dedupKey, secondaryKey)) {
+    recordWebhookDropped(account.accountId);
+    recordWebhookDedupSize(account.accountId, dedup.size);
     return;
   }
 
   // Check backpressure before processing
   if (dispatchSemaphore.pending >= MAX_QUEUED_DISPATCHES) {
     slog.error("queue_full");
+    recordWebhookDropped(account.accountId);
+    recordWebhookDedupSize(account.accountId, dedup.size);
     return;
   }
   if (dispatchSemaphore.pending > 0) {
@@ -291,10 +299,17 @@ export async function handleBasecampWebhook(
   // Dispatch with concurrency limit
   await dispatchSemaphore.acquire();
   try {
-    await dispatchBasecampEvent(msg, { account });
+    const delivered = await dispatchBasecampEvent(msg, { account });
+    if (delivered) {
+      recordWebhookDispatched(account.accountId);
+    } else {
+      recordWebhookDropped(account.accountId);
+    }
   } catch (err) {
     slog.error("dispatch_error", { error: String(err), stack: err instanceof Error ? err.stack : undefined });
+    recordWebhookError(account.accountId);
   } finally {
+    recordWebhookDedupSize(account.accountId, dedup.size);
     dispatchSemaphore.release();
   }
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,178 @@
+/**
+ * Operational metrics registry for the Basecamp channel plugin.
+ *
+ * Provides a shared in-memory metrics store that operational components
+ * (poller, webhooks, circuit breaker) write to and the status adapter reads from.
+ * All methods are synchronous — no I/O, no blocking.
+ */
+
+export interface PollerSourceMetrics {
+  lastPollAt: number | null;
+  lastSuccessAt: number | null;
+  lastErrorAt: number | null;
+  lastError: string | null;
+  currentBackoffMs: number;
+  pollCount: number;
+  errorCount: number;
+  dispatchCount: number;
+  droppedCount: number;
+}
+
+export interface WebhookMetrics {
+  receivedCount: number;
+  dispatchedCount: number;
+  droppedCount: number;
+  errorCount: number;
+  lastReceivedAt: number | null;
+}
+
+export interface CircuitBreakerMetrics {
+  state: "closed" | "open" | "half-open";
+  failures: number;
+  trippedAt: number | null;
+}
+
+export interface AccountMetrics {
+  poller: {
+    activity: PollerSourceMetrics;
+    readings: PollerSourceMetrics;
+    assignments: PollerSourceMetrics;
+  };
+  webhook: WebhookMetrics;
+  circuitBreaker: Record<string, CircuitBreakerMetrics>;
+  dedupSize: number;
+  webhookDedupSize: number;
+}
+
+function emptySourceMetrics(): PollerSourceMetrics {
+  return {
+    lastPollAt: null,
+    lastSuccessAt: null,
+    lastErrorAt: null,
+    lastError: null,
+    currentBackoffMs: 0,
+    pollCount: 0,
+    errorCount: 0,
+    dispatchCount: 0,
+    droppedCount: 0,
+  };
+}
+
+function emptyWebhookMetrics(): WebhookMetrics {
+  return {
+    receivedCount: 0,
+    dispatchedCount: 0,
+    droppedCount: 0,
+    errorCount: 0,
+    lastReceivedAt: null,
+  };
+}
+
+/** Per-account metrics store. */
+const metricsRegistry = new Map<string, AccountMetrics>();
+
+function getOrCreate(accountId: string): AccountMetrics {
+  let m = metricsRegistry.get(accountId);
+  if (!m) {
+    m = {
+      poller: {
+        activity: emptySourceMetrics(),
+        readings: emptySourceMetrics(),
+        assignments: emptySourceMetrics(),
+      },
+      webhook: emptyWebhookMetrics(),
+      circuitBreaker: {},
+      dedupSize: 0,
+      webhookDedupSize: 0,
+    };
+    metricsRegistry.set(accountId, m);
+  }
+  return m;
+}
+
+// ---------------------------------------------------------------------------
+// Writers — called by operational components
+// ---------------------------------------------------------------------------
+
+export type PollerSource = "activity" | "readings" | "assignments";
+
+export function recordPollAttempt(accountId: string, source: PollerSource): void {
+  const m = getOrCreate(accountId);
+  m.poller[source].lastPollAt = Date.now();
+  m.poller[source].pollCount++;
+}
+
+export function recordPollSuccess(accountId: string, source: PollerSource, dispatched: number, dropped?: number): void {
+  const m = getOrCreate(accountId);
+  m.poller[source].lastSuccessAt = Date.now();
+  m.poller[source].dispatchCount += dispatched;
+  if (dropped) m.poller[source].droppedCount += dropped;
+  m.poller[source].currentBackoffMs = 0;
+  m.poller[source].lastError = null;
+  m.poller[source].lastErrorAt = null;
+}
+
+export function recordPollError(accountId: string, source: PollerSource, error: string, backoffMs: number): void {
+  const m = getOrCreate(accountId);
+  m.poller[source].lastErrorAt = Date.now();
+  m.poller[source].lastError = error;
+  m.poller[source].currentBackoffMs = backoffMs;
+  m.poller[source].errorCount++;
+}
+
+export function recordWebhookReceived(accountId: string): void {
+  const m = getOrCreate(accountId);
+  m.webhook.receivedCount++;
+  m.webhook.lastReceivedAt = Date.now();
+}
+
+export function recordWebhookDispatched(accountId: string): void {
+  const m = getOrCreate(accountId);
+  m.webhook.dispatchedCount++;
+}
+
+export function recordWebhookDropped(accountId: string): void {
+  const m = getOrCreate(accountId);
+  m.webhook.droppedCount++;
+}
+
+export function recordWebhookError(accountId: string): void {
+  const m = getOrCreate(accountId);
+  m.webhook.errorCount++;
+}
+
+export function recordDedupSize(accountId: string, size: number): void {
+  const m = getOrCreate(accountId);
+  m.dedupSize = size;
+}
+
+export function recordWebhookDedupSize(accountId: string, size: number): void {
+  const m = getOrCreate(accountId);
+  m.webhookDedupSize = size;
+}
+
+export function recordCircuitBreakerState(
+  accountId: string,
+  key: string,
+  state: CircuitBreakerMetrics,
+): void {
+  const m = getOrCreate(accountId);
+  m.circuitBreaker[key] = state;
+}
+
+// ---------------------------------------------------------------------------
+// Reader — called by the status adapter
+// ---------------------------------------------------------------------------
+
+export function getAccountMetrics(accountId: string): AccountMetrics | undefined {
+  return metricsRegistry.get(accountId);
+}
+
+/** Clear metrics for an account. Used in tests. */
+export function clearMetrics(accountId?: string): void {
+  if (accountId) {
+    metricsRegistry.delete(accountId);
+  } else {
+    metricsRegistry.clear();
+  }
+}

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordPollAttempt,
+  recordPollSuccess,
+  recordPollError,
+  recordWebhookReceived,
+  recordWebhookDispatched,
+  recordWebhookDropped,
+  recordWebhookError,
+  recordDedupSize,
+  recordWebhookDedupSize,
+  recordCircuitBreakerState,
+  getAccountMetrics,
+  clearMetrics,
+} from "../src/metrics.js";
+
+beforeEach(() => {
+  clearMetrics();
+});
+
+describe("poller metrics", () => {
+  it("records poll attempt", () => {
+    recordPollAttempt("acct-1", "activity");
+
+    const m = getAccountMetrics("acct-1");
+    expect(m).toBeDefined();
+    expect(m!.poller.activity.pollCount).toBe(1);
+    expect(m!.poller.activity.lastPollAt).toBeTypeOf("number");
+  });
+
+  it("records poll success and clears error state", () => {
+    recordPollError("acct-1", "readings", "timeout", 5000);
+    recordPollSuccess("acct-1", "readings", 3);
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.poller.readings.lastSuccessAt).toBeTypeOf("number");
+    expect(m.poller.readings.dispatchCount).toBe(3);
+    expect(m.poller.readings.currentBackoffMs).toBe(0);
+    expect(m.poller.readings.lastError).toBeNull();
+    expect(m.poller.readings.lastErrorAt).toBeNull();
+  });
+
+  it("records poll error with backoff", () => {
+    recordPollError("acct-1", "assignments", "ECONNREFUSED", 60000);
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.poller.assignments.lastErrorAt).toBeTypeOf("number");
+    expect(m.poller.assignments.lastError).toBe("ECONNREFUSED");
+    expect(m.poller.assignments.currentBackoffMs).toBe(60000);
+    expect(m.poller.assignments.errorCount).toBe(1);
+  });
+
+  it("accumulates dispatch counts across successes", () => {
+    recordPollSuccess("acct-1", "activity", 2);
+    recordPollSuccess("acct-1", "activity", 5);
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.poller.activity.dispatchCount).toBe(7);
+  });
+
+  it("tracks dropped count separately from dispatched", () => {
+    recordPollSuccess("acct-1", "activity", 3, 2);
+    recordPollSuccess("acct-1", "activity", 1, 4);
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.poller.activity.dispatchCount).toBe(4);
+    expect(m.poller.activity.droppedCount).toBe(6);
+  });
+
+  it("omitting dropped parameter does not affect droppedCount", () => {
+    recordPollSuccess("acct-1", "readings", 5);
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.poller.readings.dispatchCount).toBe(5);
+    expect(m.poller.readings.droppedCount).toBe(0);
+  });
+
+  it("tracks separate sources independently", () => {
+    recordPollAttempt("acct-1", "activity");
+    recordPollAttempt("acct-1", "activity");
+    recordPollAttempt("acct-1", "readings");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.poller.activity.pollCount).toBe(2);
+    expect(m.poller.readings.pollCount).toBe(1);
+    expect(m.poller.assignments.pollCount).toBe(0);
+  });
+});
+
+describe("webhook metrics", () => {
+  it("records webhook received", () => {
+    recordWebhookReceived("acct-1");
+    recordWebhookReceived("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.webhook.receivedCount).toBe(2);
+    expect(m.webhook.lastReceivedAt).toBeTypeOf("number");
+  });
+
+  it("records webhook dispatched", () => {
+    recordWebhookDispatched("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.webhook.dispatchedCount).toBe(1);
+  });
+
+  it("records webhook dropped", () => {
+    recordWebhookDropped("acct-1");
+    recordWebhookDropped("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.webhook.droppedCount).toBe(2);
+  });
+
+  it("records webhook error", () => {
+    recordWebhookError("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.webhook.errorCount).toBe(1);
+  });
+});
+
+describe("dedup metrics", () => {
+  it("records poller dedup size", () => {
+    recordDedupSize("acct-1", 42);
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.dedupSize).toBe(42);
+  });
+
+  it("records webhook dedup size", () => {
+    recordWebhookDedupSize("acct-1", 17);
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.webhookDedupSize).toBe(17);
+  });
+});
+
+describe("circuit breaker metrics", () => {
+  it("records circuit breaker state", () => {
+    recordCircuitBreakerState("acct-1", "outbound", {
+      state: "open",
+      failures: 5,
+      trippedAt: Date.now(),
+    });
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.circuitBreaker["outbound"]).toBeDefined();
+    expect(m.circuitBreaker["outbound"]!.state).toBe("open");
+    expect(m.circuitBreaker["outbound"]!.failures).toBe(5);
+  });
+
+  it("updates circuit breaker state", () => {
+    recordCircuitBreakerState("acct-1", "outbound", {
+      state: "open",
+      failures: 5,
+      trippedAt: Date.now(),
+    });
+    recordCircuitBreakerState("acct-1", "outbound", {
+      state: "half-open",
+      failures: 5,
+      trippedAt: null,
+    });
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.circuitBreaker["outbound"]!.state).toBe("half-open");
+  });
+});
+
+describe("account isolation", () => {
+  it("tracks metrics per account", () => {
+    recordPollAttempt("acct-1", "activity");
+    recordPollAttempt("acct-2", "activity");
+    recordPollAttempt("acct-2", "activity");
+
+    expect(getAccountMetrics("acct-1")!.poller.activity.pollCount).toBe(1);
+    expect(getAccountMetrics("acct-2")!.poller.activity.pollCount).toBe(2);
+  });
+
+  it("returns undefined for unknown account", () => {
+    expect(getAccountMetrics("nonexistent")).toBeUndefined();
+  });
+});
+
+describe("clearMetrics", () => {
+  it("clears specific account", () => {
+    recordPollAttempt("acct-1", "activity");
+    recordPollAttempt("acct-2", "activity");
+
+    clearMetrics("acct-1");
+
+    expect(getAccountMetrics("acct-1")).toBeUndefined();
+    expect(getAccountMetrics("acct-2")).toBeDefined();
+  });
+
+  it("clears all accounts", () => {
+    recordPollAttempt("acct-1", "activity");
+    recordPollAttempt("acct-2", "activity");
+
+    clearMetrics();
+
+    expect(getAccountMetrics("acct-1")).toBeUndefined();
+    expect(getAccountMetrics("acct-2")).toBeUndefined();
+  });
+});

--- a/tests/poller-circuit-breaker.test.ts
+++ b/tests/poller-circuit-breaker.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Integration test: startCompositePoller → CircuitBreaker → metrics registry.
+ *
+ * Verifies the end-to-end wiring: poll functions receive a CircuitBreaker
+ * instance, failures update its internal state, and syncCircuitBreakerMetrics
+ * propagates that state to the metrics registry (read by the status adapter).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { BcqError } from "../src/bcq.js";
+import { getAccountMetrics, clearMetrics } from "../src/metrics.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks — intercept poll functions and config at the module boundary
+// ---------------------------------------------------------------------------
+
+vi.mock("../src/config.js", () => ({
+  resolvePollingIntervals: () => ({
+    activityIntervalMs: 50,
+    readingsIntervalMs: 50,
+    assignmentsIntervalMs: 50,
+  }),
+  resolveCircuitBreakerConfig: () => ({
+    threshold: 1,
+    cooldownMs: 60_000,
+  }),
+}));
+
+vi.mock("../src/logging.js", () => ({
+  createStructuredLog: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Track circuit breaker instances passed to poll functions
+let activityCbCapture: { instance: any; key: string } | undefined;
+let readingsCbCapture: { instance: any; key: string } | undefined;
+let assignmentsCbCapture: { instance: any; key: string } | undefined;
+
+vi.mock("../src/inbound/activity.js", () => ({
+  pollActivityFeed: vi.fn(async (opts: any) => {
+    activityCbCapture = opts.circuitBreaker;
+    if (opts.circuitBreaker) {
+      opts.circuitBreaker.instance.recordFailure(opts.circuitBreaker.key);
+    }
+    throw new BcqError("ETIMEDOUT", 1, "ETIMEDOUT", ["bcq", "timeline"]);
+  }),
+}));
+
+vi.mock("../src/inbound/readings.js", () => ({
+  pollReadings: vi.fn(async (opts: any) => {
+    readingsCbCapture = opts.circuitBreaker;
+    // Readings succeeds — verifies success path clears breaker state
+    if (opts.circuitBreaker) {
+      opts.circuitBreaker.instance.recordSuccess(opts.circuitBreaker.key);
+    }
+    return { events: [], newestAt: undefined, processedSgids: [] };
+  }),
+}));
+
+vi.mock("../src/inbound/assignments.js", () => ({
+  pollAssignments: vi.fn(async (opts: any) => {
+    assignmentsCbCapture = opts.circuitBreaker;
+    if (opts.circuitBreaker) {
+      opts.circuitBreaker.instance.recordFailure(opts.circuitBreaker.key);
+    }
+    throw new BcqError("ECONNREFUSED", 1, "ECONNREFUSED", ["bcq", "api", "get"]);
+  }),
+}));
+
+vi.mock("../src/bcq.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/bcq.js")>();
+  return {
+    ...actual,
+    bcqMarkReadingsRead: vi.fn(async () => ({ data: null, raw: "" })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe("startCompositePoller — circuit breaker integration", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    clearMetrics();
+    activityCbCapture = undefined;
+    readingsCbCapture = undefined;
+    assignmentsCbCapture = undefined;
+    tmpDir = await mkdtemp(join(tmpdir(), "poller-cb-"));
+  });
+
+  afterEach(async () => {
+    clearMetrics();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("propagates circuit breaker state to metrics registry after poll cycles", async () => {
+    const { startCompositePoller } = await import("../src/inbound/poller.js");
+
+    const ac = new AbortController();
+    const account = {
+      accountId: "test-cb",
+      personId: "99",
+      enabled: true,
+      token: "tok",
+      tokenSource: "inline" as const,
+      bcqProfile: undefined,
+      displayName: "Test",
+      config: { personId: "99", bcqAccountId: "12345" },
+    } as any;
+
+    // Run poller for ~300ms — enough for at least 1 poll cycle.
+    // Threshold is 1, so a single failure trips the breaker.
+    const pollerPromise = startCompositePoller({
+      account,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async () => true,
+      stateDir: tmpDir,
+      log: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    });
+
+    // Let the poller run for a few cycles
+    await new Promise((r) => setTimeout(r, 300));
+    ac.abort();
+    await pollerPromise;
+
+    // Verify circuit breaker instances were threaded through
+    expect(activityCbCapture).toBeDefined();
+    expect(activityCbCapture!.key).toBe("activity");
+    expect(readingsCbCapture).toBeDefined();
+    expect(readingsCbCapture!.key).toBe("readings");
+    expect(assignmentsCbCapture).toBeDefined();
+    expect(assignmentsCbCapture!.key).toBe("assignments");
+
+    // Verify metrics registry has circuit breaker state
+    const metrics = getAccountMetrics("test-cb");
+    expect(metrics).toBeDefined();
+
+    // Activity: 1+ failures with threshold 1 → should be "open"
+    const activityCb = metrics!.circuitBreaker["activity"];
+    expect(activityCb).toBeDefined();
+    expect(activityCb.state).toBe("open");
+    expect(activityCb.failures).toBeGreaterThanOrEqual(1);
+    expect(activityCb.trippedAt).toBeTypeOf("number");
+
+    // Readings: success path → should be "closed" (or not present if never failed)
+    // Since readings mock calls recordSuccess, the breaker key may not have state
+    // unless it previously failed. With a fresh breaker, getState returns undefined
+    // and syncCircuitBreakerMetrics returns early — so no entry is expected.
+    const readingsCb = metrics!.circuitBreaker["readings"];
+    if (readingsCb) {
+      expect(readingsCb.state).toBe("closed");
+      expect(readingsCb.failures).toBe(0);
+    }
+
+    // Assignments: 1+ failures → should be "open"
+    const assignmentsCb = metrics!.circuitBreaker["assignments"];
+    expect(assignmentsCb).toBeDefined();
+    expect(assignmentsCb.state).toBe("open");
+    expect(assignmentsCb.failures).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses separate breaker keys for readings fetch vs mark-read", async () => {
+    // Override readings mock to return events with SGIDs (triggers mark-read path)
+    const { pollReadings } = await import("../src/inbound/readings.js");
+    vi.mocked(pollReadings).mockImplementation(async (opts: any) => {
+      readingsCbCapture = opts.circuitBreaker;
+      return {
+        events: [],
+        newestAt: undefined,
+        processedSgids: ["sgid://bc3/Recording/1"],
+      };
+    });
+
+    const { bcqMarkReadingsRead } = await import("../src/bcq.js");
+    let markReadCbCapture: { instance: any; key: string } | undefined;
+    vi.mocked(bcqMarkReadingsRead).mockImplementation(async (_sgids: string[], opts: any) => {
+      markReadCbCapture = opts?.circuitBreaker;
+      return { data: null, raw: "" };
+    });
+
+    const { startCompositePoller } = await import("../src/inbound/poller.js");
+
+    const ac = new AbortController();
+    const account = {
+      accountId: "test-keys",
+      personId: "99",
+      enabled: true,
+      token: "tok",
+      tokenSource: "inline" as const,
+      config: { personId: "99", bcqAccountId: "12345" },
+    } as any;
+
+    const pollerPromise = startCompositePoller({
+      account,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async () => true,
+      stateDir: tmpDir,
+      log: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    ac.abort();
+    await pollerPromise;
+
+    // readings fetch key
+    expect(readingsCbCapture).toBeDefined();
+    expect(readingsCbCapture!.key).toBe("readings");
+
+    // mark-read key is separate
+    expect(markReadCbCapture).toBeDefined();
+    expect(markReadCbCapture!.key).toBe("readings:mark-read");
+
+    // They share the same CircuitBreaker instance but use different keys
+    expect(markReadCbCapture!.instance).toBe(readingsCbCapture!.instance);
+    expect(markReadCbCapture!.key).not.toBe(readingsCbCapture!.key);
+  });
+});

--- a/tests/status-enhanced.test.ts
+++ b/tests/status-enhanced.test.ts
@@ -19,10 +19,22 @@ vi.mock("../src/config.js", () => ({
 }));
 
 import { basecampStatusAdapter } from "../src/adapters/status.js";
-import type { BasecampProbe } from "../src/adapters/status.js";
+import type { BasecampProbe, BasecampAudit } from "../src/adapters/status.js";
 import { bcqAuthStatus, bcqMe, bcqApiGet } from "../src/bcq.js";
 import { resolveBasecampAccount } from "../src/config.js";
 import type { ResolvedBasecampAccount } from "../src/types.js";
+import {
+  recordPollAttempt,
+  recordPollSuccess,
+  recordWebhookReceived,
+  recordWebhookDispatched,
+  recordWebhookDropped,
+  recordWebhookError,
+  recordDedupSize,
+  recordWebhookDedupSize,
+  recordCircuitBreakerState,
+  clearMetrics,
+} from "../src/metrics.js";
 
 function cfg(basecamp?: Record<string, unknown>) {
   if (!basecamp) return {} as any;
@@ -41,6 +53,7 @@ const mockAccount: ResolvedBasecampAccount = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearMetrics();
   vi.mocked(resolveBasecampAccount).mockReturnValue(mockAccount);
 });
 
@@ -346,5 +359,259 @@ describe("buildAccountSnapshot (enhanced)", () => {
 
     expect(snapshot.personName).toBe("Jeremy");
     expect(snapshot.accountCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Operational metrics in probe
+// ---------------------------------------------------------------------------
+
+describe("probeAccount operational metrics", () => {
+  it("attaches metrics snapshot to probe when available", async () => {
+    vi.mocked(bcqAuthStatus).mockResolvedValue({
+      data: { authenticated: true },
+      raw: "",
+    });
+    vi.mocked(bcqMe).mockResolvedValue({
+      data: { name: "Jeremy", accounts: [{}] },
+      raw: "",
+    } as any);
+
+    // Seed some metrics for the test account
+    recordPollAttempt("test", "activity");
+    recordPollSuccess("test", "activity", 5);
+    recordWebhookReceived("test");
+
+    const probe = await basecampStatusAdapter.probeAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({}),
+    });
+
+    expect(probe.metrics).toBeDefined();
+    expect(probe.metrics!.poller.activity.pollCount).toBe(1);
+    expect(probe.metrics!.poller.activity.dispatchCount).toBe(5);
+    expect(probe.metrics!.webhook.receivedCount).toBe(1);
+  });
+
+  it("returns undefined metrics when no data recorded", async () => {
+    vi.mocked(bcqAuthStatus).mockResolvedValue({
+      data: { authenticated: true },
+      raw: "",
+    });
+    vi.mocked(bcqMe).mockResolvedValue({
+      data: { name: "Jeremy" },
+      raw: "",
+    } as any);
+
+    const probe = await basecampStatusAdapter.probeAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({}),
+    });
+
+    expect(probe.metrics).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Operational metrics in audit
+// ---------------------------------------------------------------------------
+
+describe("auditAccount operational metrics", () => {
+  it("includes poller lag in audit", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([]);
+
+    // Simulate successful polls with known timestamps
+    recordPollSuccess("test", "activity", 1);
+    recordPollSuccess("test", "readings", 2);
+    // assignments never polled — should be null
+
+    const audit = await basecampStatusAdapter.auditAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({ accounts: { test: { personId: "42" } } }),
+    });
+
+    expect(audit.pollerLag).toBeDefined();
+    // Activity and readings should have a lag >= 0 (just polled)
+    expect(audit.pollerLag!.activity).toBeTypeOf("number");
+    expect(audit.pollerLag!.activity).toBeGreaterThanOrEqual(0);
+    expect(audit.pollerLag!.readings).toBeTypeOf("number");
+    // Assignments never polled
+    expect(audit.pollerLag!.assignments).toBeNull();
+  });
+
+  it("includes webhook stats in audit", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([]);
+
+    recordWebhookReceived("test");
+    recordWebhookReceived("test");
+    recordWebhookDispatched("test");
+    recordWebhookDropped("test");
+    recordWebhookError("test");
+
+    const audit = await basecampStatusAdapter.auditAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({ accounts: { test: { personId: "42" } } }),
+    });
+
+    expect(audit.webhookStats).toEqual({
+      received: 2,
+      dispatched: 1,
+      dropped: 1,
+      errors: 1,
+    });
+  });
+
+  it("includes dedup sizes in audit", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([]);
+
+    recordDedupSize("test", 100);
+    recordWebhookDedupSize("test", 25);
+
+    const audit = await basecampStatusAdapter.auditAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({ accounts: { test: { personId: "42" } } }),
+    });
+
+    expect(audit.dedupSize).toBe(100);
+    expect(audit.webhookDedupSize).toBe(25);
+  });
+
+  it("includes circuit breaker state in audit", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([]);
+
+    recordCircuitBreakerState("test", "outbound", {
+      state: "open",
+      failures: 5,
+      trippedAt: Date.now(),
+    });
+
+    const audit = await basecampStatusAdapter.auditAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({ accounts: { test: { personId: "42" } } }),
+    });
+
+    expect(audit.circuitBreakers).toBeDefined();
+    expect(audit.circuitBreakers!["outbound"]).toEqual({
+      state: "open",
+      failures: 5,
+    });
+  });
+
+  it("omits circuit breakers when none recorded", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([]);
+
+    recordPollAttempt("test", "activity");
+
+    const audit = await basecampStatusAdapter.auditAccount!({
+      account: mockAccount,
+      timeoutMs: 5000,
+      cfg: cfg({ accounts: { test: { personId: "42" } } }),
+    });
+
+    expect(audit.circuitBreakers).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectStatusIssues — operational issues
+// ---------------------------------------------------------------------------
+
+describe("collectStatusIssues (operational)", () => {
+  it("flags lagging poller sources", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [],
+      pollerLag: {
+        activity: 700, // > 600s threshold
+        readings: 30,
+        assignments: null,
+      },
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const lagIssues = issues.filter((i) => i.message.includes("lagging"));
+    expect(lagIssues).toHaveLength(1);
+    expect(lagIssues[0]!.message).toContain("activity");
+    expect(lagIssues[0]!.message).toContain("700s");
+  });
+
+  it("flags open circuit breakers", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [],
+      circuitBreakers: {
+        outbound: { state: "open", failures: 5 },
+        "api-read": { state: "closed", failures: 0 },
+      },
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const cbIssues = issues.filter((i) => i.message.includes("Circuit breaker"));
+    expect(cbIssues).toHaveLength(1);
+    expect(cbIssues[0]!.message).toContain("outbound");
+    expect(cbIssues[0]!.message).toContain("5 failures");
+  });
+
+  it("does not flag closed circuit breakers or healthy pollers", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [],
+      pollerLag: { activity: 60, readings: 30, assignments: 120 },
+      circuitBreakers: { outbound: { state: "closed", failures: 0 } },
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    expect(issues).toHaveLength(0);
   });
 });

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -54,6 +54,7 @@ vi.mock("../src/inbound/normalize.js", () => ({
 import { Semaphore, handleBasecampWebhook, setWebhookStateDir, flushWebhookDedup } from "../src/inbound/webhooks.js";
 import { resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../src/config.js";
 import { dispatchBasecampEvent } from "../src/dispatch.js";
+import { getAccountMetrics, clearMetrics } from "../src/metrics.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -401,5 +402,111 @@ describe("webhook dedup persistence", () => {
     // Clean up temp directory
     const { rmSync } = await import("node:fs");
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Webhook metrics recording
+// ---------------------------------------------------------------------------
+
+describe("handleBasecampWebhook — metrics", () => {
+  beforeEach(async () => {
+    clearMetrics();
+    // Ensure resolveBasecampAccount returns the expected default mock
+    const { resolveBasecampAccount } = await import("../src/config.js");
+    vi.mocked(resolveBasecampAccount).mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      personId: "1",
+      token: "",
+      tokenSource: "none",
+      config: { personId: "1" },
+    } as any);
+  });
+
+  afterEach(() => {
+    clearMetrics();
+  });
+
+  it("records received and dispatched metrics on successful webhook", async () => {
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+    expect(res.status).toBe(200);
+
+    const metrics = getAccountMetrics("default");
+    expect(metrics).toBeDefined();
+    expect(metrics!.webhook.receivedCount).toBe(1);
+    expect(metrics!.webhook.dispatchedCount).toBe(1);
+    expect(metrics!.webhook.droppedCount).toBe(0);
+    expect(metrics!.webhook.errorCount).toBe(0);
+  });
+
+  it("records dropped metric when self-message is filtered", async () => {
+    const { isSelfMessage } = await import("../src/inbound/normalize.js");
+    vi.mocked(isSelfMessage).mockReturnValueOnce(true);
+
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    const metrics = getAccountMetrics("default");
+    expect(metrics).toBeDefined();
+    expect(metrics!.webhook.receivedCount).toBe(1);
+    expect(metrics!.webhook.droppedCount).toBe(1);
+    expect(metrics!.webhook.dispatchedCount).toBe(0);
+  });
+
+  it("records dropped metric when dispatch returns false (route miss / policy drop)", async () => {
+    vi.mocked(dispatchBasecampEvent).mockResolvedValueOnce(false);
+
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    const metrics = getAccountMetrics("default");
+    expect(metrics).toBeDefined();
+    expect(metrics!.webhook.receivedCount).toBe(1);
+    expect(metrics!.webhook.droppedCount).toBe(1);
+    expect(metrics!.webhook.dispatchedCount).toBe(0);
+    expect(metrics!.webhook.errorCount).toBe(0);
+  });
+
+  it("records error metric on dispatch failure", async () => {
+    vi.mocked(dispatchBasecampEvent).mockRejectedValueOnce(new Error("dispatch failed"));
+
+    const payload = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const req = mockReq("POST", "/webhooks/basecamp?token=test-secret-123", payload);
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    const metrics = getAccountMetrics("default");
+    expect(metrics).toBeDefined();
+    expect(metrics!.webhook.receivedCount).toBe(1);
+    expect(metrics!.webhook.errorCount).toBe(1);
+    expect(metrics!.webhook.dispatchedCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Wire operational metrics into poller, webhooks, and status adapter
- Fix dispatch metric inflation: `onEvent` contract changed from `Promise<void>` to `Promise<boolean>`, counting only true deliveries
- Wire circuit breaker into poller bcq calls with per-source keys (`activity`, `readings`, `assignments`, `readings:mark-read`)
- Status adapter surfaces poller lag, circuit breaker state, webhook stats, and dedup sizes in probe/audit

## Test plan

- 738 tests pass, types clean
- Regression tests for route-miss/policy-drop → dropped metric (not dispatched)
- Integration tests proving end-to-end CB wiring through poller → metrics registry
- Split breaker key test: readings fetch vs mark-read use separate keys