### PR TITLE
Generic Basecamp API tools: basecamp_api_read and basecamp_api_write

### DIFF
--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -15,6 +15,10 @@
  *
  * Read tools:
  *   basecamp_read_history  — Fetch recent messages/comments for a recording
+ *
+ * Generic API tools:
+ *   basecamp_api_read     — GET any Basecamp 3 resource
+ *   basecamp_api_write    — POST/PUT/DELETE any Basecamp 3 resource
  */
 
 import type { ChannelAgentTool } from "openclaw/plugin-sdk";
@@ -85,6 +89,21 @@ const AnswerCheckinParams = Type.Object({
   bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
   questionId: Type.String({ description: "Check-in question ID to answer" }),
   content: Type.String({ description: "Answer content (Basecamp HTML or plain text)" }),
+});
+
+const ApiReadParams = Type.Object({
+  path: Type.String({ description: "Basecamp API path (e.g., /buckets/123/todos/456.json)" }),
+  query: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "URL query parameters (e.g., {completed: 'true'})" })),
+});
+
+const ApiWriteParams = Type.Object({
+  method: Type.Union([
+    Type.Literal("POST"),
+    Type.Literal("PUT"),
+    Type.Literal("DELETE"),
+  ], { description: "HTTP method" }),
+  path: Type.String({ description: "Basecamp API path" }),
+  body: Type.Optional(Type.Unknown({ description: "JSON request body" })),
 });
 
 // ---------------------------------------------------------------------------
@@ -349,6 +368,78 @@ async function executeReadHistory(
 }
 
 // ---------------------------------------------------------------------------
+// apiRead — GET any Basecamp 3 resource
+// ---------------------------------------------------------------------------
+
+type ApiReadInput = Static<typeof ApiReadParams>;
+
+async function executeApiRead(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const { path, query } = rawParams as ApiReadInput;
+  let effectivePath = path;
+  if (query && Object.keys(query).length > 0) {
+    const params = new URLSearchParams(query);
+    const separator = effectivePath.includes("?") ? "&" : "?";
+    effectivePath = `${effectivePath}${separator}${params.toString()}`;
+  }
+
+  try {
+    const result = await bcqApiGet(effectivePath);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, data: result }) }],
+      details: { ok: true },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// apiWrite — POST/PUT/DELETE any Basecamp 3 resource
+// ---------------------------------------------------------------------------
+
+type ApiWriteInput = Static<typeof ApiWriteParams>;
+
+async function executeApiWrite(
+  _toolCallId: string,
+  rawParams: unknown,
+) {
+  const { method, path, body } = rawParams as ApiWriteInput;
+
+  try {
+    let result: unknown;
+    const bodyStr = body != null ? JSON.stringify(body) : undefined;
+
+    switch (method) {
+      case "POST":
+        result = await bcqApiPost(path, bodyStr);
+        break;
+      case "PUT":
+        result = (await bcqPut(path, bodyStr ? { extraFlags: ["-d", bodyStr] } : {})).data;
+        break;
+      case "DELETE":
+        result = (await bcqDelete(path)).data;
+        break;
+    }
+
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: true, data: result }) }],
+      details: { ok: true },
+    };
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: String(err) }) }],
+      details: { ok: false, error: String(err) },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Exported tools array
 // ---------------------------------------------------------------------------
 
