### PR TITLE
Startup validation, shutdown timeouts, and bounded ping cache

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -39,8 +39,16 @@ import { basecampAgentTools } from "./adapters/agent-tools.js";
 import { setWebhookStateDir, flushWebhookDedup, flushWebhookSecrets, getWebhookSecretRegistry } from "./inbound/webhooks.js";
 import { reconcileWebhooks, deactivateWebhooks } from "./inbound/webhook-lifecycle.js";
 
+/** Guard to run config-wide startup validation only once across all accounts. */
+let startupValidationDone = false;
+
 /**
  * Race a promise against a timeout. Returns the promise result or undefined on timeout.
+ *
+ * Note: this only stops *awaiting* the promise — it does not cancel the underlying
+ * operation (e.g. a bcq child process). Node will keep the process alive until
+ * the child exits. This is acceptable for shutdown: the OS will reap orphaned
+ * bcq processes, and a stuck child is better than blocking shutdown indefinitely.
  */
 async function withTimeout<T>(
   promise: Promise<T>,
@@ -215,27 +223,29 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         );
       }
 
-      // Validate persona mappings
-      const startupSection = ctx.cfg.channels?.basecamp as BasecampChannelConfig | undefined;
-      if (startupSection?.personas) {
-        for (const [agentId, targetAccountId] of Object.entries(startupSection.personas)) {
-          const targetAccounts = startupSection.accounts ?? {};
-          if (!targetAccounts[targetAccountId]) {
-            ctx.log?.warn(
-              `[${account.accountId}] validation: persona "${agentId}" references non-existent account "${targetAccountId}"`,
-            );
+      // Validate persona and virtualAccounts mappings once (not per-account)
+      // to avoid log spam in multi-account setups.
+      if (!startupValidationDone) {
+        startupValidationDone = true;
+        const startupSection = ctx.cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+        if (startupSection?.personas) {
+          for (const [agentId, targetAccountId] of Object.entries(startupSection.personas)) {
+            const targetAccounts = startupSection.accounts ?? {};
+            if (!targetAccounts[targetAccountId]) {
+              ctx.log?.warn(
+                `validation: persona "${agentId}" references non-existent account "${targetAccountId}"`,
+              );
+            }
           }
         }
-      }
-
-      // Validate virtualAccounts mappings
-      if (startupSection?.virtualAccounts) {
-        for (const [key, va] of Object.entries(startupSection.virtualAccounts)) {
-          const targetAccounts = startupSection.accounts ?? {};
-          if (!targetAccounts[va.accountId]) {
-            ctx.log?.warn(
-              `[${account.accountId}] validation: virtualAccount "${key}" references non-existent account "${va.accountId}"`,
-            );
+        if (startupSection?.virtualAccounts) {
+          for (const [key, va] of Object.entries(startupSection.virtualAccounts)) {
+            const targetAccounts = startupSection.accounts ?? {};
+            if (!targetAccounts[va.accountId]) {
+              ctx.log?.warn(
+                `validation: virtualAccount "${key}" references non-existent account "${va.accountId}"`,
+              );
+            }
           }
         }
       }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -39,6 +39,29 @@ import { basecampAgentTools } from "./adapters/agent-tools.js";
 import { setWebhookStateDir, flushWebhookDedup, flushWebhookSecrets, getWebhookSecretRegistry } from "./inbound/webhooks.js";
 import { reconcileWebhooks, deactivateWebhooks } from "./inbound/webhook-lifecycle.js";
 
+/**
+ * Race a promise against a timeout. Returns the promise result or undefined on timeout.
+ */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+  log?: { warn: (msg: string) => void },
+): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => {
+      log?.warn(`[basecamp] ${label} timed out after ${ms}ms`);
+      resolve(undefined);
+    }, ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
   id: "basecamp",
 
@@ -184,6 +207,39 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
     startAccount: async (ctx) => {
       const account = await resolveBasecampAccountAsync(ctx.cfg, ctx.account.accountId);
 
+      // ----- Startup validation -----
+      // Verify critical config is valid. Log warnings but don't block startup.
+      if (!account.personId) {
+        ctx.log?.warn(
+          `[${account.accountId}] validation: personId is not set — self-message filtering will not work`,
+        );
+      }
+
+      // Validate persona mappings
+      const startupSection = ctx.cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+      if (startupSection?.personas) {
+        for (const [agentId, targetAccountId] of Object.entries(startupSection.personas)) {
+          const targetAccounts = startupSection.accounts ?? {};
+          if (!targetAccounts[targetAccountId]) {
+            ctx.log?.warn(
+              `[${account.accountId}] validation: persona "${agentId}" references non-existent account "${targetAccountId}"`,
+            );
+          }
+        }
+      }
+
+      // Validate virtualAccounts mappings
+      if (startupSection?.virtualAccounts) {
+        for (const [key, va] of Object.entries(startupSection.virtualAccounts)) {
+          const targetAccounts = startupSection.accounts ?? {};
+          if (!targetAccounts[va.accountId]) {
+            ctx.log?.warn(
+              `[${account.accountId}] validation: virtualAccount "${key}" references non-existent account "${va.accountId}"`,
+            );
+          }
+        }
+      }
+
       // If bcqProfile is configured, verify bcq auth status before proceeding
       if (account.bcqProfile) {
         try {
@@ -327,12 +383,12 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           },
         });
       } finally {
-        // Deactivate webhooks on shutdown if configured
+        // Deactivate webhooks on shutdown if configured (with timeout)
         const whShutdownConfig = resolveWebhooksConfig(ctx.cfg);
         if (whShutdownConfig.deactivateOnStop && whShutdownConfig.payloadUrl && whShutdownConfig.projects.length > 0) {
           const registry = getWebhookSecretRegistry(account.accountId);
-          try {
-            await deactivateWebhooks(
+          await withTimeout(
+            deactivateWebhooks(
               {
                 payloadUrl: whShutdownConfig.payloadUrl,
                 projects: whShutdownConfig.projects,
@@ -346,17 +402,28 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
                 error: (e, d) => ctx.log?.error?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
                 debug: (e, d) => ctx.log?.debug?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
               } : undefined,
-            );
-          } catch (err) {
-            ctx.log?.error(
-              `[${account.accountId}] webhook deactivation failed: ${String(err)}`,
-            );
-          }
+            ).catch((err) => {
+              ctx.log?.error(
+                `[${account.accountId}] webhook deactivation failed: ${String(err)}`,
+              );
+            }),
+            5000,
+            `${account.accountId} webhook deactivation`,
+            ctx.log as any,
+          );
         }
 
-        // Flush webhook dedup + secret stores before marking as stopped
-        flushWebhookDedup();
-        flushWebhookSecrets();
+        // Flush webhook dedup + secret stores (with timeout)
+        await withTimeout(
+          Promise.resolve().then(() => {
+            flushWebhookDedup();
+            flushWebhookSecrets();
+          }),
+          5000,
+          `${account.accountId} state flush`,
+          ctx.log as any,
+        );
+
         ctx.setStatus({
           accountId: account.accountId,
           running: false,

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -16,10 +16,44 @@ import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount } from "../config.js";
 
 // ---------------------------------------------------------------------------
-// Ping transcript cache — avoids re-fetching /circles/<id>.json per reply
+// Ping transcript cache — LRU-bounded to avoid unbounded growth
 // ---------------------------------------------------------------------------
 
-const pingTranscriptCache = new Map<string, string>();
+const PING_CACHE_MAX = 500;
+
+class LruCache<K, V> {
+  private map = new Map<K, V>();
+  constructor(private readonly max: number) {}
+
+  get(key: K): V | undefined {
+    const value = this.map.get(key);
+    if (value !== undefined) {
+      // Move to end (most recently used)
+      this.map.delete(key);
+      this.map.set(key, value);
+    }
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    if (this.map.has(key)) {
+      this.map.delete(key);
+    } else if (this.map.size >= this.max) {
+      // Evict oldest (first entry in Map iteration order)
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) {
+        this.map.delete(oldest);
+      }
+    }
+    this.map.set(key, value);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}
+
+const pingTranscriptCache = new LruCache<string, string>(PING_CACHE_MAX);
 
 async function resolvePingTranscriptCached(
   bucketId: string,
@@ -32,6 +66,8 @@ async function resolvePingTranscriptCached(
   if (transcriptId) pingTranscriptCache.set(bucketId, transcriptId);
   return transcriptId;
 }
+
+export { LruCache, PING_CACHE_MAX };
 
 // ---------------------------------------------------------------------------
 // Helpers — Basecamp API write operations via bcq

--- a/tests/lru-cache.test.ts
+++ b/tests/lru-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 // Mock transitive dependencies to avoid module resolution issues
 vi.mock("../src/bcq.js", () => ({

--- a/tests/startup-shutdown.test.ts
+++ b/tests/startup-shutdown.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock transitive dependencies to avoid module resolution issues
+vi.mock("../src/bcq.js", () => ({
+  bcqPost: vi.fn(),
+  bcqApiPost: vi.fn(),
+  bcqPut: vi.fn(),
+  bcqDelete: vi.fn(),
+  bcqResolvePingTranscript: vi.fn(),
+  withRetry: vi.fn(),
+  isRetryableError: vi.fn(),
+  BcqError: class extends Error { name = "BcqError"; },
+}));
+
+vi.mock("../src/runtime.js", () => ({
+  getBasecampRuntime: vi.fn(() => ({
+    config: { loadConfig: vi.fn(() => ({})) },
+  })),
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(() => ({})),
+}));
+
+vi.mock("../src/outbound/format.js", () => ({
+  markdownToBasecampHtml: vi.fn((s: string) => s),
+}));
+
+// Test the LRU cache directly
+import { LruCache, PING_CACHE_MAX } from "../src/outbound/send.js";
+
+describe("LruCache", () => {
+  it("stores and retrieves values", () => {
+    const cache = new LruCache<string, string>(3);
+    cache.set("a", "1");
+    cache.set("b", "2");
+    expect(cache.get("a")).toBe("1");
+    expect(cache.get("b")).toBe("2");
+  });
+
+  it("evicts oldest entry when full", () => {
+    const cache = new LruCache<string, number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    cache.set("d", 4); // Should evict "a"
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe(2);
+    expect(cache.get("d")).toBe(4);
+    expect(cache.size).toBe(3);
+  });
+
+  it("accessing an entry refreshes its position", () => {
+    const cache = new LruCache<string, number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    cache.get("a"); // Refresh "a"
+    cache.set("d", 4); // Should evict "b" (oldest untouched)
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("d")).toBe(4);
+  });
+
+  it("updating an entry refreshes its position", () => {
+    const cache = new LruCache<string, number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    cache.set("a", 10); // Update "a" — should refresh position
+    cache.set("d", 4); // Should evict "b"
+    expect(cache.get("a")).toBe(10);
+    expect(cache.get("b")).toBeUndefined();
+  });
+
+  it("respects max size at large scale", () => {
+    const cache = new LruCache<number, number>(PING_CACHE_MAX);
+    for (let i = 0; i < PING_CACHE_MAX + 50; i++) {
+      cache.set(i, i * 10);
+    }
+    expect(cache.size).toBe(PING_CACHE_MAX);
+    // First 50 should be evicted
+    expect(cache.get(0)).toBeUndefined();
+    expect(cache.get(49)).toBeUndefined();
+    // Last entry should be present
+    expect(cache.get(PING_CACHE_MAX + 49)).toBe((PING_CACHE_MAX + 49) * 10);
+  });
+
+  it("handles get on empty cache", () => {
+    const cache = new LruCache<string, string>(10);
+    expect(cache.get("missing")).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it("PING_CACHE_MAX is 500", () => {
+    expect(PING_CACHE_MAX).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

- **Startup validation**: Warns on missing personId, invalid persona mappings, and invalid virtualAccount references during `startAccount` — doesn't block startup, but surfaces misconfig early
- **Shutdown timeouts**: Wraps webhook deactivation (5s) and state flush (5s) with `withTimeout` helper — prevents stuck bcq calls from hanging shutdown indefinitely
- **Bounded ping cache**: Replaces unbounded `Map` with `LruCache` (max 500 entries) for ping transcript ID cache in `src/outbound/send.ts` — prevents memory growth in long-running processes

## Test plan

- [ ] 7 new LruCache tests: store/retrieve, eviction at capacity, LRU refresh on access, LRU refresh on update, large-scale eviction, empty cache, constant value
- [ ] `PING_CACHE_MAX` exported and verified as 500
- [ ] `npx tsc --noEmit` clean
- [ ] 787 total tests pass