### PR TITLE
Dead-letter semantics and queue-full metrics

### DIFF
--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -49,6 +49,10 @@ export type BasecampAudit = {
     dropped: number;
     errors: number;
   };
+  /** Count of dispatch failures (dead-lettered events). */
+  dispatchFailures?: number;
+  /** Count of events dropped due to full dispatch queue. */
+  queueFullDrops?: number;
 };
 
 /** Seconds since last successful poll, or null if never succeeded. */
@@ -180,6 +184,13 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
         dropped: metrics.webhook.droppedCount,
         errors: metrics.webhook.errorCount,
       };
+
+      if (metrics.dispatchFailureCount > 0) {
+        result.dispatchFailures = metrics.dispatchFailureCount;
+      }
+      if (metrics.queueFullDropCount > 0) {
+        result.queueFullDrops = metrics.queueFullDropCount;
+      }
     }
 
     return result;
@@ -289,6 +300,24 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
             });
           }
         }
+      }
+      if (audit?.dispatchFailures && audit.dispatchFailures > 0) {
+        issues.push({
+          channel: "basecamp",
+          accountId: s.accountId,
+          kind: "runtime",
+          message: `${audit.dispatchFailures} dispatch failure(s) (dead-lettered events)`,
+          fix: "Check gateway logs for dead_letter entries with correlationId for details",
+        });
+      }
+      if (audit?.queueFullDrops && audit.queueFullDrops > 0) {
+        issues.push({
+          channel: "basecamp",
+          accountId: s.accountId,
+          kind: "runtime",
+          message: `${audit.queueFullDrops} event(s) dropped due to full dispatch queue`,
+          fix: "Check for slow agent responses or increase dispatch concurrency",
+        });
       }
     }
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -21,7 +21,7 @@ import { markdownToBasecampHtml } from "./outbound/format.js";
 import { chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
 import { createStructuredLog } from "./logging.js";
 import { CircuitBreaker } from "./bcq.js";
-import { recordCircuitBreakerState } from "./metrics.js";
+import { recordCircuitBreakerState, recordDispatchFailure } from "./metrics.js";
 
 /** Per-account outbound circuit breakers. Separate from poller CBs. */
 const outboundCircuitBreakers = new Map<string, CircuitBreaker>();
@@ -238,6 +238,21 @@ export async function dispatchBasecampEvent(
           sender: msg.sender.id,
           type: errorType,
           error: String(err),
+        });
+        recordDispatchFailure(account.accountId);
+        // Dead-letter entry: structured log with enough context to replay or investigate
+        slog.error("dead_letter", {
+          correlationId,
+          agent: route.agentId,
+          event: msg.meta.eventKind,
+          recordableType: msg.meta.recordableType,
+          recording: msg.meta.recordingId,
+          bucket: msg.meta.bucketId,
+          sender: msg.sender.id,
+          peer: msg.peer.id,
+          type: errorType,
+          error: String(err),
+          timestamp: Date.now(),
         });
         syncOutboundCircuitBreakerMetrics(outboundCb, outboundCbKey, outboundBcqAccountId, cfg);
       },

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -239,7 +239,7 @@ export async function dispatchBasecampEvent(
           type: errorType,
           error: String(err),
         });
