### PR TITLE
Webhook infrastructure: HMAC verification, lifecycle management, hybrid inbound

### DIFF
--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -498,6 +498,71 @@ export async function bcqProfileList(opts: BcqOptions = {}): Promise<BcqResult<s
 }
 
 // ---------------------------------------------------------------------------
+// Webhook CRUD wrappers (bcq webhooks commands)
+// ---------------------------------------------------------------------------
+
+/** Shape returned by `bcq webhooks list` and `bcq webhooks create`. */
+export interface BcqWebhook {
+  id: number;
+  active: boolean;
+  payload_url: string;
+  types?: string[];
+  kinds?: string[];
+  /** Only returned on create. */
+  secret?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * List webhooks for a project.
+ * `bcq webhooks list --in <projectId> --json`
+ */
+export async function bcqWebhookList(
+  projectId: string,
+  opts: BcqOptions = {},
+): Promise<BcqResult<BcqWebhook[]>> {
+  const fn = () =>
+    execBcq<BcqWebhook[]>(["webhooks", "list", "--in", projectId], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
+}
+
+/**
+ * Create a webhook for a project.
+ * `bcq webhooks create --in <projectId> --url <url> [--types <types>]`
+ *
+ * IMPORTANT: The `secret` field is only returned in the create response.
+ * Callers must persist it immediately.
+ */
+export async function bcqWebhookCreate(
+  projectId: string,
+  payloadUrl: string,
+  types?: string[],
+  opts: BcqOptions = {},
+): Promise<BcqResult<BcqWebhook>> {
+  const args = ["webhooks", "create", "--in", projectId, "--url", payloadUrl];
+  if (types && types.length > 0) {
+    args.push("--types", types.join(","));
+  }
+  const fn = () => execBcq<BcqWebhook>(args, opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
+}
+
+/**
+ * Delete a webhook.
+ * `bcq webhooks delete <webhookId> --in <projectId>`
+ */
+export async function bcqWebhookDelete(
+  projectId: string,
+  webhookId: string | number,
+  opts: BcqOptions = {},
+): Promise<BcqResult<unknown>> {
+  const fn = () =>
+    execBcq(["webhooks", "delete", String(webhookId), "--in", projectId], opts);
+  return opts.retry ? withRetry(fn, opts.retry) : fn();
+}
+
+// ---------------------------------------------------------------------------
 // Interactive auth helpers (used by channel auth adapter)
 // ---------------------------------------------------------------------------
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -35,7 +35,7 @@ import { resolveOutboundTarget, chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } f
 import { basecampMentionAdapter } from "./adapters/mentions.js";
 import { basecampActionsAdapter } from "./adapters/actions.js";
 import { basecampAgentTools } from "./adapters/agent-tools.js";
-import { setWebhookStateDir, flushWebhookDedup } from "./inbound/webhooks.js";
+import { setWebhookStateDir, flushWebhookDedup, flushWebhookSecrets } from "./inbound/webhooks.js";
 
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   id: "basecamp",
@@ -282,8 +282,9 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           },
         });
       } finally {
-        // Flush webhook dedup stores before marking as stopped
+        // Flush webhook dedup + secret stores before marking as stopped
         flushWebhookDedup();
+        flushWebhookSecrets();
         ctx.setStatus({
           accountId: account.accountId,
           running: false,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -15,6 +15,7 @@ import {
   resolveBasecampAccountAsync,
   resolveDefaultBasecampAccountId,
   resolveBasecampAllowFrom,
+  resolveWebhooksConfig,
 } from "./config.js";
 import { getBasecampRuntime } from "./runtime.js";
 import { sendBasecampText } from "./outbound/send.js";
@@ -35,7 +36,8 @@ import { resolveOutboundTarget, chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } f
 import { basecampMentionAdapter } from "./adapters/mentions.js";
 import { basecampActionsAdapter } from "./adapters/actions.js";
 import { basecampAgentTools } from "./adapters/agent-tools.js";
-import { setWebhookStateDir, flushWebhookDedup, flushWebhookSecrets } from "./inbound/webhooks.js";
+import { setWebhookStateDir, flushWebhookDedup, flushWebhookSecrets, getWebhookSecretRegistry } from "./inbound/webhooks.js";
+import { reconcileWebhooks, deactivateWebhooks } from "./inbound/webhook-lifecycle.js";
 
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   id: "basecamp",
@@ -241,6 +243,36 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       // Share state directory with webhook handler for persistent dedup
       setWebhookStateDir(stateDir);
 
+      // Auto-register webhooks for configured projects
+      const whConfig = resolveWebhooksConfig(ctx.cfg);
+      if (whConfig.autoRegister && whConfig.payloadUrl && whConfig.projects.length > 0) {
+        const registry = getWebhookSecretRegistry(account.accountId);
+        try {
+          const result = await reconcileWebhooks(
+            {
+              payloadUrl: whConfig.payloadUrl,
+              projects: whConfig.projects,
+              types: whConfig.types,
+              bcqOpts: { accountId: account.config.bcqAccountId, profile: account.bcqProfile },
+            },
+            registry,
+            ctx.log ? {
+              info: (e, d) => ctx.log?.info?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+              warn: (e, d) => ctx.log?.warn?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+              error: (e, d) => ctx.log?.error?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+              debug: (e, d) => ctx.log?.debug?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+            } : undefined,
+          );
+          ctx.log?.info(
+            `[${account.accountId}] webhook reconciliation: ${result.created.length} created, ${result.existing.length} existing, ${result.failed.length} failed`,
+          );
+        } catch (err) {
+          ctx.log?.error(
+            `[${account.accountId}] webhook reconciliation failed: ${String(err)}`,
+          );
+        }
+      }
+
       // Event handler: filter self-messages, then dispatch to OpenClaw agents.
       // Returns true if dispatched to an agent, false if dropped (no route,
       // engagement gate, DM policy, etc.).
@@ -282,6 +314,33 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           },
         });
       } finally {
+        // Deactivate webhooks on shutdown if configured
+        const whShutdownConfig = resolveWebhooksConfig(ctx.cfg);
+        if (whShutdownConfig.deactivateOnStop && whShutdownConfig.payloadUrl && whShutdownConfig.projects.length > 0) {
+          const registry = getWebhookSecretRegistry(account.accountId);
+          try {
+            await deactivateWebhooks(
+              {
+                payloadUrl: whShutdownConfig.payloadUrl,
+                projects: whShutdownConfig.projects,
+                types: whShutdownConfig.types,
+                bcqOpts: { accountId: account.config.bcqAccountId, profile: account.bcqProfile },
+              },
+              registry,
+              ctx.log ? {
+                info: (e, d) => ctx.log?.info?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                warn: (e, d) => ctx.log?.warn?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                error: (e, d) => ctx.log?.error?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                debug: (e, d) => ctx.log?.debug?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+              } : undefined,
+            );
+          } catch (err) {
+            ctx.log?.error(
+              `[${account.accountId}] webhook deactivation failed: ${String(err)}`,
+            );
+          }
+        }
+
         // Flush webhook dedup + secret stores before marking as stopped
         flushWebhookDedup();
         flushWebhookSecrets();

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -209,6 +209,12 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         return;
       }
 
