### PR TITLE
Outbound circuit breaker: fail fast on persistent API failures

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -186,7 +186,9 @@ export async function dispatchBasecampEvent(
   let dispatchHadError = false;
 
   // Outbound circuit breaker: fail fast when Basecamp API is persistently down.
-  const outboundCb = getOutboundCircuitBreaker(cfg, outboundAccount.accountId);
+  // Key by effective bcq account ID so virtual accounts sharing the same real
+  // Basecamp account share a single breaker instance.
+  const outboundCb = getOutboundCircuitBreaker(cfg, outboundBcqAccountId);
   const outboundCbKey = "outbound";
 
   await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
@@ -231,13 +233,13 @@ export async function dispatchBasecampEvent(
           type: errorType,
           error: String(err),
         });
-        syncOutboundCircuitBreakerMetrics(outboundCb, outboundCbKey, account.accountId, cfg);
+        syncOutboundCircuitBreakerMetrics(outboundCb, outboundCbKey, outboundBcqAccountId, cfg);
       },
     },
   });
 
   if (!dispatchHadError) {
-    syncOutboundCircuitBreakerMetrics(outboundCb, outboundCbKey, account.accountId, cfg);
+    syncOutboundCircuitBreakerMetrics(outboundCb, outboundCbKey, outboundBcqAccountId, cfg);
     slog.info("delivered", {
       agent: route.agentId,
       event: msg.meta.eventKind,

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -15,11 +15,26 @@ import type { BasecampInboundMessage, BasecampChannelConfig, BasecampEngagementT
 import { DEFAULT_ENGAGE } from "./types.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { getBasecampRuntime } from "./runtime.js";
-import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom } from "./config.js";
+import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom, resolveCircuitBreakerConfig } from "./config.js";
 import { postReplyToEvent } from "./outbound/send.js";
 import { markdownToBasecampHtml } from "./outbound/format.js";
 import { chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
 import { createStructuredLog } from "./logging.js";
+import { CircuitBreaker } from "./bcq.js";
+import { recordCircuitBreakerState } from "./metrics.js";
+
+/** Per-account outbound circuit breakers. Separate from poller CBs. */
+const outboundCircuitBreakers = new Map<string, CircuitBreaker>();
+
+function getOutboundCircuitBreaker(cfg: OpenClawConfig, accountId: string): CircuitBreaker {
+  let cb = outboundCircuitBreakers.get(accountId);
+  if (!cb) {
+    const cbConfig = resolveCircuitBreakerConfig(cfg);
+    cb = new CircuitBreaker({ threshold: cbConfig.threshold, cooldownMs: cbConfig.cooldownMs });
+    outboundCircuitBreakers.set(accountId, cb);
+  }
+  return cb;
+}
 
 export type DispatchOptions = {
   /** The resolved account that received this event. */
@@ -170,6 +185,10 @@ export async function dispatchBasecampEvent(
   // ----- Dispatch with buffered block dispatcher -----
   let dispatchHadError = false;
 
+  // Outbound circuit breaker: fail fast when Basecamp API is persistently down.
+  const outboundCb = getOutboundCircuitBreaker(cfg, outboundAccount.accountId);
+  const outboundCbKey = "outbound";
+
   await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
     ctx,
     cfg,
@@ -193,6 +212,7 @@ export async function dispatchBasecampEvent(
             accountId: outboundBcqAccountId,
             profile: outboundProfile,
             retries: 2,
+            circuitBreaker: { instance: outboundCb, key: outboundCbKey },
           });
 
           if (!result.ok) {
@@ -211,11 +231,13 @@ export async function dispatchBasecampEvent(
           type: errorType,
           error: String(err),
         });
+        syncOutboundCircuitBreakerMetrics(outboundCb, outboundCbKey, account.accountId, cfg);
       },
     },
   });
 
   if (!dispatchHadError) {
+    syncOutboundCircuitBreakerMetrics(outboundCb, outboundCbKey, account.accountId, cfg);
     slog.info("delivered", {
       agent: route.agentId,
       event: msg.meta.eventKind,
@@ -383,5 +405,28 @@ function buildUntrustedContext(msg: BasecampInboundMessage): string[] {
   }
 
   return lines;
+}
+
+/**
+ * Sync outbound circuit breaker state to the metrics registry.
+ */
+function syncOutboundCircuitBreakerMetrics(
+  cb: CircuitBreaker,
+  key: string,
+  accountId: string,
+  cfg: OpenClawConfig,
+): void {
+  const state = cb.getState(key);
+  if (!state) return;
+  const cbConfig = resolveCircuitBreakerConfig(cfg);
+  let derived: "closed" | "open" | "half-open" = "closed";
+  if (state.trippedAt != null) {
+    derived = Date.now() - state.trippedAt >= cbConfig.cooldownMs ? "half-open" : "open";
+  }
+  recordCircuitBreakerState(accountId, key, {
+    state: derived,
+    failures: state.failures,
+    trippedAt: state.trippedAt,
+  });
 }
 

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -9,7 +9,8 @@
  */
 
 import type { BasecampRecordableType } from "../types.js";
-import { bcqApiPost, withRetry, isRetryableError, BcqError, bcqResolvePingTranscript } from "../bcq.js";
+import { bcqPost, bcqApiPost, withRetry, isRetryableError, BcqError, bcqResolvePingTranscript } from "../bcq.js";
+import type { CircuitBreaker } from "../bcq.js";
 import { markdownToBasecampHtml } from "./format.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount } from "../config.js";
@@ -47,12 +48,15 @@ export async function postCampfireLine(params: {
   accountId?: string;
   profile?: string;
   retries?: number;
+  circuitBreaker?: { instance: CircuitBreaker; key: string };
 }): Promise<{ ok: boolean; recordingId?: string; retryable?: boolean; error?: string }> {
-  const { bucketId, transcriptId, content, accountId, profile, retries } = params;
+  const { bucketId, transcriptId, content, accountId, profile, retries, circuitBreaker } = params;
   const path = `/buckets/${bucketId}/chats/${transcriptId}/lines.json`;
   const body = JSON.stringify({ content });
 
-  const doPost = () => bcqApiPost(path, body, accountId, profile);
+  const doPost = () => circuitBreaker
+    ? bcqPost(path, { accountId, profile, extraFlags: ["-d", body], circuitBreaker }).then(r => r.data)
+    : bcqApiPost(path, body, accountId, profile);
 
   try {
     const result = retries && retries > 0
@@ -86,12 +90,15 @@ export async function postComment(params: {
   accountId?: string;
   profile?: string;
   retries?: number;
+  circuitBreaker?: { instance: CircuitBreaker; key: string };
 }): Promise<{ ok: boolean; commentId?: string; retryable?: boolean; error?: string }> {
-  const { bucketId, recordingId, content, accountId, profile, retries } = params;
+  const { bucketId, recordingId, content, accountId, profile, retries, circuitBreaker } = params;
   const path = `/buckets/${bucketId}/recordings/${recordingId}/comments.json`;
   const body = JSON.stringify({ content });
 
-  const doPost = () => bcqApiPost(path, body, accountId, profile);
+  const doPost = () => circuitBreaker
+    ? bcqPost(path, { accountId, profile, extraFlags: ["-d", body], circuitBreaker }).then(r => r.data)
+    : bcqApiPost(path, body, accountId, profile);
 
   try {
     const result = retries && retries > 0
@@ -143,8 +150,9 @@ export async function postReplyToEvent(params: {
   accountId?: string;
   profile?: string;
   retries?: number;
+  circuitBreaker?: { instance: CircuitBreaker; key: string };
 }): Promise<{ ok: boolean; messageId?: string; retryable?: boolean; error?: string }> {
-  const { bucketId, recordingId, recordableType, peerId, content, accountId, profile, retries } = params;
+  const { bucketId, recordingId, recordableType, peerId, content, accountId, profile, retries, circuitBreaker } = params;
   const parsed = parsePeerId(peerId);
 
   // Pings: resolve the transcript ID from the circle's bucket ID
@@ -160,6 +168,7 @@ export async function postReplyToEvent(params: {
       accountId,
       profile,
       retries,
+      circuitBreaker,
     });
     return { ok: result.ok, messageId: result.recordingId, retryable: result.retryable, error: result.error };
   }
@@ -183,6 +192,7 @@ export async function postReplyToEvent(params: {
       accountId,
       profile,
       retries,
+      circuitBreaker,
     });
     return { ok: result.ok, messageId: result.recordingId, retryable: result.retryable, error: result.error };
   }
@@ -196,6 +206,7 @@ export async function postReplyToEvent(params: {
     accountId,
     profile,
     retries,
+    circuitBreaker,
   });
   return { ok: result.ok, messageId: result.commentId, retryable: result.retryable, error: result.error };
 }

--- a/tests/dispatch-enhanced.test.ts
+++ b/tests/dispatch-enhanced.test.ts
@@ -17,6 +17,7 @@ vi.mock("../src/runtime.js", () => ({
 vi.mock("../src/config.js", () => ({
   resolvePersonaAccountId: vi.fn(),
   resolveBasecampAccount: vi.fn(),
+  resolveCircuitBreakerConfig: vi.fn(() => ({ threshold: 5, cooldownMs: 300000 })),
 }));
 vi.mock("../src/outbound/send.js", () => ({
   postReplyToEvent: vi.fn(),

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -21,6 +21,7 @@ vi.mock("../src/config.js", () => ({
   resolveBasecampAccount: vi.fn(),
   resolveBasecampDmPolicy: vi.fn(() => "open"),
   resolveBasecampAllowFrom: vi.fn(() => []),
+  resolveCircuitBreakerConfig: vi.fn(() => ({ threshold: 5, cooldownMs: 300000 })),
 }));
 vi.mock("../src/outbound/send.js", () => ({
   postReplyToEvent: vi.fn(),
@@ -319,5 +320,48 @@ describe("dispatch outbound reliability", () => {
         recordingId: "LINE_99",
       }),
     );
+  });
+
+  it("passes outbound circuit breaker to postReplyToEvent", async () => {
+    vi.mocked(postReplyToEvent).mockResolvedValue({ ok: true, messageId: "1" });
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+
+    const call =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
+        .calls[0][0];
+    const deliver = call.dispatcherOptions.deliver;
+    await deliver({ text: "CB test" }, {});
+
+    expect(postReplyToEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        circuitBreaker: expect.objectContaining({
+          key: "outbound",
+          instance: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  it("uses same circuit breaker key 'outbound' across multiple dispatches", async () => {
+    vi.mocked(postReplyToEvent).mockResolvedValue({ ok: true, messageId: "1" });
+
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+    await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+
+    const calls =
+      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls;
+    const deliver1 = calls[0][0].dispatcherOptions.deliver;
+    const deliver2 = calls[1][0].dispatcherOptions.deliver;
+    await deliver1({ text: "First" }, {});
+    await deliver2({ text: "Second" }, {});
+
+    // Both calls should use the same CB key
+    const call1Args = vi.mocked(postReplyToEvent).mock.calls[0][0] as any;
+    const call2Args = vi.mocked(postReplyToEvent).mock.calls[1][0] as any;
+    expect(call1Args.circuitBreaker.key).toBe("outbound");
+    expect(call2Args.circuitBreaker.key).toBe("outbound");
+    // Same CB instance (shared per account)
+    expect(call1Args.circuitBreaker.instance).toBe(call2Args.circuitBreaker.instance);
   });
 });

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -21,6 +21,7 @@ vi.mock("../src/config.js", () => ({
   resolveBasecampAccount: vi.fn(),
   resolveBasecampDmPolicy: vi.fn(() => "open"),
   resolveBasecampAllowFrom: vi.fn(() => []),
+  resolveCircuitBreakerConfig: vi.fn(() => ({ threshold: 5, cooldownMs: 300000 })),
 }));
 vi.mock("../src/outbound/send.js", () => ({
   postReplyToEvent: vi.fn(),
@@ -240,6 +241,7 @@ describe("dispatchBasecampEvent", () => {
       accountId: "12345",
       profile: undefined,
       retries: 2,
+      circuitBreaker: expect.objectContaining({ key: "outbound" }),
     });
   });
 

--- a/tests/outbound-retry.test.ts
+++ b/tests/outbound-retry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../src/bcq.js", () => ({
   bcqApiPost: vi.fn(),
+  bcqPost: vi.fn(),
   withRetry: vi.fn(),
   isRetryableError: vi.fn(),
   BcqError: class BcqError extends Error {
@@ -15,6 +16,14 @@ vi.mock("../src/bcq.js", () => ({
       this.name = "BcqError";
     }
   },
+  CircuitBreaker: class CircuitBreaker {
+    private _open = false;
+    isOpen() { return this._open; }
+    recordFailure() {}
+    recordSuccess() {}
+    getState() { return { failures: 0, trippedAt: null }; }
+    setOpen(v: boolean) { this._open = v; }
+  },
 }));
 vi.mock("../src/outbound/format.js", () => ({
   markdownToBasecampHtml: vi.fn((t: string) => t),
@@ -27,7 +36,7 @@ vi.mock("../src/config.js", () => ({
 }));
 
 import { postCampfireLine, postComment, postReplyToEvent } from "../src/outbound/send.js";
-import { bcqApiPost, withRetry, isRetryableError, BcqError } from "../src/bcq.js";
+import { bcqApiPost, bcqPost, withRetry, isRetryableError, BcqError, CircuitBreaker } from "../src/bcq.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -216,5 +225,68 @@ describe("postReplyToEvent", () => {
 
     expect(result.ok).toBe(false);
     expect(result.retryable).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Circuit breaker integration
+// ---------------------------------------------------------------------------
+
+describe("postCampfireLine with circuit breaker", () => {
+  it("uses bcqPost instead of bcqApiPost when circuitBreaker is provided", async () => {
+    const cb = new (CircuitBreaker as any)();
+    vi.mocked(bcqPost).mockResolvedValue({ data: { id: 100 }, raw: "" });
+
+    const result = await postCampfireLine({
+      bucketId: "1",
+      transcriptId: "2",
+      content: "Hello",
+      circuitBreaker: { instance: cb, key: "outbound" },
+    });
+
+    expect(result).toEqual({ ok: true, recordingId: "100" });
+    expect(bcqPost).toHaveBeenCalledTimes(1);
+    expect(bcqApiPost).not.toHaveBeenCalled();
+    expect(bcqPost).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        circuitBreaker: { instance: cb, key: "outbound" },
+      }),
+    );
+  });
+
+  it("returns error when bcqPost fails with circuit breaker", async () => {
+    const cb = new (CircuitBreaker as any)();
+    const err = new (BcqError as any)("Circuit breaker open", null, "", ["bcq"]);
+    vi.mocked(bcqPost).mockRejectedValue(err);
+    vi.mocked(isRetryableError).mockReturnValue(false);
+
+    const result = await postCampfireLine({
+      bucketId: "1",
+      transcriptId: "2",
+      content: "Hello",
+      circuitBreaker: { instance: cb, key: "outbound" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Circuit breaker open");
+  });
+});
+
+describe("postComment with circuit breaker", () => {
+  it("uses bcqPost instead of bcqApiPost when circuitBreaker is provided", async () => {
+    const cb = new (CircuitBreaker as any)();
+    vi.mocked(bcqPost).mockResolvedValue({ data: { id: 200 }, raw: "" });
+
+    const result = await postComment({
+      bucketId: "1",
+      recordingId: "2",
+      content: "A comment",
+      circuitBreaker: { instance: cb, key: "outbound" },
+    });
+
+    expect(result).toEqual({ ok: true, commentId: "200" });
+    expect(bcqPost).toHaveBeenCalledTimes(1);
+    expect(bcqApiPost).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Thread the existing circuit breaker into the outbound delivery path (`dispatch.ts` → `send.ts` → `bcqApiPost`)
- Separate breaker key `"outbound"` distinct from poll source keys
- When Basecamp API is persistently failing, outbound replies fail fast instead of queueing up and timing out
- CB state surfaced in operational metrics alongside poll source breakers

## Test plan
- [ ] `npx vitest run tests/dispatch*.test.ts` — dispatch tests pass with CB wiring
- [ ] `npx tsc --noEmit` — types clean
- [ ] Verify outbound CB trips after sustained failures and recovers after cooldown