### PR TITLE
Agent tools expansion: move card, post message, answer check-in

### DIFF
--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -70,7 +70,7 @@ const AddBoostParams = Type.Object({
 const MoveCardParams = Type.Object({
   bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
   cardId: Type.String({ description: "Card recording ID to move" }),
-  columnId: Type.String({ description: "Target column ID to move the card to" }),
+  columnId: Type.Number({ description: "Target column ID to move the card to" }),
 });
 
 const PostMessageParams = Type.Object({
@@ -78,7 +78,7 @@ const PostMessageParams = Type.Object({
   messageBoardId: Type.String({ description: "Message board ID to post to" }),
   subject: Type.String({ description: "Message subject/title" }),
   content: Type.Optional(Type.String({ description: "Message body content (Basecamp HTML or plain text)" })),
-  categoryId: Type.Optional(Type.String({ description: "Message type/category ID" })),
+  categoryId: Type.Optional(Type.Number({ description: "Message type/category ID" })),
 });
 
 const AnswerCheckinParams = Type.Object({
@@ -216,8 +216,8 @@ async function executeMoveCard(
   const path = `/buckets/${bucketId}/card_tables/cards/${cardId}/moves.json`;
 
   try {
-    const result = await bcqPut<{ id?: number }>(path, {
-      extraFlags: ["-d", JSON.stringify({ column_id: Number(columnId) })],
+    await bcqPut(path, {
+      extraFlags: ["-d", JSON.stringify({ column_id: columnId })],
     });
     return {
       content: [{ type: "text" as const, text: JSON.stringify({ ok: true, cardId, columnId }) }],
@@ -245,7 +245,7 @@ async function executePostMessage(
   const path = `/buckets/${bucketId}/message_boards/${messageBoardId}/messages.json`;
   const body: Record<string, unknown> = { subject };
   if (content) body.content = content;
-  if (categoryId) body.category_id = Number(categoryId);
+  if (categoryId) body.category_id = categoryId;
 
   try {
     const result = await bcqApiPost<{ id?: number; subject?: string }>(

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -5,10 +5,13 @@
  * agents perform Basecamp-specific operations during response generation.
  *
  * Write tools:
- *   basecamp_create_todo   — Create a new to-do in a to-do list
- *   basecamp_complete_todo — Mark a to-do as complete
- *   basecamp_reopen_todo   — Mark a to-do as incomplete
- *   basecamp_add_boost     — Add a boost (reaction) to any recording
+ *   basecamp_create_todo    — Create a new to-do in a to-do list
+ *   basecamp_complete_todo  — Mark a to-do as complete
+ *   basecamp_reopen_todo    — Mark a to-do as incomplete
+ *   basecamp_add_boost      — Add a boost (reaction) to any recording
+ *   basecamp_move_card      — Move a card to a different column in a card table
+ *   basecamp_post_message   — Post a new message to a message board
+ *   basecamp_answer_checkin — Answer a check-in question
  *
  * Read tools:
  *   basecamp_read_history  — Fetch recent messages/comments for a recording
@@ -17,7 +20,7 @@
 import type { ChannelAgentTool } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
-import { bcqApiGet, bcqApiPost, bcqDelete } from "../bcq.js";
+import { bcqApiGet, bcqApiPost, bcqPut, bcqDelete } from "../bcq.js";
 import { basecampHtmlToPlainText } from "../outbound/format.js";
 
 // ---------------------------------------------------------------------------
@@ -62,6 +65,26 @@ const AddBoostParams = Type.Object({
   bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
   recordingId: Type.String({ description: "Recording ID to boost (any recording: comment, todo, campfire line, etc.)" }),
   content: Type.Optional(Type.String({ description: "Boost content — an emoji or short celebratory text (e.g., '👍', '🎉', 'Congrats!'). Defaults to '👍'." })),
+});
+
+const MoveCardParams = Type.Object({
+  bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
+  cardId: Type.String({ description: "Card recording ID to move" }),
+  columnId: Type.String({ description: "Target column ID to move the card to" }),
+});
+
+const PostMessageParams = Type.Object({
+  bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
+  messageBoardId: Type.String({ description: "Message board ID to post to" }),
+  subject: Type.String({ description: "Message subject/title" }),
+  content: Type.Optional(Type.String({ description: "Message body content (Basecamp HTML or plain text)" })),
+  categoryId: Type.Optional(Type.String({ description: "Message type/category ID" })),
+});
+
+const AnswerCheckinParams = Type.Object({
+  bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
+  questionId: Type.String({ description: "Check-in question ID to answer" }),
+  content: Type.String({ description: "Answer content (Basecamp HTML or plain text)" }),
 });
 
 // ---------------------------------------------------------------------------
@@ -180,6 +203,98 @@ async function executeAddBoost(
 }
 
 // ---------------------------------------------------------------------------
+// moveCard — move a card to a different column in a card table
+// ---------------------------------------------------------------------------
+
+type MoveCardInput = Static<typeof MoveCardParams>;
+
+async function executeMoveCard(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const { bucketId, cardId, columnId } = rawParams as MoveCardInput;
+  const path = `/buckets/${bucketId}/card_tables/cards/${cardId}/moves.json`;
+
+  try {
+    const result = await bcqPut<{ id?: number }>(path, {
+      extraFlags: ["-d", JSON.stringify({ column_id: Number(columnId) })],
+    });
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, cardId, columnId }) }],
+      details: { ok: true, cardId, columnId },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// postMessage — post a new message to a message board
+// ---------------------------------------------------------------------------
+
+type PostMessageInput = Static<typeof PostMessageParams>;
+
+async function executePostMessage(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const { bucketId, messageBoardId, subject, content, categoryId } = rawParams as PostMessageInput;
+  const path = `/buckets/${bucketId}/message_boards/${messageBoardId}/messages.json`;
+  const body: Record<string, unknown> = { subject };
+  if (content) body.content = content;
+  if (categoryId) body.category_id = Number(categoryId);
+
+  try {
+    const result = await bcqApiPost<{ id?: number; subject?: string }>(
+      path,
+      JSON.stringify(body),
+    );
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, messageId: result?.id, subject: result?.subject }) }],
+      details: { ok: true, messageId: result?.id },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// answerCheckin — answer a check-in question
+// ---------------------------------------------------------------------------
+
+type AnswerCheckinInput = Static<typeof AnswerCheckinParams>;
+
+async function executeAnswerCheckin(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const { bucketId, questionId, content } = rawParams as AnswerCheckinInput;
+  const path = `/buckets/${bucketId}/questions/${questionId}/answers.json`;
+
+  try {
+    const result = await bcqApiPost<{ id?: number }>(
+      path,
+      JSON.stringify({ content }),
+    );
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, answerId: result?.id }) }],
+      details: { ok: true, answerId: result?.id },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // readHistory — fetch recent messages/comments for context
 // ---------------------------------------------------------------------------
 
@@ -277,5 +392,33 @@ export const basecampAgentTools: ChannelAgentTool[] = [
       "Content can be an emoji or short celebratory text. Defaults to '👍' if not specified.",
     parameters: AddBoostParams,
     execute: executeAddBoost,
+  },
+  {
+    name: "basecamp_move_card",
+    label: "Move Basecamp Card",
+    description:
+      "Move a card to a different column in a Basecamp card table. " +
+      "Requires the project (bucket) ID, card recording ID, and target column ID.",
+    parameters: MoveCardParams,
+    execute: executeMoveCard,
+  },
+  {
+    name: "basecamp_post_message",
+    label: "Post Basecamp Message",
+    description:
+      "Post a new message to a Basecamp message board. " +
+      "Requires the project (bucket) ID, message board ID, and subject. " +
+      "Optionally include body content and a message category/type ID.",
+    parameters: PostMessageParams,
+    execute: executePostMessage,
+  },
+  {
+    name: "basecamp_answer_checkin",
+    label: "Answer Basecamp Check-in",
+    description:
+      "Answer a Basecamp check-in question. " +
+      "Requires the project (bucket) ID, question ID, and answer content.",
+    parameters: AnswerCheckinParams,
+    execute: executeAnswerCheckin,
   },
 ];

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../src/bcq.js", () => ({
   bcqApiGet: vi.fn(),
   bcqApiPost: vi.fn(),
+  bcqPut: vi.fn(),
   bcqDelete: vi.fn(),
 }));
 
@@ -11,7 +12,7 @@ vi.mock("../src/outbound/format.js", () => ({
 }));
 
 import { basecampAgentTools } from "../src/adapters/agent-tools.js";
-import { bcqApiGet, bcqApiPost, bcqDelete } from "../src/bcq.js";
+import { bcqApiGet, bcqApiPost, bcqPut, bcqDelete } from "../src/bcq.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -28,8 +29,8 @@ function findTool(name: string) {
 // ---------------------------------------------------------------------------
 
 describe("basecampAgentTools", () => {
-  it("exports five tools", () => {
-    expect(basecampAgentTools).toHaveLength(5);
+  it("exports eight tools", () => {
+    expect(basecampAgentTools).toHaveLength(8);
   });
 
   it("has correct tool names", () => {
@@ -40,6 +41,9 @@ describe("basecampAgentTools", () => {
       "basecamp_reopen_todo",
       "basecamp_read_history",
       "basecamp_add_boost",
+      "basecamp_move_card",
+      "basecamp_post_message",
+      "basecamp_answer_checkin",
     ]);
   });
 
@@ -431,6 +435,162 @@ describe("basecamp_add_boost", () => {
     const result = await tool.execute("call-20", {
       bucketId: "100",
       recordingId: "500",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("422 Unprocessable");
+    expect(result.details).toEqual({ ok: false, error: expect.stringContaining("422 Unprocessable") });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_move_card
+// ---------------------------------------------------------------------------
+
+describe("basecamp_move_card", () => {
+  const tool = findTool("basecamp_move_card");
+
+  it("moves a card to the target column", async () => {
+    vi.mocked(bcqPut).mockResolvedValue({ data: { id: 1 }, raw: "" });
+
+    const result = await tool.execute("call-21", {
+      bucketId: "100",
+      cardId: "600",
+      columnId: "700",
+    });
+
+    expect(bcqPut).toHaveBeenCalledWith(
+      "/buckets/100/card_tables/cards/600/moves.json",
+      { extraFlags: ["-d", JSON.stringify({ column_id: 700 })] },
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, cardId: "600", columnId: "700" });
+    expect(result.details).toEqual({ ok: true, cardId: "600", columnId: "700" });
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqPut).mockRejectedValue(new Error("404 Not Found"));
+
+    const result = await tool.execute("call-22", {
+      bucketId: "100",
+      cardId: "600",
+      columnId: "700",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("404 Not Found");
+    expect(result.details).toEqual({ ok: false, error: expect.stringContaining("404 Not Found") });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_post_message
+// ---------------------------------------------------------------------------
+
+describe("basecamp_post_message", () => {
+  const tool = findTool("basecamp_post_message");
+
+  it("posts a message with minimal params", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 800, subject: "Weekly Update" });
+
+    const result = await tool.execute("call-23", {
+      bucketId: "100",
+      messageBoardId: "200",
+      subject: "Weekly Update",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/message_boards/200/messages.json",
+      JSON.stringify({ subject: "Weekly Update" }),
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, messageId: 800, subject: "Weekly Update" });
+    expect(result.details).toEqual({ ok: true, messageId: 800 });
+  });
+
+  it("posts a message with content and category", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 801, subject: "Announcement" });
+
+    await tool.execute("call-24", {
+      bucketId: "100",
+      messageBoardId: "200",
+      subject: "Announcement",
+      content: "<p>Big news!</p>",
+      categoryId: "5",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/message_boards/200/messages.json",
+      JSON.stringify({ subject: "Announcement", content: "<p>Big news!</p>", category_id: 5 }),
+    );
+  });
+
+  it("omits optional fields when not provided", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 802 });
+
+    await tool.execute("call-25", {
+      bucketId: "100",
+      messageBoardId: "200",
+      subject: "Simple",
+    });
+
+    const bodyArg = vi.mocked(bcqApiPost).mock.calls[0]![1];
+    const body = JSON.parse(bodyArg!);
+    expect(body).toEqual({ subject: "Simple" });
+    expect(body).not.toHaveProperty("content");
+    expect(body).not.toHaveProperty("category_id");
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqApiPost).mockRejectedValue(new Error("403 Forbidden"));
+
+    const result = await tool.execute("call-26", {
+      bucketId: "100",
+      messageBoardId: "200",
+      subject: "Fail",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("403 Forbidden");
+    expect(result.details).toEqual({ ok: false, error: expect.stringContaining("403 Forbidden") });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_answer_checkin
+// ---------------------------------------------------------------------------
+
+describe("basecamp_answer_checkin", () => {
+  const tool = findTool("basecamp_answer_checkin");
+
+  it("answers a check-in question", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 900 });
+
+    const result = await tool.execute("call-27", {
+      bucketId: "100",
+      questionId: "300",
+      content: "Everything is on track!",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/questions/300/answers.json",
+      JSON.stringify({ content: "Everything is on track!" }),
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, answerId: 900 });
+    expect(result.details).toEqual({ ok: true, answerId: 900 });
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqApiPost).mockRejectedValue(new Error("422 Unprocessable"));
+
+    const result = await tool.execute("call-28", {
+      bucketId: "100",
+      questionId: "300",
+      content: "Fail",
     });
 
     const parsed = JSON.parse(result.content[0].text);

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -457,7 +457,7 @@ describe("basecamp_move_card", () => {
     const result = await tool.execute("call-21", {
       bucketId: "100",
       cardId: "600",
-      columnId: "700",
+      columnId: 700,
     });
 
     expect(bcqPut).toHaveBeenCalledWith(
@@ -465,8 +465,8 @@ describe("basecamp_move_card", () => {
       { extraFlags: ["-d", JSON.stringify({ column_id: 700 })] },
     );
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed).toEqual({ ok: true, cardId: "600", columnId: "700" });
-    expect(result.details).toEqual({ ok: true, cardId: "600", columnId: "700" });
+    expect(parsed).toEqual({ ok: true, cardId: "600", columnId: 700 });
+    expect(result.details).toEqual({ ok: true, cardId: "600", columnId: 700 });
   });
 
   it("returns error on API failure", async () => {
@@ -475,7 +475,7 @@ describe("basecamp_move_card", () => {
     const result = await tool.execute("call-22", {
       bucketId: "100",
       cardId: "600",
-      columnId: "700",
+      columnId: 700,
     });
 
     const parsed = JSON.parse(result.content[0].text);
@@ -518,7 +518,7 @@ describe("basecamp_post_message", () => {
       messageBoardId: "200",
       subject: "Announcement",
       content: "<p>Big news!</p>",
-      categoryId: "5",
+      categoryId: 5,
     });
 
     expect(bcqApiPost).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- **Move card** (`basecamp_move_card`): Move a card between columns in a card table via `PUT /buckets/{id}/card_tables/cards/{id}/moves.json`
- **Post message** (`basecamp_post_message`): Create new messages on message boards via `POST /buckets/{id}/message_boards/{id}/messages.json`
- **Answer check-in** (`basecamp_answer_checkin`): Respond to check-in questions via `POST /buckets/{id}/questions/{id}/answers.json`

Each tool includes bcq wrapper, TypeBox param schema, and tests. Builds on B1 (Boosts, PR #20) to round out agent workflow automation.

## Test plan
- [ ] `npx vitest run tests/agent-tools.test.ts` — all agent tool tests pass
- [ ] `npx tsc --noEmit` — types clean
- [ ] Verify each new tool appears in the agent tools array with correct schema