+      // Resolve the bcq numeric account ID for API calls.
+      // Prefers explicit bcqAccountId config, falls back to accountId only if numeric.
+      const bcqAccountId =
+        account.config.bcqAccountId ??
+        (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
+
       ctx.log?.info(
         `[${account.accountId}] starting Basecamp channel (person: ${account.personId})`,
       );
@@ -254,7 +260,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
               payloadUrl: whConfig.payloadUrl,
               projects: whConfig.projects,
               types: whConfig.types,
-              bcqOpts: { accountId: account.config.bcqAccountId, profile: account.bcqProfile },
+              bcqOpts: { accountId: bcqAccountId, profile: account.bcqProfile },
             },
             registry,
             ctx.log ? {
@@ -331,7 +337,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
                 payloadUrl: whShutdownConfig.payloadUrl,
                 projects: whShutdownConfig.projects,
                 types: whShutdownConfig.types,
-                bcqOpts: { accountId: account.config.bcqAccountId, profile: account.bcqProfile },
+                bcqOpts: { accountId: bcqAccountId, profile: account.bcqProfile },
               },
               registry,
               ctx.log ? {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -245,6 +245,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
 
       // Auto-register webhooks for configured projects
       const whConfig = resolveWebhooksConfig(ctx.cfg);
+      let webhookActiveProjects: Set<string> | undefined;
       if (whConfig.autoRegister && whConfig.payloadUrl && whConfig.projects.length > 0) {
         const registry = getWebhookSecretRegistry(account.accountId);
         try {
@@ -266,6 +267,11 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           ctx.log?.info(
             `[${account.accountId}] webhook reconciliation: ${result.created.length} created, ${result.existing.length} existing, ${result.failed.length} failed`,
           );
+          // Projects with active webhooks (created or already existing)
+          const active = [...result.created, ...result.existing];
+          if (active.length > 0) {
+            webhookActiveProjects = new Set(active);
+          }
         } catch (err) {
           ctx.log?.error(
             `[${account.accountId}] webhook reconciliation failed: ${String(err)}`,
@@ -306,6 +312,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           abortSignal: ctx.abortSignal,
           onEvent,
           stateDir,
+          webhookActiveProjects,
           log: {
             info: (msg) => ctx.log?.info?.(msg),
             warn: (msg) => ctx.log?.warn?.(msg),

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,16 @@ export const BasecampConfigSchema = z.object({
   engage: z.array(EngagementTypeSchema).optional(),
   /** Secret token for webhook URL verification. Required to accept webhook requests. */
   webhookSecret: z.string().optional(),
+  /** Webhook subscription management. */
+  webhooks: z
+    .object({
+      payloadUrl: z.string().url().optional(),
+      projects: z.array(z.string()).optional(),
+      types: z.array(z.string()).optional(),
+      autoRegister: z.boolean().optional(),
+      deactivateOnStop: z.boolean().optional(),
+    })
+    .optional(),
   polling: z
     .object({
       activityIntervalMs: z.number().positive().optional(),
@@ -325,6 +335,25 @@ export function resolveBasecampAllowFrom(cfg: OpenClawConfig): string[] {
 export function resolveWebhookSecret(cfg: OpenClawConfig): string | undefined {
   const section = getBasecampSection(cfg);
   return section?.webhookSecret;
+}
+
+/** Resolve webhook subscription config with defaults. */
+export function resolveWebhooksConfig(cfg: OpenClawConfig): {
+  payloadUrl?: string;
+  projects: string[];
+  types: string[];
+  autoRegister: boolean;
+  deactivateOnStop: boolean;
+} {
+  const section = getBasecampSection(cfg);
+  const wh = section?.webhooks;
+  return {
+    payloadUrl: wh?.payloadUrl,
+    projects: wh?.projects ?? [],
+    types: wh?.types ?? [],
+    autoRegister: wh?.autoRegister ?? true,
+    deactivateOnStop: wh?.deactivateOnStop ?? false,
+  };
 }
 
 /**

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -42,6 +42,10 @@ export interface CompositePollerOptions {
     error: (msg: string) => void;
   };
   stateDir?: string;
+  /** Projects with active webhook subscriptions. When non-empty, the activity
+   *  poll interval is extended (5x) since webhooks provide real-time delivery
+   *  and polling becomes a reconciliation mechanism. */
+  webhookActiveProjects?: Set<string>;
 }
 
 function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
@@ -87,7 +91,12 @@ export async function startCompositePoller(
   const slog = createStructuredLog(log, { accountId: account.accountId, source: "poller" });
 
   const intervals = resolvePollingIntervals(cfg);
-  const activityIntervalMs = intervals.activityIntervalMs;
+  const webhookActive = opts.webhookActiveProjects && opts.webhookActiveProjects.size > 0;
+  // When webhooks are active, activity polling becomes reconciliation — extend interval 5x
+  const WEBHOOK_RECONCILIATION_MULTIPLIER = 5;
+  const activityIntervalMs = webhookActive
+    ? intervals.activityIntervalMs * WEBHOOK_RECONCILIATION_MULTIPLIER
+    : intervals.activityIntervalMs;
   const readingsIntervalMs = intervals.readingsIntervalMs;
   const assignmentsIntervalMs = intervals.assignmentsIntervalMs;
 
@@ -167,7 +176,12 @@ export async function startCompositePoller(
     }
   }
 
-  slog.info("started", { activityMs: activityIntervalMs, readingsMs: readingsIntervalMs, assignmentsMs: assignmentsIntervalMs });
+  slog.info("started", {
+    activityMs: activityIntervalMs,
+    readingsMs: readingsIntervalMs,
+    assignmentsMs: assignmentsIntervalMs,
+    ...(webhookActive ? { mode: "reconciliation", webhookProjects: opts.webhookActiveProjects!.size } : { mode: "primary" }),
+  });
 
   while (!abortSignal?.aborted) {
     const now = Date.now();

--- a/src/inbound/webhook-lifecycle.ts
+++ b/src/inbound/webhook-lifecycle.ts
@@ -1,0 +1,171 @@
+/**
+ * Webhook subscription lifecycle management.
+ *
+ * Automatically registers webhooks for configured projects on gateway
+ * startup, reconciles existing subscriptions, and optionally deactivates
+ * on shutdown.
+ *
+ * Secrets from webhook creation are persisted via WebhookSecretRegistry
+ * so HMAC verification survives restarts.
+ */
+
+import type { BcqOptions, BcqWebhook } from "../bcq.js";
+import { bcqWebhookList, bcqWebhookCreate, bcqWebhookDelete } from "../bcq.js";
+import type { WebhookSecretRegistry } from "./webhook-secrets.js";
+import type { StructuredLog } from "../logging.js";
+
+export interface WebhookLifecycleConfig {
+  /** HTTPS URL where Basecamp sends webhook payloads. */
+  payloadUrl: string;
+  /** Bucket IDs to create webhooks for. */
+  projects: string[];
+  /** Recordable types to subscribe to. Empty = all types. */
+  types: string[];
+  /** bcq options for API calls (accountId, profile, etc). */
+  bcqOpts?: BcqOptions;
+}
+
+export interface ReconcileResult {
+  created: string[];
+  existing: string[];
+  failed: string[];
+}
+
+/**
+ * Reconcile webhook subscriptions for configured projects.
+ *
+ * For each project:
+ * 1. List existing webhooks
+ * 2. If a webhook with matching payloadUrl exists → skip (already registered)
+ * 3. If no match → create a new webhook and persist the secret
+ *
+ * Returns which projects were created, already existed, or failed.
+ */
+export async function reconcileWebhooks(
+  config: WebhookLifecycleConfig,
+  registry: WebhookSecretRegistry,
+  log?: StructuredLog,
+): Promise<ReconcileResult> {
+  const result: ReconcileResult = { created: [], existing: [], failed: [] };
+
+  for (const projectId of config.projects) {
+    try {
+      // List existing webhooks for this project
+      let existing: BcqWebhook[] = [];
+      try {
+        const listResult = await bcqWebhookList(projectId, config.bcqOpts ?? {});
+        existing = Array.isArray(listResult.data) ? listResult.data : [];
+      } catch {
+        // List failed — treat as empty (will attempt create)
+        existing = [];
+      }
+
+      // Check if a webhook with our payloadUrl already exists
+      const match = existing.find(
+        (wh) => wh.payload_url === config.payloadUrl && wh.active,
+      );
+
+      if (match) {
+        log?.debug("webhook_exists", {
+          project: projectId,
+          webhookId: match.id,
+        });
+
+        // If we don't have a secret stored for this project (e.g., first
+        // startup after manual webhook creation), record what we can.
+        // We can't recover the secret from the API — it's only returned on create.
+        if (!registry.get(projectId)) {
+          registry.set(projectId, {
+            webhookId: String(match.id),
+            secret: "", // Unknown — created before lifecycle management
+            payloadUrl: match.payload_url,
+            types: match.types ?? [],
+          });
+        }
+
+        result.existing.push(projectId);
+        continue;
+      }
+
+      // Create a new webhook
+      log?.info("webhook_creating", {
+        project: projectId,
+        url: config.payloadUrl,
+        types: config.types.length > 0 ? config.types.join(",") : "all",
+      });
+
+      const createResult = await bcqWebhookCreate(
+        projectId,
+        config.payloadUrl,
+        config.types.length > 0 ? config.types : undefined,
+        config.bcqOpts ?? {},
+      );
+
+      const webhook = createResult.data;
+      if (!webhook?.id) {
+        log?.error("webhook_create_failed", {
+          project: projectId,
+          error: "No webhook ID in response",
+        });
+        result.failed.push(projectId);
+        continue;
+      }
+
+      // Persist the secret — it's only returned on create
+      registry.set(projectId, {
+        webhookId: String(webhook.id),
+        secret: webhook.secret ?? "",
+        payloadUrl: webhook.payload_url ?? config.payloadUrl,
+        types: webhook.types ?? config.types,
+      });
+
+      log?.info("webhook_created", {
+        project: projectId,
+        webhookId: webhook.id,
+        hasSecret: Boolean(webhook.secret),
+      });
+
+      result.created.push(projectId);
+    } catch (err) {
+      log?.error("webhook_reconcile_failed", {
+        project: projectId,
+        error: String(err),
+      });
+      result.failed.push(projectId);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Deactivate webhooks for configured projects.
+ *
+ * Deletes webhooks that match our payloadUrl. Used on graceful shutdown
+ * when `webhooks.deactivateOnStop` is true.
+ */
+export async function deactivateWebhooks(
+  config: WebhookLifecycleConfig,
+  registry: WebhookSecretRegistry,
+  log?: StructuredLog,
+): Promise<void> {
+  for (const projectId of config.projects) {
+    const entry = registry.get(projectId);
+    if (!entry?.webhookId) continue;
+
+    try {
+      await bcqWebhookDelete(projectId, entry.webhookId, config.bcqOpts ?? {});
+      registry.remove(projectId);
+      log?.info("webhook_deactivated", {
+        project: projectId,
+        webhookId: entry.webhookId,
+      });
+    } catch (err) {
+      log?.error("webhook_deactivate_failed", {
+        project: projectId,
+        webhookId: entry.webhookId,
+        error: String(err),
+      });
+    }
+  }
+}

--- a/src/inbound/webhook-lifecycle.ts
+++ b/src/inbound/webhook-lifecycle.ts
@@ -25,6 +25,17 @@ export interface WebhookLifecycleConfig {
   bcqOpts?: BcqOptions;
 }
 
+/**
+ * Check whether a webhook's subscribed types match the desired types.
+ * Empty array means "all types" — two empty arrays match.
+ */
+function typesMatch(webhookTypes: string[] | undefined, configTypes: string[]): boolean {
+  const wt = (webhookTypes ?? []).slice().sort();
+  const ct = configTypes.slice().sort();
+  if (wt.length !== ct.length) return false;
+  return wt.every((t, i) => t === ct[i]);
+}
+
 export interface ReconcileResult {
   created: string[];
   existing: string[];
@@ -61,14 +72,14 @@ export async function reconcileWebhooks(
       }
 
       // Check if a webhook with our payloadUrl already exists
-      const match = existing.find(
+      const urlMatch = existing.find(
         (wh) => wh.payload_url === config.payloadUrl && wh.active,
       );
 
-      if (match) {
+      if (urlMatch && typesMatch(urlMatch.types, config.types)) {
         log?.debug("webhook_exists", {
           project: projectId,
-          webhookId: match.id,
+          webhookId: urlMatch.id,
         });
 
         // If we don't have a secret stored for this project (e.g., first
@@ -76,15 +87,35 @@ export async function reconcileWebhooks(
         // We can't recover the secret from the API — it's only returned on create.
         if (!registry.get(projectId)) {
           registry.set(projectId, {
-            webhookId: String(match.id),
+            webhookId: String(urlMatch.id),
             secret: "", // Unknown — created before lifecycle management
-            payloadUrl: match.payload_url,
-            types: match.types ?? [],
+            payloadUrl: urlMatch.payload_url,
+            types: urlMatch.types ?? [],
           });
         }
 
         result.existing.push(projectId);
         continue;
+      }
+
+      // URL matches but types differ — delete stale webhook before creating new one
+      if (urlMatch) {
+        log?.info("webhook_types_changed", {
+          project: projectId,
+          webhookId: urlMatch.id,
+          oldTypes: (urlMatch.types ?? []).join(",") || "all",
+          newTypes: config.types.length > 0 ? config.types.join(",") : "all",
+        });
+        try {
+          await bcqWebhookDelete(projectId, String(urlMatch.id), config.bcqOpts ?? {});
+          registry.remove(projectId);
+        } catch (delErr) {
+          log?.warn("webhook_stale_delete_failed", {
+            project: projectId,
+            webhookId: urlMatch.id,
+            error: String(delErr),
+          });
+        }
       }
 
       // Create a new webhook
@@ -152,6 +183,18 @@ export async function deactivateWebhooks(
   for (const projectId of config.projects) {
     const entry = registry.get(projectId);
     if (!entry?.webhookId) continue;
+
+    // Only delete webhooks that match our current payloadUrl to avoid
+    // accidentally removing webhooks from a different deployment.
+    if (entry.payloadUrl && entry.payloadUrl !== config.payloadUrl) {
+      log?.debug("webhook_deactivate_skipped", {
+        project: projectId,
+        reason: "payloadUrl mismatch",
+        registered: entry.payloadUrl,
+        configured: config.payloadUrl,
+      });
+      continue;
+    }
 
     try {
       await bcqWebhookDelete(projectId, entry.webhookId, config.bcqOpts ?? {});

--- a/src/inbound/webhook-secrets.ts
+++ b/src/inbound/webhook-secrets.ts
@@ -1,0 +1,129 @@
+/**
+ * Persistent webhook secret store.
+ *
+ * Basecamp returns webhook secrets only on creation. We must persist them
+ * so HMAC verification survives restarts. Each account gets its own store
+ * file: `webhook-secrets-{accountId}.json`.
+ *
+ * Format: { [projectId]: { webhookId, secret, payloadUrl, types } }
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface WebhookSecretEntry {
+  webhookId: string;
+  secret: string;
+  payloadUrl: string;
+  types: string[];
+}
+
+export type WebhookSecretSnapshot = Record<string, WebhookSecretEntry>;
+
+export interface WebhookSecretStore {
+  load(): WebhookSecretSnapshot;
+  save(snapshot: WebhookSecretSnapshot): void;
+}
+
+/**
+ * JSON file-backed webhook secret store.
+ *
+ * Atomic writes via temp+rename. Best-effort persistence — if the write
+ * fails, the in-memory state is still authoritative.
+ */
+export class JsonFileWebhookSecretStore implements WebhookSecretStore {
+  constructor(private readonly filePath: string) {}
+
+  load(): WebhookSecretSnapshot {
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw);
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        return data as WebhookSecretSnapshot;
+      }
+    } catch {
+      // File doesn't exist or is malformed — start fresh
+    }
+    return {};
+  }
+
+  save(snapshot: WebhookSecretSnapshot): void {
+    try {
+      const dir = dirname(this.filePath);
+      mkdirSync(dir, { recursive: true });
+      const tmp = join(dir, `.webhook-secrets-${Date.now()}.tmp`);
+      writeFileSync(tmp, JSON.stringify(snapshot, null, 2), "utf-8");
+      renameSync(tmp, this.filePath);
+    } catch {
+      // Best-effort persistence
+    }
+  }
+}
+
+/**
+ * In-memory webhook secret registry with optional persistent backing.
+ *
+ * - get(projectId) → secret string or undefined (for HMAC verification)
+ * - getAll() → full snapshot (for lifecycle reconciliation)
+ * - set(projectId, entry) → add/update, auto-saves
+ * - remove(projectId) → delete, auto-saves
+ * - getAllSecrets() → flat array of all secrets (for verification lookup)
+ */
+export class WebhookSecretRegistry {
+  private entries: WebhookSecretSnapshot;
+  private store?: WebhookSecretStore;
+
+  constructor(store?: WebhookSecretStore) {
+    this.store = store;
+    this.entries = store?.load() ?? {};
+  }
+
+  get(projectId: string): WebhookSecretEntry | undefined {
+    return this.entries[projectId];
+  }
+
+  getAll(): WebhookSecretSnapshot {
+    return { ...this.entries };
+  }
+
+  /**
+   * Find a secret by its value. Used for HMAC verification when we don't
+   * know which project a webhook payload came from yet.
+   */
+  findSecret(secret: string): WebhookSecretEntry | undefined {
+    for (const entry of Object.values(this.entries)) {
+      if (entry.secret === secret) return entry;
+    }
+    return undefined;
+  }
+
+  /**
+   * Get all unique secrets. Used to try each secret for HMAC verification
+   * when the incoming webhook doesn't identify which project it belongs to.
+   */
+  getAllSecrets(): string[] {
+    const secrets = new Set<string>();
+    for (const entry of Object.values(this.entries)) {
+      if (entry.secret) secrets.add(entry.secret);
+    }
+    return [...secrets];
+  }
+
+  set(projectId: string, entry: WebhookSecretEntry): void {
+    this.entries[projectId] = entry;
+    this.store?.save(this.entries);
+  }
+
+  remove(projectId: string): void {
+    delete this.entries[projectId];
+    this.store?.save(this.entries);
+  }
+
+  get size(): number {
+    return Object.keys(this.entries).length;
+  }
+
+  flush(): void {
+    this.store?.save(this.entries);
+  }
+}

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -11,11 +11,13 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import crypto from "node:crypto";
 import { join } from "node:path";
 import type { BasecampWebhookPayload, ResolvedBasecampAccount } from "../types.js";
 import { normalizeWebhookPayload, isSelfMessage } from "./normalize.js";
 import { EventDedup } from "./dedup.js";
 import { JsonFileDedupStore } from "./dedup-store.js";
+import { WebhookSecretRegistry, JsonFileWebhookSecretStore } from "./webhook-secrets.js";
 import { dispatchBasecampEvent } from "../dispatch.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount, resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
@@ -113,6 +115,84 @@ export function flushWebhookDedup(): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// HMAC-SHA256 verification (Stripe-style: X-Basecamp-Signature + Timestamp)
+// ---------------------------------------------------------------------------
+
+/** Per-account webhook secret registries. */
+const secretRegistries = new Map<string, WebhookSecretRegistry>();
+
+/**
+ * Get or create a webhook secret registry for an account.
+ * The registry is backed by a persistent JSON file when a state dir is set.
+ */
+export function getWebhookSecretRegistry(accountId: string): WebhookSecretRegistry {
+  let reg = secretRegistries.get(accountId);
+  if (!reg) {
+    const store = webhookStateDir
+      ? new JsonFileWebhookSecretStore(join(webhookStateDir, `webhook-secrets-${accountId}.json`))
+      : undefined;
+    reg = new WebhookSecretRegistry(store);
+    secretRegistries.set(accountId, reg);
+  }
+  return reg;
+}
+
+/** Maximum age (in seconds) for timestamp replay protection. Default: 5 minutes. */
+const MAX_TIMESTAMP_AGE_S = 300;
+
+/**
+ * Verify a Basecamp webhook HMAC-SHA256 signature.
+ *
+ * Protocol (Stripe-style):
+ *   signed_payload = "{timestamp}.{body}"
+ *   expected = "sha256=" + HMAC-SHA256(secret, signed_payload).hex()
+ *
+ * Returns true if the signature is valid for any of the provided secrets.
+ */
+export function verifyWebhookSignature(params: {
+  signature: string;
+  timestamp: string;
+  rawBody: string;
+  secrets: string[];
+}): boolean {
+  const { signature, timestamp, rawBody, secrets } = params;
+  if (!signature || !timestamp || secrets.length === 0) return false;
+
+  // Replay protection: reject if timestamp is too old
+  const ts = parseInt(timestamp, 10);
+  if (isNaN(ts)) return false;
+  const age = Math.abs(Math.floor(Date.now() / 1000) - ts);
+  if (age > MAX_TIMESTAMP_AGE_S) return false;
+
+  const signedPayload = `${timestamp}.${rawBody}`;
+
+  for (const secret of secrets) {
+    const expected = "sha256=" + crypto
+      .createHmac("sha256", secret)
+      .update(signedPayload)
+      .digest("hex");
+
+    // Timing-safe comparison
+    if (expected.length === signature.length) {
+      const a = Buffer.from(expected);
+      const b = Buffer.from(signature);
+      if (crypto.timingSafeEqual(a, b)) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Flush all webhook secret registries to disk. Call on graceful shutdown.
+ */
+export function flushWebhookSecrets(): void {
+  for (const reg of secretRegistries.values()) {
+    reg.flush();
+  }
+}
+
 /** Maximum allowed webhook request body size (1 MiB). */
 const MAX_WEBHOOK_BODY_BYTES = 1 * 1024 * 1024;
 
@@ -169,9 +249,7 @@ export async function handleBasecampWebhook(
     return;
   }
 
-  // ----- Webhook secret verification -----
-  // Reject requests when no webhookSecret is configured (disabled by default)
-  // or when the provided token doesn't match.
+  // ----- Load config -----
   let cfg;
   try {
     const runtime = getBasecampRuntime();
@@ -183,27 +261,70 @@ export async function handleBasecampWebhook(
     return;
   }
 
+  // ----- Read body first (needed for both HMAC and JSON parsing) -----
+  let rawBody: string;
+  try {
+    rawBody = await readBody(req);
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid request body" }));
+    return;
+  }
+
+  // ----- Authentication -----
+  // Try HMAC signature verification first (X-Basecamp-Signature header),
+  // then fall back to query-string token (?token=<secret>).
+  // At least one method must be configured and pass.
+  const hmacSignature = req.headers["x-basecamp-signature"] as string | undefined;
+  const hmacTimestamp = req.headers["x-basecamp-timestamp"] as string | undefined;
   const webhookSecret = resolveWebhookSecret(cfg);
-  if (!webhookSecret) {
-    res.writeHead(403, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Webhooks not configured (set channels.basecamp.webhookSecret)" }));
+
+  let authenticated = false;
+
+  if (hmacSignature && hmacTimestamp) {
+    // HMAC path: collect all known secrets from registered webhooks
+    const allSecrets: string[] = [];
+    for (const reg of secretRegistries.values()) {
+      allSecrets.push(...reg.getAllSecrets());
+    }
+    if (allSecrets.length > 0) {
+      authenticated = verifyWebhookSignature({
+        signature: hmacSignature,
+        timestamp: hmacTimestamp,
+        rawBody,
+        secrets: allSecrets,
+      });
+    }
+  }
+
+  if (!authenticated) {
+    // Query-string token fallback
+    if (webhookSecret) {
+      const urlObj = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+      const providedToken = urlObj.searchParams.get("token");
+      if (providedToken && providedToken === webhookSecret) {
+        authenticated = true;
+      }
+    }
+  }
+
+  if (!authenticated) {
+    // No valid authentication — check if webhooks are configured at all
+    const hasAnySecrets = [...secretRegistries.values()].some(r => r.size > 0);
+    if (!webhookSecret && !hasAnySecrets) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Webhooks not configured (set channels.basecamp.webhookSecret or configure webhooks.payloadUrl)" }));
+    } else {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Invalid webhook signature or token" }));
+    }
     return;
   }
 
-  // Check token from query string: /webhooks/basecamp?token=<secret>
-  const urlObj = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
-  const providedToken = urlObj.searchParams.get("token");
-  if (!providedToken || providedToken !== webhookSecret) {
-    res.writeHead(403, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Invalid webhook token" }));
-    return;
-  }
-
-  // Read and parse body
+  // ----- Parse body -----
   let payload: BasecampWebhookPayload;
   try {
-    const body = await readBody(req);
-    payload = JSON.parse(body) as BasecampWebhookPayload;
+    payload = JSON.parse(rawBody) as BasecampWebhookPayload;
   } catch {
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Invalid JSON body" }));

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -119,23 +119,34 @@ export function flushWebhookDedup(): void {
 // HMAC-SHA256 verification (Stripe-style: X-Basecamp-Signature + Timestamp)
 // ---------------------------------------------------------------------------
 
-/** Per-account webhook secret registries. */
-const secretRegistries = new Map<string, WebhookSecretRegistry>();
+/** Per-account webhook secret registries, keyed by account and bound to a state dir. */
+const secretRegistries = new Map<string, { registry: WebhookSecretRegistry; stateDir: string | undefined }>();
 
 /**
  * Get or create a webhook secret registry for an account.
  * The registry is backed by a persistent JSON file when a state dir is set.
+ * If the state dir has changed since the registry was created, the old one
+ * is flushed and a new one is created for the new path.
  */
 export function getWebhookSecretRegistry(accountId: string): WebhookSecretRegistry {
-  let reg = secretRegistries.get(accountId);
-  if (!reg) {
-    const store = webhookStateDir
-      ? new JsonFileWebhookSecretStore(join(webhookStateDir, `webhook-secrets-${accountId}.json`))
-      : undefined;
-    reg = new WebhookSecretRegistry(store);
-    secretRegistries.set(accountId, reg);
+  const currentStateDir = webhookStateDir;
+  const entry = secretRegistries.get(accountId);
+
+  if (entry && entry.stateDir === currentStateDir) {
+    return entry.registry;
   }
-  return reg;
+
+  // State dir changed or first access — flush old registry if present
+  if (entry) {
+    entry.registry.flush();
+  }
+
+  const store = currentStateDir
+    ? new JsonFileWebhookSecretStore(join(currentStateDir, `webhook-secrets-${accountId}.json`))
+    : undefined;
+  const registry = new WebhookSecretRegistry(store);
+  secretRegistries.set(accountId, { registry, stateDir: currentStateDir });
+  return registry;
 }
 
 /** Maximum age (in seconds) for timestamp replay protection. Default: 5 minutes. */
@@ -188,8 +199,8 @@ export function verifyWebhookSignature(params: {
  * Flush all webhook secret registries to disk. Call on graceful shutdown.
  */
 export function flushWebhookSecrets(): void {
-  for (const reg of secretRegistries.values()) {
-    reg.flush();
+  for (const { registry } of secretRegistries.values()) {
+    registry.flush();
   }
 }
 
@@ -282,17 +293,40 @@ export async function handleBasecampWebhook(
   let authenticated = false;
 
   if (hmacSignature && hmacTimestamp) {
-    // HMAC path: collect all known secrets from registered webhooks
-    const allSecrets: string[] = [];
-    for (const reg of secretRegistries.values()) {
-      allSecrets.push(...reg.getAllSecrets());
+    // HMAC path: scope verification to the specific bucket/account when possible.
+    // Parse the payload first to extract bucketId, then use only the secrets
+    // for the account that owns that bucket. Falls back to all secrets if
+    // bucket resolution fails.
+    let candidateSecrets: string[] = [];
+    try {
+      const parsed = JSON.parse(rawBody) as { recording?: { bucket?: { id?: number } } };
+      const bucketId = parsed?.recording?.bucket?.id;
+      if (bucketId != null) {
+        const bucketAccountId = resolveAccountForBucket(cfg, String(bucketId));
+        if (bucketAccountId) {
+          const entry = secretRegistries.get(bucketAccountId);
+          if (entry) {
+            candidateSecrets = entry.registry.getAllSecrets().filter(s => s.length > 0);
+          }
+        }
+      }
+    } catch {
+      // JSON parse failed — fall through to all secrets
     }
-    if (allSecrets.length > 0) {
+
+    // Fall back to all known secrets if bucket-scoped resolution didn't yield any
+    if (candidateSecrets.length === 0) {
+      for (const { registry } of secretRegistries.values()) {
+        candidateSecrets.push(...registry.getAllSecrets().filter(s => s.length > 0));
+      }
+    }
+
+    if (candidateSecrets.length > 0) {
       authenticated = verifyWebhookSignature({
         signature: hmacSignature,
         timestamp: hmacTimestamp,
         rawBody,
-        secrets: allSecrets,
+        secrets: candidateSecrets,
       });
     }
   }
@@ -310,7 +344,7 @@ export async function handleBasecampWebhook(
 
   if (!authenticated) {
     // No valid authentication — check if webhooks are configured at all
-    const hasAnySecrets = [...secretRegistries.values()].some(r => r.size > 0);
+    const hasAnySecrets = [...secretRegistries.values()].some(({ registry }) => registry.size > 0);
     if (!webhookSecret && !hasAnySecrets) {
       res.writeHead(403, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Webhooks not configured (set channels.basecamp.webhookSecret or configure webhooks.payloadUrl)" }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -457,6 +457,19 @@ export type BasecampChannelConfig = {
   engage?: BasecampEngagementType[];
   /** Secret token for webhook URL verification. Webhook requests are rejected when unset. */
   webhookSecret?: string;
+  /** Webhook subscription management. */
+  webhooks?: {
+    /** HTTPS URL where Basecamp sends webhook payloads. Required for auto-registration. */
+    payloadUrl?: string;
+    /** Bucket IDs to create webhooks for. Omit for manual-only management. */
+    projects?: string[];
+    /** Recordable types to subscribe to. Defaults to all types. */
+    types?: string[];
+    /** Auto-register webhooks on gateway startup. Default: true. */
+    autoRegister?: boolean;
+    /** Deactivate webhooks on gateway shutdown. Default: false. */
+    deactivateOnStop?: boolean;
+  };
   /** Polling cadence overrides (milliseconds). */
   polling?: {
     activityIntervalMs?: number;

--- a/tests/webhook-hmac.test.ts
+++ b/tests/webhook-hmac.test.ts
@@ -66,7 +66,6 @@ import {
   handleBasecampWebhook,
   getWebhookSecretRegistry,
   setWebhookStateDir,
-  flushWebhookSecrets,
 } from "../src/inbound/webhooks.js";
 import { WebhookSecretRegistry, JsonFileWebhookSecretStore } from "../src/inbound/webhook-secrets.js";
 
@@ -282,7 +281,7 @@ describe("WebhookSecretRegistry", () => {
   });
 
   it("persists to backing store", () => {
-    const { mkdtempSync, readdirSync, rmSync } = require("node:fs");
+    const { mkdtempSync, rmSync } = require("node:fs");
     const { join } = require("node:path");
     const { tmpdir } = require("node:os");
     const dir = mkdtempSync(join(tmpdir(), "wh-secrets-test-"));

--- a/tests/webhook-hmac.test.ts
+++ b/tests/webhook-hmac.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import crypto from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+vi.mock("../src/dispatch.js", () => ({
+  dispatchBasecampEvent: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("../src/runtime.js", () => ({
+  getBasecampRuntime: vi.fn(() => ({
+    config: {
+      loadConfig: () => ({
+        channels: {
+          basecamp: {
+            accounts: { default: { personId: "1" } },
+            // No webhookSecret — HMAC-only mode
+          },
+        },
+      }),
+    },
+  })),
+}));
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(() => ({
+    accountId: "default",
+    enabled: true,
+    personId: "1",
+    token: "",
+    tokenSource: "none",
+    config: { personId: "1" },
+  })),
+  resolveDefaultBasecampAccountId: vi.fn(() => "default"),
+  resolveWebhookSecret: vi.fn(() => undefined),
+  resolveAccountForBucket: vi.fn(() => undefined),
+  listBasecampAccountIds: vi.fn(() => ["default"]),
+}));
+let hmacDedupSeq = 100;
+vi.mock("../src/inbound/normalize.js", () => ({
+  normalizeWebhookPayload: vi.fn(() => {
+    const seq = ++hmacDedupSeq;
+    return {
+      channel: "basecamp",
+      accountId: "default",
+      peer: { kind: "group", id: `recording:${seq}` },
+      sender: { id: "2", name: "Tester" },
+      text: "hi",
+      html: "<p>hi</p>",
+      meta: {
+        bucketId: "1",
+        recordingId: String(seq),
+        recordableType: "Comment",
+        eventKind: "created",
+        mentions: [],
+        mentionsAgent: false,
+        attachments: [],
+        sources: ["webhook"],
+      },
+      dedupKey: `webhook:${seq}`,
+      createdAt: `2025-01-01T00:00:${String(seq).padStart(2, "0")}Z`,
+    };
+  }),
+  isSelfMessage: vi.fn(() => false),
+}));
+
+import {
+  verifyWebhookSignature,
+  handleBasecampWebhook,
+  getWebhookSecretRegistry,
+  setWebhookStateDir,
+  flushWebhookSecrets,
+} from "../src/inbound/webhooks.js";
+import { WebhookSecretRegistry, JsonFileWebhookSecretStore } from "../src/inbound/webhook-secrets.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function signPayload(secret: string, timestamp: string, body: string): string {
+  return (
+    "sha256=" +
+    crypto.createHmac("sha256", secret).update(`${timestamp}.${body}`).digest("hex")
+  );
+}
+
+function mockReq(
+  method: string,
+  url: string,
+  body?: string,
+  headers?: Record<string, string>,
+): IncomingMessage {
+  const { Readable } = require("node:stream");
+  const req = new Readable({
+    read() {
+      if (body) this.push(body);
+      this.push(null);
+    },
+  }) as IncomingMessage;
+  req.method = method;
+  req.url = url;
+  req.headers = { host: "localhost:18789", ...headers };
+  return req;
+}
+
+function mockRes(): ServerResponse & { status: number; body: string } {
+  const res = {
+    status: 0,
+    body: "",
+    writeHead(code: number, _headers?: Record<string, string>) {
+      res.status = code;
+    },
+    end(data?: string) {
+      res.body = data ?? "";
+    },
+  } as any;
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// verifyWebhookSignature unit tests
+// ---------------------------------------------------------------------------
+
+describe("verifyWebhookSignature", () => {
+  const secret = "test-webhook-secret-abc123";
+  const body = '{"kind":"comment_created","recording":{"id":1}}';
+  const timestamp = String(Math.floor(Date.now() / 1000));
+
+  it("accepts valid HMAC-SHA256 signature", () => {
+    const signature = signPayload(secret, timestamp, body);
+    expect(
+      verifyWebhookSignature({
+        signature,
+        timestamp,
+        rawBody: body,
+        secrets: [secret],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects invalid signature", () => {
+    expect(
+      verifyWebhookSignature({
+        signature: "sha256=deadbeef",
+        timestamp,
+        rawBody: body,
+        secrets: [secret],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects when no secrets provided", () => {
+    const signature = signPayload(secret, timestamp, body);
+    expect(
+      verifyWebhookSignature({
+        signature,
+        timestamp,
+        rawBody: body,
+        secrets: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects expired timestamp (replay protection)", () => {
+    const oldTimestamp = String(Math.floor(Date.now() / 1000) - 600);
+    const signature = signPayload(secret, oldTimestamp, body);
+    expect(
+      verifyWebhookSignature({
+        signature,
+        timestamp: oldTimestamp,
+        rawBody: body,
+        secrets: [secret],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects non-numeric timestamp", () => {
+    const signature = signPayload(secret, "not-a-number", body);
+    expect(
+      verifyWebhookSignature({
+        signature,
+        timestamp: "not-a-number",
+        rawBody: body,
+        secrets: [secret],
+      }),
+    ).toBe(false);
+  });
+
+  it("tries multiple secrets and accepts if any matches", () => {
+    const signature = signPayload(secret, timestamp, body);
+    expect(
+      verifyWebhookSignature({
+        signature,
+        timestamp,
+        rawBody: body,
+        secrets: ["wrong-secret-1", "wrong-secret-2", secret],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects when body has been tampered with", () => {
+    const signature = signPayload(secret, timestamp, body);
+    expect(
+      verifyWebhookSignature({
+        signature,
+        timestamp,
+        rawBody: body + "tampered",
+        secrets: [secret],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects empty signature", () => {
+    expect(
+      verifyWebhookSignature({
+        signature: "",
+        timestamp,
+        rawBody: body,
+        secrets: [secret],
+      }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WebhookSecretRegistry unit tests
+// ---------------------------------------------------------------------------
+
+describe("WebhookSecretRegistry", () => {
+  it("stores and retrieves entries by project ID", () => {
+    const reg = new WebhookSecretRegistry();
+    reg.set("123", {
+      webhookId: "w1",
+      secret: "secret-abc",
+      payloadUrl: "https://example.com/webhooks",
+      types: ["Todo", "Comment"],
+    });
+
+    const entry = reg.get("123");
+    expect(entry).toBeDefined();
+    expect(entry!.secret).toBe("secret-abc");
+    expect(entry!.webhookId).toBe("w1");
+  });
+
+  it("getAllSecrets returns unique secrets", () => {
+    const reg = new WebhookSecretRegistry();
+    reg.set("100", {
+      webhookId: "w1",
+      secret: "secret-a",
+      payloadUrl: "https://example.com/wh",
+      types: [],
+    });
+    reg.set("200", {
+      webhookId: "w2",
+      secret: "secret-b",
+      payloadUrl: "https://example.com/wh",
+      types: [],
+    });
+    // Duplicate secret
+    reg.set("300", {
+      webhookId: "w3",
+      secret: "secret-a",
+      payloadUrl: "https://example.com/wh",
+      types: [],
+    });
+
+    const secrets = reg.getAllSecrets();
+    expect(secrets).toHaveLength(2);
+    expect(secrets).toContain("secret-a");
+    expect(secrets).toContain("secret-b");
+  });
+
+  it("remove deletes an entry", () => {
+    const reg = new WebhookSecretRegistry();
+    reg.set("100", {
+      webhookId: "w1",
+      secret: "s",
+      payloadUrl: "u",
+      types: [],
+    });
+    expect(reg.size).toBe(1);
+    reg.remove("100");
+    expect(reg.size).toBe(0);
+    expect(reg.get("100")).toBeUndefined();
+  });
+
+  it("persists to backing store", () => {
+    const { mkdtempSync, readdirSync, rmSync } = require("node:fs");
+    const { join } = require("node:path");
+    const { tmpdir } = require("node:os");
+    const dir = mkdtempSync(join(tmpdir(), "wh-secrets-test-"));
+    const filePath = join(dir, "secrets.json");
+
+    const store = new JsonFileWebhookSecretStore(filePath);
+    const reg = new WebhookSecretRegistry(store);
+
+    reg.set("42", {
+      webhookId: "w99",
+      secret: "persist-test",
+      payloadUrl: "https://example.com",
+      types: ["Todo"],
+    });
+
+    // Load from a fresh registry backed by the same file
+    const reg2 = new WebhookSecretRegistry(new JsonFileWebhookSecretStore(filePath));
+    const entry = reg2.get("42");
+    expect(entry).toBeDefined();
+    expect(entry!.secret).toBe("persist-test");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HMAC verification in handleBasecampWebhook integration test
+// ---------------------------------------------------------------------------
+
+describe("handleBasecampWebhook — HMAC authentication", () => {
+  const webhookSecret = "hmac-test-secret-xyz";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Seed a webhook secret into the registry so HMAC verification can find it
+    const reg = getWebhookSecretRegistry("default");
+    reg.set("100", {
+      webhookId: "w1",
+      secret: webhookSecret,
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: ["Comment"],
+    });
+  });
+
+  afterEach(() => {
+    // Clean up registries
+    setWebhookStateDir("");
+  });
+
+  it("accepts request with valid HMAC signature (no query token needed)", async () => {
+    const body = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = signPayload(webhookSecret, timestamp, body);
+
+    const req = mockReq("POST", "/webhooks/basecamp", body, {
+      "x-basecamp-signature": signature,
+      "x-basecamp-timestamp": timestamp,
+    });
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects request with invalid HMAC signature", async () => {
+    const body = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+
+    const req = mockReq("POST", "/webhooks/basecamp", body, {
+      "x-basecamp-signature": "sha256=invalid",
+      "x-basecamp-timestamp": timestamp,
+    });
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toContain("Invalid webhook signature or token");
+  });
+
+  it("rejects request with expired HMAC timestamp", async () => {
+    const body = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 100, name: "Test" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    // 10 minutes ago — beyond the 5-minute window
+    const oldTimestamp = String(Math.floor(Date.now() / 1000) - 600);
+    const signature = signPayload(webhookSecret, oldTimestamp, body);
+
+    const req = mockReq("POST", "/webhooks/basecamp", body, {
+      "x-basecamp-signature": signature,
+      "x-basecamp-timestamp": oldTimestamp,
+    });
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/webhook-lifecycle.test.ts
+++ b/tests/webhook-lifecycle.test.ts
@@ -108,7 +108,7 @@ describe("reconcileWebhooks", () => {
           id: 42,
           active: true,
           payload_url: "https://example.com/webhooks/basecamp",
-          types: ["Todo"],
+          types: ["Comment", "Todo"],
         },
       ],
       raw: "[]",
@@ -120,7 +120,7 @@ describe("reconcileWebhooks", () => {
       webhookId: "42",
       secret: "known-secret",
       payloadUrl: "https://example.com/webhooks/basecamp",
-      types: ["Todo"],
+      types: ["Comment", "Todo"],
     });
 
     const result = await reconcileWebhooks(
@@ -131,6 +131,47 @@ describe("reconcileWebhooks", () => {
     expect(result.existing).toEqual(["100"]);
     // Secret should be preserved
     expect(registry.get("100")!.secret).toBe("known-secret");
+  });
+
+  it("deletes and recreates webhook when types differ", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({
+      data: [
+        {
+          id: 42,
+          active: true,
+          payload_url: "https://example.com/webhooks/basecamp",
+          types: ["Todo"],
+        },
+      ],
+      raw: "[]",
+    });
+    vi.mocked(bcqWebhookDelete).mockResolvedValue({ data: null, raw: "" });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 43,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        types: ["Todo", "Comment"],
+        secret: "new-secret",
+      },
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    const log = mockLog();
+    const result = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+      log,
+    );
+
+    // Old webhook should be deleted, new one created
+    expect(bcqWebhookDelete).toHaveBeenCalledWith("100", "42", expect.any(Object));
+    expect(bcqWebhookCreate).toHaveBeenCalledTimes(1);
+    expect(result.created).toEqual(["100"]);
+    expect(registry.get("100")!.secret).toBe("new-secret");
+    expect(registry.get("100")!.webhookId).toBe("43");
+    expect(log.info).toHaveBeenCalledWith("webhook_types_changed", expect.any(Object));
   });
 
   it("records failed projects when create returns no ID", async () => {
@@ -352,6 +393,23 @@ describe("deactivateWebhooks", () => {
 
     expect(log.error).toHaveBeenCalled();
     // Registry entry should NOT be removed on failure
+    expect(registry.get("100")).toBeDefined();
+  });
+
+  it("skips deletion when registry payloadUrl does not match config", async () => {
+    const registry = new WebhookSecretRegistry();
+    registry.set("100", {
+      webhookId: "w1",
+      secret: "s",
+      payloadUrl: "https://other-deployment.example.com/webhooks/basecamp",
+      types: [],
+    });
+
+    await deactivateWebhooks(makeConfig(), registry);
+
+    // Should NOT have called delete — different payloadUrl means different deployment
+    expect(bcqWebhookDelete).not.toHaveBeenCalled();
+    // Registry entry should be preserved
     expect(registry.get("100")).toBeDefined();
   });
 });

--- a/tests/webhook-lifecycle.test.ts
+++ b/tests/webhook-lifecycle.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/bcq.js", () => ({
+  bcqWebhookList: vi.fn(),
+  bcqWebhookCreate: vi.fn(),
+  bcqWebhookDelete: vi.fn(),
+}));
+
+import { bcqWebhookList, bcqWebhookCreate, bcqWebhookDelete } from "../src/bcq.js";
+import { WebhookSecretRegistry } from "../src/inbound/webhook-secrets.js";
+import { reconcileWebhooks, deactivateWebhooks } from "../src/inbound/webhook-lifecycle.js";
+import type { WebhookLifecycleConfig } from "../src/inbound/webhook-lifecycle.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides?: Partial<WebhookLifecycleConfig>): WebhookLifecycleConfig {
+  return {
+    payloadUrl: "https://example.com/webhooks/basecamp",
+    projects: ["100", "200"],
+    types: ["Todo", "Comment"],
+    ...overrides,
+  };
+}
+
+function mockLog() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// reconcileWebhooks
+// ---------------------------------------------------------------------------
+
+describe("reconcileWebhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates webhooks for projects with no existing match", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({ data: [], raw: "[]" });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 1,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        types: ["Todo", "Comment"],
+        secret: "new-secret-abc",
+      },
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    const log = mockLog();
+    const result = await reconcileWebhooks(makeConfig(), registry, log);
+
+    expect(result.created).toEqual(["100", "200"]);
+    expect(result.existing).toEqual([]);
+    expect(result.failed).toEqual([]);
+
+    // Verify secrets were persisted
+    const entry100 = registry.get("100");
+    expect(entry100).toBeDefined();
+    expect(entry100!.secret).toBe("new-secret-abc");
+    expect(entry100!.webhookId).toBe("1");
+
+    // Both projects should have called create
+    expect(bcqWebhookCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips projects that already have a matching active webhook", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({
+      data: [
+        {
+          id: 42,
+          active: true,
+          payload_url: "https://example.com/webhooks/basecamp",
+          types: ["Todo", "Comment"],
+        },
+      ],
+      raw: "[]",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    const log = mockLog();
+    const result = await reconcileWebhooks(makeConfig(), registry, log);
+
+    expect(result.existing).toEqual(["100", "200"]);
+    expect(result.created).toEqual([]);
+    expect(bcqWebhookCreate).not.toHaveBeenCalled();
+
+    // Should still store the webhook ID (without secret since it's pre-existing)
+    const entry = registry.get("100");
+    expect(entry).toBeDefined();
+    expect(entry!.webhookId).toBe("42");
+    expect(entry!.secret).toBe("");
+  });
+
+  it("does not overwrite existing registry entries for matched webhooks", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({
+      data: [
+        {
+          id: 42,
+          active: true,
+          payload_url: "https://example.com/webhooks/basecamp",
+          types: ["Todo"],
+        },
+      ],
+      raw: "[]",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    // Pre-populate with known secret
+    registry.set("100", {
+      webhookId: "42",
+      secret: "known-secret",
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: ["Todo"],
+    });
+
+    const result = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+    );
+
+    expect(result.existing).toEqual(["100"]);
+    // Secret should be preserved
+    expect(registry.get("100")!.secret).toBe("known-secret");
+  });
+
+  it("records failed projects when create returns no ID", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({ data: [], raw: "[]" });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {} as any,
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    const log = mockLog();
+    const result = await reconcileWebhooks(makeConfig(), registry, log);
+
+    expect(result.failed).toEqual(["100", "200"]);
+    expect(result.created).toEqual([]);
+    expect(log.error).toHaveBeenCalled();
+  });
+
+  it("records failed projects on thrown errors", async () => {
+    vi.mocked(bcqWebhookList).mockRejectedValue(new Error("network error"));
+    vi.mocked(bcqWebhookCreate).mockRejectedValue(new Error("network error"));
+
+    const registry = new WebhookSecretRegistry();
+    const log = mockLog();
+    const result = await reconcileWebhooks(makeConfig(), registry, log);
+
+    expect(result.failed).toEqual(["100", "200"]);
+    expect(log.error).toHaveBeenCalled();
+  });
+
+  it("treats list failure as empty and attempts create", async () => {
+    vi.mocked(bcqWebhookList).mockRejectedValue(new Error("list failed"));
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 5,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        types: [],
+        secret: "fresh-secret",
+      },
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    const result = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+    );
+
+    expect(result.created).toEqual(["100"]);
+    expect(bcqWebhookCreate).toHaveBeenCalledTimes(1);
+    expect(registry.get("100")!.secret).toBe("fresh-secret");
+  });
+
+  it("ignores inactive webhooks with matching URL", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({
+      data: [
+        {
+          id: 10,
+          active: false,
+          payload_url: "https://example.com/webhooks/basecamp",
+          types: [],
+        },
+      ],
+      raw: "[]",
+    });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 11,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        types: ["Todo", "Comment"],
+        secret: "new-secret",
+      },
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    const result = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+    );
+
+    // Inactive match should not count — should create new
+    expect(result.created).toEqual(["100"]);
+    expect(bcqWebhookCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes bcqOpts through to list and create calls", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({ data: [], raw: "[]" });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 1,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        secret: "s",
+      },
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    await reconcileWebhooks(
+      makeConfig({
+        projects: ["100"],
+        bcqOpts: { accountId: "acct-1", profile: "prod" },
+      }),
+      registry,
+    );
+
+    expect(bcqWebhookList).toHaveBeenCalledWith("100", {
+      accountId: "acct-1",
+      profile: "prod",
+    });
+    expect(bcqWebhookCreate).toHaveBeenCalledWith(
+      "100",
+      "https://example.com/webhooks/basecamp",
+      ["Todo", "Comment"],
+      { accountId: "acct-1", profile: "prod" },
+    );
+  });
+
+  it("passes undefined types when config types array is empty", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({ data: [], raw: "[]" });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 1,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        secret: "s",
+      },
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    await reconcileWebhooks(
+      makeConfig({ projects: ["100"], types: [] }),
+      registry,
+    );
+
+    expect(bcqWebhookCreate).toHaveBeenCalledWith(
+      "100",
+      "https://example.com/webhooks/basecamp",
+      undefined,
+      expect.any(Object),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deactivateWebhooks
+// ---------------------------------------------------------------------------
+
+describe("deactivateWebhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes webhooks for projects with registry entries", async () => {
+    vi.mocked(bcqWebhookDelete).mockResolvedValue({ data: null, raw: "" });
+
+    const registry = new WebhookSecretRegistry();
+    registry.set("100", {
+      webhookId: "w1",
+      secret: "s",
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: [],
+    });
+    registry.set("200", {
+      webhookId: "w2",
+      secret: "s",
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: [],
+    });
+
+    const log = mockLog();
+    await deactivateWebhooks(makeConfig(), registry, log);
+
+    expect(bcqWebhookDelete).toHaveBeenCalledTimes(2);
+    expect(bcqWebhookDelete).toHaveBeenCalledWith("100", "w1", expect.any(Object));
+    expect(bcqWebhookDelete).toHaveBeenCalledWith("200", "w2", expect.any(Object));
+
+    // Registry entries should be removed after deletion
+    expect(registry.get("100")).toBeUndefined();
+    expect(registry.get("200")).toBeUndefined();
+  });
+
+  it("skips projects with no registry entry", async () => {
+    const registry = new WebhookSecretRegistry();
+    // Only "100" has an entry — "200" does not
+    registry.set("100", {
+      webhookId: "w1",
+      secret: "s",
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: [],
+    });
+
+    vi.mocked(bcqWebhookDelete).mockResolvedValue({ data: null, raw: "" });
+
+    await deactivateWebhooks(makeConfig(), registry);
+
+    expect(bcqWebhookDelete).toHaveBeenCalledTimes(1);
+    expect(bcqWebhookDelete).toHaveBeenCalledWith("100", "w1", expect.any(Object));
+  });
+
+  it("logs errors but does not throw when delete fails", async () => {
+    vi.mocked(bcqWebhookDelete).mockRejectedValue(new Error("delete failed"));
+
+    const registry = new WebhookSecretRegistry();
+    registry.set("100", {
+      webhookId: "w1",
+      secret: "s",
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: [],
+    });
+
+    const log = mockLog();
+    // Should not throw
+    await deactivateWebhooks(makeConfig(), registry, log);
+
+    expect(log.error).toHaveBeenCalled();
+    // Registry entry should NOT be removed on failure
+    expect(registry.get("100")).toBeDefined();
+  });
+});

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -231,7 +231,7 @@ describe("handleBasecampWebhook — hardening", () => {
     const res = mockRes();
     await handleBasecampWebhook(req, res);
     expect(res.status).toBe(403);
-    expect(res.body).toContain("Invalid webhook token");
+    expect(res.body).toContain("Invalid webhook signature or token");
   });
 
   it("rejects requests with no token", async () => {


### PR DESCRIPTION
## Summary

Three stacked commits building webhook infrastructure:

1. **HMAC-SHA256 verification and secret store** — Implements Stripe-style webhook signature verification (`X-Basecamp-Signature` + `X-Basecamp-Timestamp` headers), timing-safe comparison, 5-minute replay protection. `WebhookSecretRegistry` persists per-project secrets to disk so HMAC verification survives restarts. Falls back to query-string token auth for pre-HMAC Basecamp instances.

2. **Webhook lifecycle management** — Auto-registers webhooks for configured projects on gateway startup via `bcq webhooks` CLI. Reconciles existing subscriptions (skip matching, create missing). Optionally deactivates on shutdown. Secrets from create responses are immediately persisted.

3. **Hybrid inbound** — When webhooks are active, activity poll interval extends 5x (120s → 600s). Polling becomes a reconciliation mechanism that catches events missed during webhook downtime. Cross-source dedup prevents double-dispatch.

### Config

```yaml
channels.basecamp.webhooks:
  payloadUrl: "https://my-openclaw.example.com/webhooks/basecamp"
  projects: ["12345", "67890"]
  types: ["Todo", "Comment", "Message"]
  autoRegister: true        # default
  deactivateOnStop: false   # default
```

## Test plan
- [ ] `npx vitest run tests/webhook-hmac.test.ts` — HMAC verification tests (15 tests)
- [ ] `npx vitest run tests/webhook-lifecycle.test.ts` — lifecycle management tests (12 tests)
- [ ] `npx vitest run` — full suite passes (765 tests)
- [ ] `npx tsc --noEmit` — types clean
- [ ] Send HMAC-signed test payload to webhook endpoint, verify dispatch
- [ ] Send unsigned payload, verify 403 rejection
- [ ] Start gateway with `webhooks.autoRegister: true`, verify webhooks registered
- [ ] With webhooks active, verify activity poll interval extends to 600s