### PR TITLE
Correlation IDs across inbound-dispatch-outbound pipeline

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -57,11 +57,12 @@ export async function dispatchBasecampEvent(
   const cfg = runtime.config.loadConfig();
   const { account, log } = options;
   const slog = createStructuredLog(log, { accountId: account.accountId, source: "dispatch" });
+  const correlationId = msg.correlationId;
 
   // ----- Self-message filtering -----
   // Skip messages from our own service account to avoid loops.
   if (msg.sender.id === account.personId) {
-    slog.debug("self_message_skipped", { personId: msg.sender.id });
+    slog.debug("self_message_skipped", { correlationId, personId: msg.sender.id });
     return false;
   }
 
@@ -80,7 +81,7 @@ export async function dispatchBasecampEvent(
   });
 
   if (!route) {
-    slog.debug("no_route", { peer: msg.peer.id });
+    slog.debug("no_route", { correlationId, peer: msg.peer.id });
     return false;
   }
 
@@ -92,6 +93,7 @@ export async function dispatchBasecampEvent(
   const engagePolicy = resolveEngagePolicy(cfg, msg.meta.bucketId);
   if (!engagePolicy.includes(engagement)) {
     slog.debug("engagement_gate_dropped", {
+      correlationId,
       engagement,
       event: msg.meta.eventKind,
       type: msg.meta.recordableType,
@@ -108,13 +110,14 @@ export async function dispatchBasecampEvent(
   if (engagement === "dm") {
     const dmPolicy = resolveBasecampDmPolicy(cfg);
     if (dmPolicy === "disabled") {
-      slog.debug("dm_policy_dropped", { sender: msg.sender.id, policy: "disabled" });
+      slog.debug("dm_policy_dropped", { correlationId, sender: msg.sender.id, policy: "disabled" });
       return false;
     }
     if (dmPolicy === "pairing" || dmPolicy === "allowlist") {
       const allowFrom = resolveBasecampAllowFrom(cfg);
       if (!allowFrom.includes(msg.sender.id)) {
         slog.debug("dm_policy_dropped", {
+          correlationId,
           sender: msg.sender.id,
           policy: dmPolicy,
           allowFrom: allowFrom.join(","),
@@ -126,6 +129,7 @@ export async function dispatchBasecampEvent(
   }
 
   slog.info("dispatching", {
+    correlationId,
     agent: route.agentId,
     matchedBy: route.matchedBy,
     peer: `${msg.peer.kind}:${msg.peer.id}`,
@@ -215,6 +219,7 @@ export async function dispatchBasecampEvent(
             profile: outboundProfile,
             retries: 2,
             circuitBreaker: { instance: outboundCb, key: outboundCbKey },
+            correlationId,
           });
 
           if (!result.ok) {
@@ -226,6 +231,7 @@ export async function dispatchBasecampEvent(
         dispatchHadError = true;
         const errorType = classifyDispatchError(err);
         slog.error("delivery_failed", {
+          correlationId,
           agent: route.agentId,
           event: msg.meta.eventKind,
           recording: msg.meta.recordingId,
@@ -241,6 +247,7 @@ export async function dispatchBasecampEvent(
   if (!dispatchHadError) {
     syncOutboundCircuitBreakerMetrics(outboundCb, outboundCbKey, outboundBcqAccountId, cfg);
     slog.info("delivered", {
+      correlationId,
       agent: route.agentId,
       event: msg.meta.eventKind,
       recording: msg.meta.recordingId,

--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -9,6 +9,7 @@
  * into the canonical BasecampInboundMessage shape used by dispatch.ts.
  */
 
+import crypto from "node:crypto";
 import type {
   BasecampActivityEvent,
   BasecampAssignmentTodo,
@@ -379,6 +380,7 @@ export function normalizeActivityEvent(
     meta,
     dedupKey: dedupPrimary,
     createdAt: raw.created_at,
+    correlationId: crypto.randomUUID(),
   };
 }
 
@@ -472,6 +474,7 @@ export function normalizeReadingsEvent(
     meta,
     dedupKey: dedupPrimary,
     createdAt: raw.unread_at ?? raw.created_at,
+    correlationId: crypto.randomUUID(),
   };
 }
 
@@ -547,6 +550,7 @@ export function normalizeAssignmentTodo(
     meta,
     dedupKey: dedupPrimary,
     createdAt: raw.updated_at ?? raw.created_at ?? new Date().toISOString(),
+    correlationId: crypto.randomUUID(),
   };
 }
 
@@ -618,5 +622,6 @@ export function normalizeWebhookPayload(
     meta,
     dedupKey: dedupPrimary,
     createdAt: raw.created_at,
+    correlationId: crypto.randomUUID(),
   };
 }

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -49,8 +49,9 @@ export async function postCampfireLine(params: {
   profile?: string;
   retries?: number;
   circuitBreaker?: { instance: CircuitBreaker; key: string };
+  correlationId?: string;
 }): Promise<{ ok: boolean; recordingId?: string; retryable?: boolean; error?: string }> {
-  const { bucketId, transcriptId, content, accountId, profile, retries, circuitBreaker } = params;
+  const { bucketId, transcriptId, content, accountId, profile, retries, circuitBreaker, correlationId } = params;
   const path = `/buckets/${bucketId}/chats/${transcriptId}/lines.json`;
   const body = JSON.stringify({ content });
 
@@ -65,7 +66,7 @@ export async function postCampfireLine(params: {
     const parsed = typeof result === "string" ? JSON.parse(result) : result;
     console.log(
       `[basecamp:outbound] sent ok — ` +
-      `type=campfire recording=${transcriptId} account=${accountId ?? "default"}`,
+      `type=campfire recording=${transcriptId} account=${accountId ?? "default"} correlation=${correlationId ?? "none"}`,
     );
     return { ok: true, recordingId: String(parsed?.id ?? "") };
   } catch (err) {
@@ -73,7 +74,7 @@ export async function postCampfireLine(params: {
     console.warn(
       `[basecamp:outbound] failed — ` +
       `type=campfire recording=${transcriptId} account=${accountId ?? "default"} ` +
-      `retryable=${retryable} error=${String(err)}`,
+      `correlation=${correlationId ?? "none"} retryable=${retryable} error=${String(err)}`,
     );
     return { ok: false, retryable, error: String(err) };
   }
@@ -91,8 +92,9 @@ export async function postComment(params: {
   profile?: string;
   retries?: number;
   circuitBreaker?: { instance: CircuitBreaker; key: string };
+  correlationId?: string;
 }): Promise<{ ok: boolean; commentId?: string; retryable?: boolean; error?: string }> {
-  const { bucketId, recordingId, content, accountId, profile, retries, circuitBreaker } = params;
+  const { bucketId, recordingId, content, accountId, profile, retries, circuitBreaker, correlationId } = params;
   const path = `/buckets/${bucketId}/recordings/${recordingId}/comments.json`;
   const body = JSON.stringify({ content });
 
@@ -107,7 +109,7 @@ export async function postComment(params: {
     const parsed = typeof result === "string" ? JSON.parse(result) : result;
     console.log(
       `[basecamp:outbound] sent ok — ` +
-      `type=comment recording=${recordingId} account=${accountId ?? "default"}`,
+      `type=comment recording=${recordingId} account=${accountId ?? "default"} correlation=${correlationId ?? "none"}`,
     );
     return { ok: true, commentId: String(parsed?.id ?? "") };
   } catch (err) {
@@ -115,7 +117,7 @@ export async function postComment(params: {
     console.warn(
       `[basecamp:outbound] failed — ` +
       `type=comment recording=${recordingId} account=${accountId ?? "default"} ` +
-      `retryable=${retryable} error=${String(err)}`,
+      `correlation=${correlationId ?? "none"} retryable=${retryable} error=${String(err)}`,
     );
     return { ok: false, retryable, error: String(err) };
   }
@@ -151,8 +153,9 @@ export async function postReplyToEvent(params: {
   profile?: string;
   retries?: number;
   circuitBreaker?: { instance: CircuitBreaker; key: string };
+  correlationId?: string;
 }): Promise<{ ok: boolean; messageId?: string; retryable?: boolean; error?: string }> {
-  const { bucketId, recordingId, recordableType, peerId, content, accountId, profile, retries, circuitBreaker } = params;
+  const { bucketId, recordingId, recordableType, peerId, content, accountId, profile, retries, circuitBreaker, correlationId } = params;
   const parsed = parsePeerId(peerId);
 
   // Pings: resolve the transcript ID from the circle's bucket ID
@@ -169,6 +172,7 @@ export async function postReplyToEvent(params: {
       profile,
       retries,
       circuitBreaker,
+      correlationId,
     });
     return { ok: result.ok, messageId: result.recordingId, retryable: result.retryable, error: result.error };
   }
@@ -193,6 +197,7 @@ export async function postReplyToEvent(params: {
       profile,
       retries,
       circuitBreaker,
+      correlationId,
     });
     return { ok: result.ok, messageId: result.recordingId, retryable: result.retryable, error: result.error };
   }
@@ -207,6 +212,7 @@ export async function postReplyToEvent(params: {
     profile,
     retries,
     circuitBreaker,
+    correlationId,
   });
   return { ok: result.ok, messageId: result.commentId, retryable: result.retryable, error: result.error };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,8 @@ export type BasecampInboundMessage = {
   dedupKey: string;
   /** ISO timestamp of the original event. */
   createdAt: string;
+  /** Correlation ID for end-to-end tracing (normalize → dispatch → outbound). */
+  correlationId: string;
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/correlation-ids.test.ts
+++ b/tests/correlation-ids.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock bcq before importing normalizers
+vi.mock("../src/bcq.js", () => ({
+  bcqApiGet: vi.fn(),
+  bcqApiPost: vi.fn(),
+  bcqPut: vi.fn(),
+  bcqDelete: vi.fn(),
+}));
+
+vi.mock("../src/mentions/parse.js", () => ({
+  mentionsAgent: vi.fn(() => false),
+  extractAttachmentSgids: vi.fn(() => []),
+  htmlToPlainText: vi.fn((s: string) => s),
+}));
+
+import {
+  normalizeActivityEvent,
+  normalizeReadingsEvent,
+  normalizeAssignmentTodo,
+  normalizeWebhookPayload,
+} from "../src/inbound/normalize.js";
+import type { ResolvedBasecampAccount } from "../src/types.js";
+
+const mockAccount: ResolvedBasecampAccount = {
+  accountId: "test-account",
+  enabled: true,
+  personId: "999",
+  token: "test-token",
+  tokenSource: "config",
+  config: { personId: "999" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("correlation IDs", () => {
+  it("normalizeActivityEvent generates a correlationId", () => {
+    const msg = normalizeActivityEvent(
+      {
+        id: 1,
+        kind: "comment_created",
+        action: "created",
+        created_at: "2025-01-01T00:00:00Z",
+        bucket: { id: 100, name: "Test" },
+        creator: { id: 10, name: "Alice" },
+        recording: { id: 200, type: "Comment" },
+      },
+      mockAccount,
+    );
+
+    expect(msg.correlationId).toBeTruthy();
+    expect(typeof msg.correlationId).toBe("string");
+    expect(msg.correlationId.length).toBeGreaterThan(0);
+  });
+
+  it("normalizeReadingsEvent generates a correlationId", () => {
+    const msg = normalizeReadingsEvent(
+      {
+        id: 2,
+        type: "Message",
+        created_at: "2025-01-01T00:00:00Z",
+        app_url: "https://3.basecamp.com/1/buckets/100/messages/300",
+      },
+      mockAccount,
+    );
+
+    expect(msg).not.toBeNull();
+    expect(msg!.correlationId).toBeTruthy();
+    expect(typeof msg!.correlationId).toBe("string");
+  });
+
+  it("normalizeAssignmentTodo generates a correlationId", () => {
+    const msg = normalizeAssignmentTodo(
+      {
+        id: 3,
+        content: "Review PR",
+        bucket: { id: 100, name: "Test" },
+      },
+      mockAccount,
+    );
+
+    expect(msg.correlationId).toBeTruthy();
+    expect(typeof msg.correlationId).toBe("string");
+  });
+
+  it("normalizeWebhookPayload generates a correlationId", () => {
+    const msg = normalizeWebhookPayload(
+      {
+        id: 4,
+        kind: "comment_created",
+        created_at: "2025-01-01T00:00:00Z",
+        recording: {
+          id: 400,
+          type: "Comment",
+          bucket: { id: 100, name: "Test" },
+        },
+        creator: { id: 10, name: "Alice" },
+      },
+      mockAccount,
+    );
+
+    expect(msg.correlationId).toBeTruthy();
+    expect(typeof msg.correlationId).toBe("string");
+  });
+
+  it("each call generates a unique correlationId", () => {
+    const msg1 = normalizeActivityEvent(
+      {
+        id: 10,
+        kind: "comment_created",
+        action: "created",
+        created_at: "2025-01-01T00:00:00Z",
+        bucket: { id: 100, name: "Test" },
+        creator: { id: 10, name: "Alice" },
+      },
+      mockAccount,
+    );
+
+    const msg2 = normalizeActivityEvent(
+      {
+        id: 11,
+        kind: "comment_created",
+        action: "created",
+        created_at: "2025-01-01T00:01:00Z",
+        bucket: { id: 100, name: "Test" },
+        creator: { id: 10, name: "Alice" },
+      },
+      mockAccount,
+    );
+
+    expect(msg1.correlationId).not.toBe(msg2.correlationId);
+  });
+});


### PR DESCRIPTION
## Summary

- Generates a unique `correlationId` (crypto.randomUUID) during event normalization in all 4 normalizers (activity, readings, assignments, webhook)
- Threads correlationId through every structured log call in dispatch (self_message_skipped, no_route, engagement_gate_dropped, dm_policy_dropped, dispatching, delivery_failed, delivered)
- Includes correlationId in outbound `postCampfireLine` and `postComment` console output for end-to-end tracing

Enables tracing any outbound delivery failure back to the exact inbound event that triggered it — critical for debugging across 3 polling sources + webhooks.

## Test plan

- [ ] 5 new tests verifying all 4 normalizers generate unique correlationIds
- [ ] `npx tsc --noEmit` clean
- [ ] 785 total tests pass