@@ -420,5 +511,46 @@ export const basecampAgentTools: ChannelAgentTool[] = [
       "Requires the project (bucket) ID, question ID, and answer content.",
     parameters: AnswerCheckinParams,
     execute: executeAnswerCheckin,
+  },
+  {
+    name: "basecamp_api_read",
+    label: "Read Basecamp API",
+    description:
+      "Read any Basecamp 3 resource. The projectId (bucketId) is always " +
+      "available in event metadata.\n\n" +
+      "Key paths:\n" +
+      "- /projects.json — list projects\n" +
+      "- /projects/{projectId}.json — project details + dock (todoset ID, message board ID, schedule ID, card table ID, vault ID)\n" +
+      "- /projects/{projectId}/people.json — project members\n" +
+      "- /people.json — all people in the account\n" +
+      "- /buckets/{projectId}/todos/{todoId}.json — todo details\n" +
+      "- /buckets/{projectId}/todolists/{todolistId}/todos.json — list todos\n" +
+      "- /buckets/{projectId}/todosets/{todosetId}/todolists.json — list todolists\n" +
+      "- /buckets/{projectId}/recordings/{recordingId}/comments.json — comments\n" +
+      "- /buckets/{projectId}/documents/{documentId}.json — document content\n" +
+      "- /buckets/{projectId}/card_tables/cards/{cardId}.json — card details\n" +
+      "- /buckets/{projectId}/card_tables/{cardTableId}/columns.json — columns\n" +
+      "- /buckets/{projectId}/messages/{messageId}.json — message content\n" +
+      "- /buckets/{projectId}/schedules/{scheduleId}/entries.json — schedule entries\n\n" +
+      "Use query params for filtering, e.g. query: {completed: 'true'}",
+    parameters: ApiReadParams,
+    execute: executeApiRead,
+  },
+  {
+    name: "basecamp_api_write",
+    label: "Write Basecamp API",
+    description:
+      "Create, update, or delete any Basecamp 3 resource.\n\n" +
+      "Common operations:\n" +
+      "- POST /buckets/{id}/recordings/{id}/comments.json — add comment\n" +
+      "- PUT /buckets/{id}/todos/{id}.json — update todo (content, assignees, due_on)\n" +
+      "- POST /buckets/{id}/todolists/{id}/todos.json — create todo\n" +
+      "- POST /buckets/{id}/message_boards/{id}/messages.json — post message\n" +
+      "- PUT /buckets/{id}/card_tables/cards/{id}/moves.json — move card\n" +
+      "- POST /buckets/{id}/documents/{id}.json — create document\n" +
+      "- POST /buckets/{id}/schedules/{id}/entries.json — create schedule entry\n\n" +
+      "Body should be a JSON object matching the Basecamp 3 API.",
+    parameters: ApiWriteParams,
+    execute: executeApiWrite,
   },
 ];

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -368,6 +368,19 @@ async function executeReadHistory(
 }
 
 // ---------------------------------------------------------------------------
