### PR TITLE
Fix bucket-scoped HMAC verification and eager secret loading

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -357,19 +357,21 @@ export function resolveWebhooksConfig(cfg: OpenClawConfig): {
 }
 
 /**
- * Resolve the account for a given bucket ID.
- * Checks virtualAccounts for a scope mapping, then falls back to the
- * first concrete account. Returns undefined if no account found.
+ * Resolve the concrete account ID that owns a given bucket.
+ * Checks virtualAccounts for a scope mapping and returns the concrete
+ * accountId (not the virtual alias key). Returns undefined if no mapping found.
  */
 export function resolveAccountForBucket(
   cfg: OpenClawConfig,
   bucketId: string,
 ): string | undefined {
   const section = getBasecampSection(cfg);
-  // Check virtualAccounts for a scope mapping to this bucket
+  // Check virtualAccounts for a scope mapping to this bucket.
+  // Return the concrete account ID — not the alias key — so callers can
+  // look up per-account resources (secret registries, circuit breakers, etc.).
   if (section?.virtualAccounts) {
-    for (const [key, va] of Object.entries(section.virtualAccounts)) {
-      if (va.bucketId === bucketId) return key;
+    for (const [_key, va] of Object.entries(section.virtualAccounts)) {
+      if (va.bucketId === bucketId) return va.accountId;
     }
   }
   // No virtual account mapping for this bucket

--- a/src/config.ts
+++ b/src/config.ts
@@ -371,7 +371,7 @@ export function resolveAccountForBucket(
   // look up per-account resources (secret registries, circuit breakers, etc.).
   if (section?.virtualAccounts) {
     for (const [_key, va] of Object.entries(section.virtualAccounts)) {
-      if (va.bucketId === bucketId) return va.accountId;
+      if (va.bucketId === bucketId) return normalizeAccountId(va.accountId);
     }
   }
   // No virtual account mapping for this bucket

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -297,26 +297,32 @@ export async function handleBasecampWebhook(
     // Parse the payload first to extract bucketId, then use only the secrets
     // for the account that owns that bucket. Falls back to all secrets if
     // bucket resolution fails.
+    //
+    // Uses getWebhookSecretRegistry() (not secretRegistries.get()) so that
+    // persisted secrets are eagerly loaded from disk even if the registry
+    // wasn't previously instantiated in this process.
     let candidateSecrets: string[] = [];
     try {
       const parsed = JSON.parse(rawBody) as { recording?: { bucket?: { id?: number } } };
       const bucketId = parsed?.recording?.bucket?.id;
       if (bucketId != null) {
+        // resolveAccountForBucket returns the concrete account ID (not the
+        // virtual alias), matching the key used in getWebhookSecretRegistry.
         const bucketAccountId = resolveAccountForBucket(cfg, String(bucketId));
         if (bucketAccountId) {
-          const entry = secretRegistries.get(bucketAccountId);
-          if (entry) {
-            candidateSecrets = entry.registry.getAllSecrets().filter(s => s.length > 0);
-          }
+          const registry = getWebhookSecretRegistry(bucketAccountId);
+          candidateSecrets = registry.getAllSecrets().filter(s => s.length > 0);
         }
       }
     } catch {
       // JSON parse failed — fall through to all secrets
     }
 
-    // Fall back to all known secrets if bucket-scoped resolution didn't yield any
+    // Fall back to all known secrets if bucket-scoped resolution didn't yield any.
+    // Iterate all configured account IDs and eagerly load their registries.
     if (candidateSecrets.length === 0) {
-      for (const { registry } of secretRegistries.values()) {
+      for (const accountId of listBasecampAccountIds(cfg)) {
+        const registry = getWebhookSecretRegistry(accountId);
         candidateSecrets.push(...registry.getAllSecrets().filter(s => s.length > 0));
       }
     }
@@ -343,8 +349,12 @@ export async function handleBasecampWebhook(
   }
 
   if (!authenticated) {
-    // No valid authentication — check if webhooks are configured at all
-    const hasAnySecrets = [...secretRegistries.values()].some(({ registry }) => registry.size > 0);
+    // No valid authentication — check if webhooks are configured at all.
+    // Eagerly load registries for all configured accounts to avoid false
+    // negatives when secrets exist on disk but weren't loaded yet.
+    const hasAnySecrets = listBasecampAccountIds(cfg).some(
+      (id) => getWebhookSecretRegistry(id).size > 0,
+    );
     if (!webhookSecret && !hasAnySecrets) {
       res.writeHead(403, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Webhooks not configured (set channels.basecamp.webhookSecret or configure webhooks.payloadUrl)" }));

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -302,6 +302,7 @@ export async function handleBasecampWebhook(
     // persisted secrets are eagerly loaded from disk even if the registry
     // wasn't previously instantiated in this process.
     let candidateSecrets: string[] = [];
+    let bucketResolved = false;
     try {
       const parsed = JSON.parse(rawBody) as { recording?: { bucket?: { id?: number } } };
       const bucketId = parsed?.recording?.bucket?.id;
@@ -310,6 +311,7 @@ export async function handleBasecampWebhook(
         // virtual alias), matching the key used in getWebhookSecretRegistry.
         const bucketAccountId = resolveAccountForBucket(cfg, String(bucketId));
         if (bucketAccountId) {
+          bucketResolved = true;
           const registry = getWebhookSecretRegistry(bucketAccountId);
           candidateSecrets = registry.getAllSecrets().filter(s => s.length > 0);
         }
@@ -318,9 +320,11 @@ export async function handleBasecampWebhook(
       // JSON parse failed — fall through to all secrets
     }
 
-    // Fall back to all known secrets if bucket-scoped resolution didn't yield any.
-    // Iterate all configured account IDs and eagerly load their registries.
-    if (candidateSecrets.length === 0) {
+    // Only fall back to all known secrets when bucket resolution itself failed
+    // (no virtualAccounts mapping, no bucketId in payload, or parse error).
+    // If resolution succeeded but the scoped registry is empty, fail closed —
+    // don't let another account's secret authenticate this bucket's request.
+    if (!bucketResolved && candidateSecrets.length === 0) {
       for (const accountId of listBasecampAccountIds(cfg)) {
         const registry = getWebhookSecretRegistry(accountId);
         candidateSecrets.push(...registry.getAllSecrets().filter(s => s.length > 0));

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -17,6 +17,7 @@ import {
   resolvePollingIntervals,
   resolveBasecampDmPolicy,
   resolveBasecampAllowFrom,
+  resolveAccountForBucket,
 } from "../src/config.js";
 
 // ---------------------------------------------------------------------------
@@ -523,5 +524,53 @@ describe("resolveBasecampAllowFrom", () => {
     expect(
       resolveBasecampAllowFrom(cfg({ allowFrom: ["abc", 42, "def"] })),
     ).toEqual(["abc", "42", "def"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAccountForBucket
+// ---------------------------------------------------------------------------
+
+describe("resolveAccountForBucket", () => {
+  it("returns concrete account ID (not alias key) for mapped bucket", () => {
+    const config = cfg({
+      accounts: { "acct-123": { personId: "1" } },
+      virtualAccounts: {
+        "project-x": { accountId: "acct-123", bucketId: "456" },
+      },
+    });
+    // Should return the concrete account "acct-123", not the alias "project-x"
+    expect(resolveAccountForBucket(config, "456")).toBe("acct-123");
+  });
+
+  it("returns undefined for unmapped bucket", () => {
+    const config = cfg({
+      accounts: { "acct-123": { personId: "1" } },
+      virtualAccounts: {
+        "project-x": { accountId: "acct-123", bucketId: "456" },
+      },
+    });
+    expect(resolveAccountForBucket(config, "999")).toBeUndefined();
+  });
+
+  it("returns undefined when no virtualAccounts configured", () => {
+    const config = cfg({ accounts: { "default": { personId: "1" } } });
+    expect(resolveAccountForBucket(config, "456")).toBeUndefined();
+  });
+
+  it("returns undefined for empty config", () => {
+    expect(resolveAccountForBucket(cfg(), "456")).toBeUndefined();
+  });
+
+  it("resolves first matching virtualAccount when multiple exist", () => {
+    const config = cfg({
+      accounts: { "a1": { personId: "1" }, "a2": { personId: "2" } },
+      virtualAccounts: {
+        "proj-a": { accountId: "a1", bucketId: "100" },
+        "proj-b": { accountId: "a2", bucketId: "200" },
+      },
+    });
+    expect(resolveAccountForBucket(config, "100")).toBe("a1");
+    expect(resolveAccountForBucket(config, "200")).toBe("a2");
   });
 });

--- a/tests/webhook-hmac.test.ts
+++ b/tests/webhook-hmac.test.ts
@@ -456,4 +456,32 @@ describe("handleBasecampWebhook — HMAC authentication", () => {
 
     expect(res.status).toBe(403);
   });
+
+  it("fails closed when bucket resolves to an account with no secrets", async () => {
+    // Account "acct-empty" has an empty registry (no secrets registered).
+    // The "default" account has a valid secret (seeded in beforeEach).
+    // Bucket 888 resolves to "acct-empty" — should NOT fall back to default's secret.
+    getWebhookSecretRegistry("acct-empty"); // ensure registry exists but empty
+
+    vi.mocked(resolveAccountForBucket).mockReturnValue("acct-empty");
+
+    const body = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 888, name: "Empty" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    // Sign with the default account's secret — should be rejected
+    const signature = signPayload(webhookSecret, timestamp, body);
+
+    const req = mockReq("POST", "/webhooks/basecamp", body, {
+      "x-basecamp-signature": signature,
+      "x-basecamp-timestamp": timestamp,
+    });
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    expect(res.status).toBe(403);
+  });
 });

--- a/tests/webhook-hmac.test.ts
+++ b/tests/webhook-hmac.test.ts
@@ -68,6 +68,7 @@ import {
   setWebhookStateDir,
 } from "../src/inbound/webhooks.js";
 import { WebhookSecretRegistry, JsonFileWebhookSecretStore } from "../src/inbound/webhook-secrets.js";
+import { resolveAccountForBucket } from "../src/config.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -385,6 +386,70 @@ describe("handleBasecampWebhook — HMAC authentication", () => {
     const req = mockReq("POST", "/webhooks/basecamp", body, {
       "x-basecamp-signature": signature,
       "x-basecamp-timestamp": oldTimestamp,
+    });
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("uses bucket-scoped secret when resolveAccountForBucket returns concrete account ID", async () => {
+    // Seed a secret on a different account "acct-42"
+    const scopedSecret = "bucket-scoped-secret-42";
+    const reg = getWebhookSecretRegistry("acct-42");
+    reg.set("777", {
+      webhookId: "w-scoped",
+      secret: scopedSecret,
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: ["Comment"],
+    });
+
+    // Make resolveAccountForBucket return the concrete account ID for bucket 777
+    vi.mocked(resolveAccountForBucket).mockReturnValue("acct-42");
+
+    const body = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 777, name: "Scoped" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = signPayload(scopedSecret, timestamp, body);
+
+    const req = mockReq("POST", "/webhooks/basecamp", body, {
+      "x-basecamp-signature": signature,
+      "x-basecamp-timestamp": timestamp,
+    });
+    const res = mockRes();
+    await handleBasecampWebhook(req, res);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects HMAC when bucket-scoped account has wrong secret", async () => {
+    // Seed a secret on "acct-42" but sign with a different secret
+    const reg = getWebhookSecretRegistry("acct-42");
+    reg.set("777", {
+      webhookId: "w-scoped",
+      secret: "actual-secret",
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: ["Comment"],
+    });
+
+    vi.mocked(resolveAccountForBucket).mockReturnValue("acct-42");
+
+    const body = JSON.stringify({
+      kind: "comment_created",
+      created_at: "2025-01-01T00:00:00Z",
+      recording: { id: 1, type: "Comment", bucket: { id: 777, name: "Scoped" } },
+      creator: { id: 2, name: "Tester" },
+    });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = signPayload("wrong-secret", timestamp, body);
+
+    const req = mockReq("POST", "/webhooks/basecamp", body, {
+      "x-basecamp-signature": signature,
+      "x-basecamp-timestamp": timestamp,
     });
     const res = mockRes();
     await handleBasecampWebhook(req, res);


### PR DESCRIPTION
## Summary

- **High**: `resolveAccountForBucket` returned the virtual alias key instead of the concrete account ID, so bucket-scoped HMAC lookups always missed the secret registry and fell back to scanning all secrets — defeating bucket/account isolation
- **Medium**: HMAC verification read from in-memory `secretRegistries` directly instead of `getWebhookSecretRegistry()`, so persisted secrets weren't loaded after restart — causing valid HMAC requests to be rejected

## Changes

- `src/config.ts`: `resolveAccountForBucket` now returns `va.accountId` (concrete) instead of `key` (alias)
- `src/inbound/webhooks.ts`: HMAC verification uses `getWebhookSecretRegistry()` for both scoped and fallback paths, eagerly loading from disk; `hasAnySecrets` check also uses eager loading
- `tests/config.test.ts`: 5 new tests for `resolveAccountForBucket` (concrete ID, unmapped, no config, multiple accounts)
- `tests/webhook-hmac.test.ts`: 2 new tests for bucket-scoped HMAC auth (accepts valid scoped secret, rejects wrong scoped secret)

## Test plan

- [ ] `npx vitest run` — 787 passed, 11 skipped
- [ ] `npx tsc --noEmit` — clean
- [ ] Verify bucket-scoped HMAC accepts signed request with per-account secret
- [ ] Verify HMAC rejects request signed with wrong account's secret
- [ ] Verify `resolveAccountForBucket` returns concrete account ID, not virtual alias