-        recordDispatchFailure(account.accountId);
+        recordDispatchFailure(outboundAccount.accountId);
         // Dead-letter entry: structured log with enough context to replay or investigate
         slog.error("dead_letter", {
           correlationId,

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -22,7 +22,7 @@ import { dispatchBasecampEvent } from "../dispatch.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount, resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
 import { createConsoleStructuredLog } from "../logging.js";
-import { recordWebhookReceived, recordWebhookDispatched, recordWebhookDropped, recordWebhookError, recordWebhookDedupSize } from "../metrics.js";
+import { recordWebhookReceived, recordWebhookDispatched, recordWebhookDropped, recordWebhookError, recordWebhookDedupSize, recordQueueFullDrop } from "../metrics.js";
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter
@@ -458,6 +458,7 @@ export async function handleBasecampWebhook(
   if (dispatchSemaphore.pending >= MAX_QUEUED_DISPATCHES) {
     slog.error("queue_full");
     recordWebhookDropped(account.accountId);
+    recordQueueFullDrop(account.accountId);
     recordWebhookDedupSize(account.accountId, dedup.size);
     return;
   }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -42,6 +42,8 @@ export interface AccountMetrics {
   circuitBreaker: Record<string, CircuitBreakerMetrics>;
   dedupSize: number;
   webhookDedupSize: number;
+  dispatchFailureCount: number;
+  queueFullDropCount: number;
 }
 
 function emptySourceMetrics(): PollerSourceMetrics {
@@ -84,6 +86,8 @@ function getOrCreate(accountId: string): AccountMetrics {
       circuitBreaker: {},
       dedupSize: 0,
       webhookDedupSize: 0,
+      dispatchFailureCount: 0,
+      queueFullDropCount: 0,
     };
     metricsRegistry.set(accountId, m);
   }
@@ -158,6 +162,16 @@ export function recordCircuitBreakerState(
 ): void {
   const m = getOrCreate(accountId);
   m.circuitBreaker[key] = state;
+}
+
+export function recordDispatchFailure(accountId: string): void {
+  const m = getOrCreate(accountId);
+  m.dispatchFailureCount++;
+}
+
+export function recordQueueFullDrop(accountId: string): void {
+  const m = getOrCreate(accountId);
+  m.queueFullDropCount++;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/dead-letter.test.ts
+++ b/tests/dead-letter.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordDispatchFailure,
+  recordQueueFullDrop,
+  recordWebhookReceived,
+  recordWebhookDispatched,
+  getAccountMetrics,
+  clearMetrics,
+} from "../src/metrics.js";
+
+beforeEach(() => {
+  clearMetrics();
+});
+
+describe("dead-letter metrics integration", () => {
+  it("dispatchFailureCount accumulates across multiple failures", () => {
+    recordDispatchFailure("acct-1");
+    recordDispatchFailure("acct-1");
+    recordDispatchFailure("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.dispatchFailureCount).toBe(3);
+    expect(m.queueFullDropCount).toBe(0);
+  });
+
+  it("queueFullDropCount accumulates independently", () => {
+    recordQueueFullDrop("acct-1");
+    recordQueueFullDrop("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.queueFullDropCount).toBe(2);
+    expect(m.dispatchFailureCount).toBe(0);
+  });
+
+  it("both counters track independently on the same account", () => {
+    recordDispatchFailure("acct-1");
+    recordQueueFullDrop("acct-1");
+    recordDispatchFailure("acct-1");
+    recordQueueFullDrop("acct-1");
+    recordQueueFullDrop("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.dispatchFailureCount).toBe(2);
+    expect(m.queueFullDropCount).toBe(3);
+  });
+
+  it("counters are per-account", () => {
+    recordDispatchFailure("acct-1");
+    recordDispatchFailure("acct-2");
+    recordDispatchFailure("acct-2");
+    recordQueueFullDrop("acct-1");
+    recordQueueFullDrop("acct-1");
+
+    expect(getAccountMetrics("acct-1")!.dispatchFailureCount).toBe(1);
+    expect(getAccountMetrics("acct-1")!.queueFullDropCount).toBe(2);
+    expect(getAccountMetrics("acct-2")!.dispatchFailureCount).toBe(2);
+    expect(getAccountMetrics("acct-2")!.queueFullDropCount).toBe(0);
+  });
+
+  it("counters coexist with other webhook metrics", () => {
+    recordWebhookReceived("acct-1");
+    recordWebhookDispatched("acct-1");
+    recordDispatchFailure("acct-1");
+    recordQueueFullDrop("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.webhook.receivedCount).toBe(1);
+    expect(m.webhook.dispatchedCount).toBe(1);
+    expect(m.dispatchFailureCount).toBe(1);
+    expect(m.queueFullDropCount).toBe(1);
+  });
+
+  it("clearMetrics resets all counters", () => {
+    recordDispatchFailure("acct-1");
+    recordQueueFullDrop("acct-1");
+    clearMetrics("acct-1");
+
+    expect(getAccountMetrics("acct-1")).toBeUndefined();
+  });
+});
+
+describe("status adapter audit shape", () => {
+  // These tests verify the metrics data that the status adapter would read
+  // to populate the dispatchFailures and queueFullDrops fields.
+  // (The actual status adapter integration requires mocking the full plugin SDK,
+  // which is tested in the status adapter tests.)
+
+  it("metrics include dispatchFailureCount when failures occur", () => {
+    recordDispatchFailure("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m).toHaveProperty("dispatchFailureCount");
+    expect(m.dispatchFailureCount).toBe(1);
+  });
+
+  it("metrics include queueFullDropCount when drops occur", () => {
+    recordQueueFullDrop("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m).toHaveProperty("queueFullDropCount");
+    expect(m.queueFullDropCount).toBe(1);
+  });
+
+  it("zero-value counters are present in fresh account metrics", () => {
+    // Trigger account creation with any metric
+    recordWebhookReceived("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.dispatchFailureCount).toBe(0);
+    expect(m.queueFullDropCount).toBe(0);
+  });
+});

--- a/tests/dispatch-enhanced.test.ts
+++ b/tests/dispatch-enhanced.test.ts
@@ -119,7 +119,8 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     // Simulate an error
     onError(new Error("Connection refused ECONNREFUSED"));
 
-    expect(log.error).toHaveBeenCalledTimes(1);
+    // 2 calls: delivery_failed + dead_letter
+    expect(log.error).toHaveBeenCalledTimes(2);
     const errorMsg = log.error.mock.calls[0][0];
     expect(errorMsg).toContain('"agent":"agent-1"');
     expect(errorMsg).toContain('"recording":"123"');

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -138,7 +138,8 @@ describe("dispatch outbound reliability", () => {
 
     onError(new Error("ETIMEDOUT connecting to host"));
 
-    expect(logError).toHaveBeenCalledTimes(1);
+    // 2 calls: delivery_failed + dead_letter
+    expect(logError).toHaveBeenCalledTimes(2);
     const logged = logError.mock.calls[0][0];
     expect(logged).toContain("delivery_failed");
     expect(logged).toContain('"agent":"agent-1"');

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -10,6 +10,8 @@ import {
   recordDedupSize,
   recordWebhookDedupSize,
   recordCircuitBreakerState,
+  recordDispatchFailure,
+  recordQueueFullDrop,
   getAccountMetrics,
   clearMetrics,
 } from "../src/metrics.js";
@@ -164,6 +166,49 @@ describe("circuit breaker metrics", () => {
 
     const m = getAccountMetrics("acct-1")!;
     expect(m.circuitBreaker["outbound"]!.state).toBe("half-open");
+  });
+});
+
+describe("dispatch failure metrics", () => {
+  it("records dispatch failures", () => {
+    recordDispatchFailure("acct-1");
+    recordDispatchFailure("acct-1");
+    recordDispatchFailure("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.dispatchFailureCount).toBe(3);
+  });
+
+  it("starts at zero", () => {
+    recordPollAttempt("acct-1", "activity");
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.dispatchFailureCount).toBe(0);
+  });
+});
+
+describe("queue full drop metrics", () => {
+  it("records queue full drops", () => {
+    recordQueueFullDrop("acct-1");
+    recordQueueFullDrop("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.queueFullDropCount).toBe(2);
+  });
+
+  it("starts at zero", () => {
+    recordPollAttempt("acct-1", "activity");
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.queueFullDropCount).toBe(0);
+  });
+
+  it("tracks independently from dispatch failures", () => {
+    recordDispatchFailure("acct-1");
+    recordQueueFullDrop("acct-1");
+    recordQueueFullDrop("acct-1");
+
+    const m = getAccountMetrics("acct-1")!;
+    expect(m.dispatchFailureCount).toBe(1);
+    expect(m.queueFullDropCount).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

Re-lands #31, which was accidentally squash-merged into a feature branch instead of main. Cherry-picked cleanly from `04f0ede`.

- Dead-letter structured log entries on dispatch failure
- `dispatchFailureCount` / `queueFullDropCount` counters in metrics
- `dispatchFailures` / `queueFullDrops` surfaced in status adapter
- 14 new tests covering dead-letter and queue-full paths

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 832 passed, 11 skipped (14 new tests from this PR)