+// Path validation — reject inputs that could confuse the bcq CLI
+// ---------------------------------------------------------------------------
+
+const API_PATH_RE = /^\/[^\s]*$/;
+
+function validateApiPath(path: string): string | undefined {
+  if (!API_PATH_RE.test(path)) {
+    return "Invalid API path: must start with '/' and contain no whitespace";
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
 // apiRead — GET any Basecamp 3 resource
 // ---------------------------------------------------------------------------
 
@@ -378,6 +391,15 @@ async function executeApiRead(
   rawParams: unknown,
 ) {
   const { path, query } = rawParams as ApiReadInput;
+
+  const pathError = validateApiPath(path);
+  if (pathError) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: pathError }) }],
+      details: { ok: false, error: pathError },
+    };
+  }
+
   let effectivePath = path;
   if (query && Object.keys(query).length > 0) {
     const params = new URLSearchParams(query);
@@ -410,6 +432,14 @@ async function executeApiWrite(
   rawParams: unknown,
 ) {
   const { method, path, body } = rawParams as ApiWriteInput;
+
+  const pathError = validateApiPath(path);
+  if (pathError) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: pathError }) }],
+      details: { ok: false, error: pathError },
+    };
+  }
 
   try {
     let result: unknown;

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -686,6 +686,28 @@ describe("basecamp_api_read", () => {
 
     expect(bcqApiGet).toHaveBeenCalledWith("/projects.json");
   });
+
+  it("rejects path not starting with /", async () => {
+    const result = await tool.execute("call-read-bad-1", {
+      path: "-flag-injection",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("must start with '/'");
+    expect(bcqApiGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects path with whitespace", async () => {
+    const result = await tool.execute("call-read-bad-2", {
+      path: "/buckets/100/todos.json --some-flag",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("no whitespace");
+    expect(bcqApiGet).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -808,5 +830,30 @@ describe("basecamp_api_write", () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("403 Forbidden");
+  });
+
+  it("rejects path not starting with /", async () => {
+    const result = await tool.execute("call-write-bad-1", {
+      method: "POST",
+      path: "--dangerous-flag",
+      body: { content: "test" },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("must start with '/'");
+    expect(bcqApiPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects path with whitespace", async () => {
+    const result = await tool.execute("call-write-bad-2", {
+      method: "PUT",
+      path: "/buckets/100/todos/42.json\t--inject",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("no whitespace");
+    expect(bcqPut).not.toHaveBeenCalled();
   });
 });

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -29,8 +29,8 @@ function findTool(name: string) {
 // ---------------------------------------------------------------------------
 
 describe("basecampAgentTools", () => {
-  it("exports eight tools", () => {
-    expect(basecampAgentTools).toHaveLength(8);
+  it("exports ten tools", () => {
+    expect(basecampAgentTools).toHaveLength(10);
   });
 
   it("has correct tool names", () => {
@@ -44,6 +44,8 @@ describe("basecampAgentTools", () => {
       "basecamp_move_card",
       "basecamp_post_message",
       "basecamp_answer_checkin",
+      "basecamp_api_read",
+      "basecamp_api_write",
     ]);
   });
 
@@ -597,5 +599,214 @@ describe("basecamp_answer_checkin", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("422 Unprocessable");
     expect(result.details).toEqual({ ok: false, error: expect.stringContaining("422 Unprocessable") });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_api_read
+// ---------------------------------------------------------------------------
+
+describe("basecamp_api_read", () => {
+  const tool = findTool("basecamp_api_read");
+
+  it("reads a resource by path", async () => {
+    const todoData = { id: 42, content: "Buy milk", completed: false };
+    vi.mocked(bcqApiGet).mockResolvedValue(todoData);
+
+    const result = await tool.execute("call-read-1", {
+      path: "/buckets/100/todos/42.json",
+    });
+
+    expect(bcqApiGet).toHaveBeenCalledWith("/buckets/100/todos/42.json");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, data: todoData });
+    expect(result.details).toEqual({ ok: true });
+  });
+
+  it("appends query parameters", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([]);
+
+    await tool.execute("call-read-2", {
+      path: "/buckets/100/todolists/200/todos.json",
+      query: { completed: "true", page: "2" },
+    });
+
+    const calledPath = vi.mocked(bcqApiGet).mock.calls[0]![0];
+    expect(calledPath).toContain("/buckets/100/todolists/200/todos.json?");
+    expect(calledPath).toContain("completed=true");
+    expect(calledPath).toContain("page=2");
+  });
+
+  it("reads project list", async () => {
+    const projects = [{ id: 1, name: "Project A" }, { id: 2, name: "Project B" }];
+    vi.mocked(bcqApiGet).mockResolvedValue(projects);
+
+    const result = await tool.execute("call-read-3", {
+      path: "/projects.json",
+    });
+
+    expect(bcqApiGet).toHaveBeenCalledWith("/projects.json");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toEqual(projects);
+  });
+
+  it("reads people list", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue([{ id: 10, name: "Alice" }]);
+
+    const result = await tool.execute("call-read-4", {
+      path: "/people.json",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toHaveLength(1);
+  });
+
+  it("returns error on API failure", async () => {
+    vi.mocked(bcqApiGet).mockRejectedValue(new Error("404 Not Found"));
+
+    const result = await tool.execute("call-read-5", {
+      path: "/buckets/999/todos/999.json",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("404 Not Found");
+    expect(result.details).toEqual({ ok: false, error: expect.stringContaining("404 Not Found") });
+  });
+
+  it("handles empty query params", async () => {
+    vi.mocked(bcqApiGet).mockResolvedValue({});
+
+    await tool.execute("call-read-6", {
+      path: "/projects.json",
+      query: {},
+    });
+
+    expect(bcqApiGet).toHaveBeenCalledWith("/projects.json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// basecamp_api_write
+// ---------------------------------------------------------------------------
+
+describe("basecamp_api_write", () => {
+  const tool = findTool("basecamp_api_write");
+
+  it("creates a resource with POST", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue({ id: 50, content: "New todo" });
+
+    const result = await tool.execute("call-write-1", {
+      method: "POST",
+      path: "/buckets/100/todolists/200/todos.json",
+      body: { content: "New todo" },
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/todolists/200/todos.json",
+      JSON.stringify({ content: "New todo" }),
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual({ ok: true, data: { id: 50, content: "New todo" } });
+  });
+
+  it("updates a resource with PUT", async () => {
+    vi.mocked(bcqPut).mockResolvedValue({ data: { id: 42, content: "Updated" }, raw: "" });
+
+    const result = await tool.execute("call-write-2", {
+      method: "PUT",
+      path: "/buckets/100/todos/42.json",
+      body: { content: "Updated", due_on: "2025-12-31" },
+    });
+
+    expect(bcqPut).toHaveBeenCalledWith(
+      "/buckets/100/todos/42.json",
+      { extraFlags: ["-d", JSON.stringify({ content: "Updated", due_on: "2025-12-31" })] },
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("deletes a resource with DELETE", async () => {
+    vi.mocked(bcqDelete).mockResolvedValue({ data: undefined, raw: "" });
+
+    const result = await tool.execute("call-write-3", {
+      method: "DELETE",
+      path: "/buckets/100/recordings/42/boost.json",
+    });
+
+    expect(bcqDelete).toHaveBeenCalledWith("/buckets/100/recordings/42/boost.json");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("handles POST without body", async () => {
+    vi.mocked(bcqApiPost).mockResolvedValue(undefined);
+
+    const result = await tool.execute("call-write-4", {
+      method: "POST",
+      path: "/buckets/100/todos/42/completion.json",
+    });
+
+    expect(bcqApiPost).toHaveBeenCalledWith(
+      "/buckets/100/todos/42/completion.json",
+      undefined,
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("handles PUT without body", async () => {
+    vi.mocked(bcqPut).mockResolvedValue({ data: {}, raw: "" });
+
+    await tool.execute("call-write-5", {
+      method: "PUT",
+      path: "/buckets/100/some/path.json",
+    });
+
+    expect(bcqPut).toHaveBeenCalledWith("/buckets/100/some/path.json", {});
+  });
+
+  it("returns error on POST failure", async () => {
+    vi.mocked(bcqApiPost).mockRejectedValue(new Error("422 Unprocessable"));
+
+    const result = await tool.execute("call-write-6", {
+      method: "POST",
+      path: "/buckets/100/todolists/200/todos.json",
+      body: { content: "" },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("422 Unprocessable");
+  });
+
+  it("returns error on PUT failure", async () => {
+    vi.mocked(bcqPut).mockRejectedValue(new Error("404 Not Found"));
+
+    const result = await tool.execute("call-write-7", {
+      method: "PUT",
+      path: "/buckets/999/todos/999.json",
+      body: { content: "nope" },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("404 Not Found");
+  });
+
+  it("returns error on DELETE failure", async () => {
+    vi.mocked(bcqDelete).mockRejectedValue(new Error("403 Forbidden"));
+
+    const result = await tool.execute("call-write-8", {
+      method: "DELETE",
+      path: "/buckets/100/recordings/42.json",
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("403 Forbidden");
   });
 });


### PR DESCRIPTION
## Summary

- Adds two generic agent tools (`basecamp_api_read`, `basecamp_api_write`) that expose the entire Basecamp 3 REST API surface to agents
- `basecamp_api_read` wraps GET requests with optional query params; `basecamp_api_write` supports POST/PUT/DELETE with optional JSON body
- Tool descriptions include an API path reference so agents know what endpoints exist
- Existing 8 narrow tools remain unchanged for backward compat and fine-grained tool policy

Replaces what would have been 6+ narrow read/write tool PRs — agents get complete API access from day 1.

## Test plan

- [ ] 14 new tests covering both tools: path-only reads, query params, project/people list, all HTTP methods, missing body, error handling
- [ ] Existing 31 agent tool tests unchanged and passing
- [ ] `npx tsc --noEmit` clean
- [ ] 794 total tests pass