### PR TITLE
Production readiness: cursor save timeout, config re-validation, status surfacing

### DIFF
--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -30,7 +30,9 @@ export type BasecampAudit = {
   projectsAccessible: number;
   personasMapped: number;
   personasValid: number;
-  errors: string[];
+  errors: Array<{ kind: "config" | "runtime"; message: string }>;
+  /** Whether personId is set for self-message filtering. */
+  personIdSet?: boolean;
   /** Poller lag per source (seconds since last successful poll, null if never polled). */
   pollerLag?: {
     activity: number | null;
@@ -119,7 +121,7 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
   },
 
   auditAccount: async ({ account, cfg, probe }) => {
-    const errors: string[] = [];
+    const errors: Array<{ kind: "config" | "runtime"; message: string }> = [];
     const opts: BcqOptions = {
       profile: account.bcqProfile,
       accountId: account.config.bcqAccountId,
@@ -133,7 +135,7 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
         projectsAccessible = projects.length;
       }
     } catch (err) {
-      errors.push(`Failed to verify project access: ${String(err)}`);
+      errors.push({ kind: "runtime", message: `Failed to verify project access: ${String(err)}` });
     }
 
     // Validate persona mappings
@@ -150,16 +152,16 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
         if (resolved.token || resolved.bcqProfile || resolved.config.tokenFile) {
           personasValid++;
         } else {
-          errors.push(`Persona "${agentId}" → account "${targetAccountId}": no auth configured`);
+          errors.push({ kind: "config", message: `Persona "${agentId}" → account "${targetAccountId}": no auth configured` });
         }
       } else {
-        errors.push(`Persona "${agentId}" → account "${targetAccountId}": account does not exist`);
+        errors.push({ kind: "config", message: `Persona "${agentId}" → account "${targetAccountId}": account does not exist` });
       }
     }
 
     // Enrich with operational metrics
     const metrics = getAccountMetrics(account.accountId);
-    const result: BasecampAudit = { projectsAccessible, personasMapped, personasValid, errors };
+    const result: BasecampAudit = { projectsAccessible, personasMapped, personasValid, errors, personIdSet: !!account.personId };
 
     if (metrics) {
       result.pollerLag = {
@@ -272,8 +274,31 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
         });
       }
 
-      // Operational issues from audit metrics
+      // Missing personId — risk of self-message loops
       const audit = s.audit as BasecampAudit | undefined;
+      if (audit && audit.personIdSet === false) {
+        issues.push({
+          channel: "basecamp",
+          accountId: s.accountId,
+          kind: "config",
+          message: "personId is not set — self-message filtering disabled (risk of response loops)",
+          fix: `Set channels.basecamp.accounts.${s.accountId}.personId`,
+        });
+      }
+
+      // Surface audit errors (persona misconfigs, project access failures)
+      if (audit?.errors) {
+        for (const err of audit.errors) {
+          issues.push({
+            channel: "basecamp",
+            accountId: s.accountId,
+            kind: err.kind,
+            message: err.message,
+          });
+        }
+      }
+
+      // Operational issues from audit metrics
       if (audit?.pollerLag) {
         const LAG_THRESHOLD_S = 600; // 10 minutes
         for (const [source, lag] of Object.entries(audit.pollerLag)) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -38,36 +38,15 @@ import { basecampActionsAdapter } from "./adapters/actions.js";
 import { basecampAgentTools } from "./adapters/agent-tools.js";
 import { setWebhookStateDir, flushWebhookDedup, flushWebhookSecrets, getWebhookSecretRegistry } from "./inbound/webhooks.js";
 import { reconcileWebhooks, deactivateWebhooks } from "./inbound/webhook-lifecycle.js";
+import { withTimeout } from "./util.js";
 
-/** Guard to run config-wide startup validation only once across all accounts. */
-let startupValidationDone = false;
+/** JSON snapshot of config sections relevant to persona/virtualAccount validation.
+ *  Re-validated whenever this changes (handles runtime config reload). */
+let lastValidatedConfigJson: string | undefined;
 
-/**
- * Race a promise against a timeout. Returns the promise result or undefined on timeout.
- *
- * Note: this only stops *awaiting* the promise — it does not cancel the underlying
- * operation (e.g. a bcq child process). Node will keep the process alive until
- * the child exits. This is acceptable for shutdown: the OS will reap orphaned
- * bcq processes, and a stuck child is better than blocking shutdown indefinitely.
- */
-async function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-  label: string,
-  log?: { warn: (msg: string) => void },
-): Promise<T | undefined> {
-  let timer: ReturnType<typeof setTimeout>;
-  const timeout = new Promise<undefined>((resolve) => {
-    timer = setTimeout(() => {
-      log?.warn(`[basecamp] ${label} timed out after ${ms}ms`);
-      resolve(undefined);
-    }, ms);
-  });
-  try {
-    return await Promise.race([promise, timeout]);
-  } finally {
-    clearTimeout(timer!);
-  }
+/** Reset module-level validation state. Exported only for test isolation. */
+export function _resetValidationState(): void {
+  lastValidatedConfigJson = undefined;
 }
 
 export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
@@ -223,11 +202,19 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         );
       }
 
-      // Validate persona and virtualAccounts mappings once (not per-account)
-      // to avoid log spam in multi-account setups.
-      if (!startupValidationDone) {
-        startupValidationDone = true;
-        const startupSection = ctx.cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+      // Validate persona and virtualAccounts mappings when config changes.
+      // Uses a JSON snapshot comparison so re-validation fires on runtime reload
+      // (not just first startup).
+      const startupSection = ctx.cfg.channels?.basecamp as BasecampChannelConfig | undefined;
+      const configJson = startupSection
+        ? JSON.stringify({
+            accounts: Object.keys(startupSection.accounts ?? {}).sort(),
+            personas: startupSection.personas,
+            virtualAccounts: startupSection.virtualAccounts,
+          })
+        : undefined;
+      if (configJson !== lastValidatedConfigJson) {
+        lastValidatedConfigJson = configJson;
         if (startupSection?.personas) {
           for (const [agentId, targetAccountId] of Object.entries(startupSection.personas)) {
             const targetAccounts = startupSection.accounts ?? {};
@@ -280,6 +267,14 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       const bcqAccountId =
         account.config.bcqAccountId ??
         (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
+
+      if (!bcqAccountId) {
+        ctx.log?.warn(
+          `[${account.accountId}] validation: bcqAccountId could not be resolved — ` +
+          `outbound dispatch and API tools will fail. ` +
+          `Set channels.basecamp.accounts.${account.accountId}.bcqAccountId`,
+        );
+      }
 
       ctx.log?.info(
         `[${account.accountId}] starting Basecamp channel (person: ${account.personId})`,

--- a/src/inbound/cursors.ts
+++ b/src/inbound/cursors.ts
@@ -28,6 +28,7 @@ export interface PollCursors {
 export class CursorStore {
   private cursors: PollCursors = {};
   private dirty = false;
+  private abandoned = false;
   private readonly filePath: string;
 
   constructor(stateDir: string, accountId: string) {
@@ -50,9 +51,18 @@ export class CursorStore {
     return this.cursors;
   }
 
+  /**
+   * Mark this store as abandoned. Subsequent save() calls become no-ops.
+   * Used on shutdown timeout to prevent a belated background write from
+   * overwriting newer cursors saved by a restarted poller instance.
+   */
+  abandon(): void {
+    this.abandoned = true;
+  }
+
   /** Persist cursors to disk if any changes were made. */
   async save(): Promise<void> {
-    if (!this.dirty) return;
+    if (!this.dirty || this.abandoned) return;
 
     // Ensure directory exists
     const { dirname } = await import("node:path");

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -29,6 +29,7 @@ import { CircuitBreaker, bcqMarkReadingsRead } from "../bcq.js";
 import { isSelfMessage } from "./normalize.js";
 import { createStructuredLog } from "../logging.js";
 import { recordPollAttempt, recordPollSuccess, recordPollError, recordDedupSize, recordCircuitBreakerState } from "../metrics.js";
+import { withTimeout } from "../util.js";
 
 export interface CompositePollerOptions {
   account: ResolvedBasecampAccount;
@@ -388,9 +389,20 @@ export async function startCompositePoller(
   }
 
   try {
+    // dedup.flush() is sync (writeFileSync) — best-effort, cannot be timeout-protected.
     dedup.flush();
-    await saveCursorsWithRetry(cursors, slog);
-    slog.info("stopped");
+    // Cursor save is async (fs/promises.writeFile) — timeout-protect it.
+    const saveResult = await withTimeout(
+      saveCursorsWithRetry(cursors, slog).then(() => "saved" as const),
+      5000,
+      `${account.accountId} poller cursor save`,
+      { warn: (msg: string) => slog.warn(msg) },
+    );
+    if (saveResult === "saved") {
+      slog.info("stopped");
+    } else {
+      slog.warn("stopped_with_cursor_save_timeout");
+    }
   } catch (err) {
     slog.warn("final_state_save_failed", { error: String(err) });
   }

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -401,6 +401,9 @@ export async function startCompositePoller(
     if (saveResult === "saved") {
       slog.info("stopped");
     } else {
+      // Prevent any belated background write from overwriting newer cursors
+      // saved by a restarted poller instance.
+      cursors.abandon();
       slog.warn("stopped_with_cursor_save_timeout");
     }
   } catch (err) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,27 @@
+/**
+ * Race a promise against a timeout. Returns the promise result or undefined on timeout.
+ *
+ * Note: this only stops *awaiting* the promise — it does not cancel the underlying
+ * operation (e.g. a bcq child process). Node will keep the process alive until
+ * the child exits. This is acceptable for shutdown: the OS will reap orphaned
+ * bcq processes, and a stuck child is better than blocking shutdown indefinitely.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+  log?: { warn: (msg: string) => void },
+): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => {
+      log?.warn(`[basecamp] ${label} timed out after ${ms}ms`);
+      resolve(undefined);
+    }, ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}

--- a/tests/poller-hardening.test.ts
+++ b/tests/poller-hardening.test.ts
@@ -94,6 +94,39 @@ describe("CursorStore monotonicity", () => {
 });
 
 // ---------------------------------------------------------------------------
+// CursorStore.abandon — prevents belated writes
+// ---------------------------------------------------------------------------
+
+describe("CursorStore abandon", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "cursor-abandon-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("save becomes a no-op after abandon()", async () => {
+    const store = new CursorStore(tmpDir, "acct-1");
+    await store.load();
+    store.setActivitySince("2025-01-01T00:00:00Z");
+    await store.save();
+
+    // Modify and abandon
+    store.setActivitySince("2025-06-01T00:00:00Z");
+    store.abandon();
+    await store.save();
+
+    // Reload — should see the pre-abandon value
+    const store2 = new CursorStore(tmpDir, "acct-1");
+    const loaded = await store2.load();
+    expect(loaded.activitySince).toBe("2025-01-01T00:00:00Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // L2: saveCursorsWithRetry — test via CursorStore with save() spy
 // ---------------------------------------------------------------------------
 

--- a/tests/poller-shutdown-timeout.test.ts
+++ b/tests/poller-shutdown-timeout.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("../src/config.js", () => ({
+  resolvePollingIntervals: () => ({
+    activityIntervalMs: 120_000,
+    readingsIntervalMs: 60_000,
+    assignmentsIntervalMs: 300_000,
+  }),
+  resolveCircuitBreakerConfig: () => ({
+    threshold: 5,
+    cooldownMs: 30_000,
+  }),
+}));
+
+vi.mock("../src/bcq.js", () => ({
+  CircuitBreaker: vi.fn(() => ({
+    check: vi.fn().mockReturnValue(true),
+    success: vi.fn(),
+    failure: vi.fn(),
+    getState: vi.fn(),
+  })),
+  bcqMarkReadingsRead: vi.fn(),
+}));
+
+vi.mock("../src/inbound/activity.js", () => ({
+  pollActivityFeed: vi.fn(),
+}));
+vi.mock("../src/inbound/readings.js", () => ({
+  pollReadings: vi.fn(),
+}));
+vi.mock("../src/inbound/assignments.js", () => ({
+  pollAssignments: vi.fn(),
+}));
+vi.mock("../src/inbound/normalize.js", () => ({
+  isSelfMessage: vi.fn().mockReturnValue(false),
+}));
+
+// Override withTimeout to use a 50ms deadline instead of the real 5s,
+// keeping the actual implementation for correct race semantics.
+vi.mock("../src/util.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../src/util.js")>();
+  return {
+    ...original,
+    withTimeout: (promise: Promise<any>, _ms: number, label: string, log: any) =>
+      original.withTimeout(promise, 50, label, log),
+  };
+});
+
+import { CursorStore } from "../src/inbound/cursors.js";
+import { startCompositePoller } from "../src/inbound/poller.js";
+
+// ---------------------------------------------------------------------------
+// PF-001: Poller cursor save timeout
+// ---------------------------------------------------------------------------
+
+describe("PF-001: poller cursor save timeout", () => {
+  let tmpDir: string;
+  let saveSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "pf-001-"));
+  });
+
+  afterEach(async () => {
+    saveSpy?.mockRestore();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("logs stopped_with_cursor_save_timeout when save hangs", async () => {
+    // Make CursorStore.save() return a never-resolving promise
+    saveSpy = vi.spyOn(CursorStore.prototype, "save").mockReturnValue(new Promise(() => {}));
+
+    const ac = new AbortController();
+    ac.abort(); // Pre-abort — loop body never executes
+
+    const logCalls: Array<{ level: string; msg: string }> = [];
+    const log = {
+      info: vi.fn((msg: string) => logCalls.push({ level: "info", msg })),
+      warn: vi.fn((msg: string) => logCalls.push({ level: "warn", msg })),
+      debug: vi.fn(),
+      error: vi.fn((msg: string) => logCalls.push({ level: "error", msg })),
+    };
+
+    await startCompositePoller({
+      account: {
+        accountId: "timeout-test",
+        enabled: true,
+        personId: "1",
+        token: "tok",
+        tokenSource: "config" as const,
+        bcqProfile: "default",
+        config: { personId: "1", bcqProfile: "default" },
+      },
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async () => false,
+      log,
+      stateDir: tmpDir,
+    });
+
+    // Should have warned about cursor save timeout
+    const warnMsgs = logCalls.filter((c) => c.level === "warn").map((c) => c.msg);
+    expect(warnMsgs.some((m) => m.includes("stopped_with_cursor_save_timeout"))).toBe(true);
+
+    // Should NOT have logged the normal "stopped" info
+    const infoMsgs = logCalls.filter((c) => c.level === "info").map((c) => c.msg);
+    expect(infoMsgs.some((m) => /\bstopped\b/.test(m) && !m.includes("stopped_with"))).toBe(false);
+  });
+
+  it("logs normal stopped when save succeeds before timeout", async () => {
+    // No spy on save — let the real implementation run.
+    // Since no cursor changes were made (loop was skipped), save returns immediately via dirty check.
+
+    const ac = new AbortController();
+    ac.abort();
+
+    const logCalls: Array<{ level: string; msg: string }> = [];
+    const log = {
+      info: vi.fn((msg: string) => logCalls.push({ level: "info", msg })),
+      warn: vi.fn((msg: string) => logCalls.push({ level: "warn", msg })),
+      debug: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await startCompositePoller({
+      account: {
+        accountId: "success-test",
+        enabled: true,
+        personId: "1",
+        token: "tok",
+        tokenSource: "config" as const,
+        bcqProfile: "default",
+        config: { personId: "1", bcqProfile: "default" },
+      },
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async () => false,
+      log,
+      stateDir: tmpDir,
+    });
+
+    const infoMsgs = logCalls.filter((c) => c.level === "info").map((c) => c.msg);
+    expect(infoMsgs.some((m) => /\bstopped\b/.test(m) && !m.includes("stopped_with"))).toBe(true);
+
+    const warnMsgs = logCalls.filter((c) => c.level === "warn").map((c) => c.msg);
+    expect(warnMsgs.some((m) => m.includes("stopped_with_cursor_save_timeout"))).toBe(false);
+  });
+});

--- a/tests/startup-validation.test.ts
+++ b/tests/startup-validation.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (v: string | undefined | null) => (v ?? "").trim() || "default",
+  buildChannelConfigSchema: (s: any) => s,
+  setAccountEnabledInConfigSection: vi.fn(),
+  deleteAccountFromConfigSection: vi.fn(),
+}));
+
+vi.mock("../src/bcq.js", () => ({
+  bcqAuthStatus: vi.fn(),
+  execBcqAuthLogin: vi.fn(),
+  bcqApiGet: vi.fn(),
+  bcqMe: vi.fn(),
+  bcqMarkReadingsRead: vi.fn(),
+  CircuitBreaker: vi.fn(),
+}));
+
+vi.mock("../src/config.js", () => ({
+  BasecampConfigSchema: {},
+  listBasecampAccountIds: vi.fn(),
+  resolveBasecampAccount: vi.fn(),
+  resolveBasecampAccountAsync: vi.fn(),
+  resolveDefaultBasecampAccountId: vi.fn(),
+  resolveBasecampAllowFrom: vi.fn(),
+  resolveWebhooksConfig: vi.fn().mockReturnValue({ autoRegister: false, projects: [] }),
+  resolvePollingIntervals: vi.fn(),
+  resolveCircuitBreakerConfig: vi.fn(),
+}));
+
+vi.mock("../src/runtime.js", () => ({
+  getBasecampRuntime: vi.fn(() => ({
+    state: { resolveStateDir: () => "/tmp/test-state" },
+  })),
+}));
+
+vi.mock("../src/dispatch.js", () => ({
+  dispatchBasecampEvent: vi.fn(),
+}));
+
+vi.mock("../src/outbound/send.js", () => ({
+  sendBasecampText: vi.fn(),
+}));
+
+vi.mock("../src/adapters/outbound.js", () => ({
+  resolveOutboundTarget: vi.fn(),
+  chunkMarkdownText: vi.fn(),
+  BASECAMP_TEXT_CHUNK_LIMIT: 10000,
+}));
+
+vi.mock("../src/adapters/onboarding.js", () => ({ basecampOnboardingAdapter: {} }));
+vi.mock("../src/adapters/setup.js", () => ({ basecampSetupAdapter: {} }));
+vi.mock("../src/adapters/status.js", () => ({ basecampStatusAdapter: {}, BasecampProbe: {}, BasecampAudit: {} }));
+vi.mock("../src/adapters/pairing.js", () => ({ basecampPairingAdapter: {} }));
+vi.mock("../src/adapters/directory.js", () => ({ basecampDirectoryAdapter: {} }));
+vi.mock("../src/adapters/messaging.js", () => ({ basecampMessagingAdapter: {} }));
+vi.mock("../src/adapters/resolver.js", () => ({ basecampResolverAdapter: {} }));
+vi.mock("../src/adapters/heartbeat.js", () => ({ basecampHeartbeatAdapter: {} }));
+vi.mock("../src/adapters/groups.js", () => ({ basecampGroupAdapter: {} }));
+vi.mock("../src/adapters/agent-prompt.js", () => ({ basecampAgentPromptAdapter: {} }));
+vi.mock("../src/adapters/security.js", () => ({ basecampSecurityAdapter: {} }));
+vi.mock("../src/adapters/mentions.js", () => ({ basecampMentionAdapter: {} }));
+vi.mock("../src/adapters/actions.js", () => ({ basecampActionsAdapter: {} }));
+vi.mock("../src/adapters/agent-tools.js", () => ({ basecampAgentTools: [] }));
+
+vi.mock("../src/inbound/webhooks.js", () => ({
+  setWebhookStateDir: vi.fn(),
+  flushWebhookDedup: vi.fn(),
+  flushWebhookSecrets: vi.fn(),
+  getWebhookSecretRegistry: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../src/inbound/webhook-lifecycle.js", () => ({
+  reconcileWebhooks: vi.fn(),
+  deactivateWebhooks: vi.fn(),
+}));
+
+// Make poller import throw — startAccount returns early after logging error
+// This prevents real poller startup while letting all validation code execute.
+vi.mock("../src/inbound/poller.js", () => {
+  throw new Error("test: skip poller startup");
+});
+
+import { basecampChannel, _resetValidationState } from "../src/channel.js";
+import { resolveBasecampAccountAsync } from "../src/config.js";
+import { bcqAuthStatus } from "../src/bcq.js";
+
+function makeCtx(cfg: any, accountId = "test") {
+  return {
+    cfg,
+    account: { accountId },
+    abortSignal: new AbortController().signal,
+    setStatus: vi.fn(),
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+}
+
+function makeAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    accountId: "test",
+    enabled: true,
+    personId: "42",
+    token: "tok",
+    tokenSource: "config",
+    bcqProfile: "default",
+    config: { personId: "42", bcqProfile: "default", bcqAccountId: "99" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetValidationState();
+});
+
+// ---------------------------------------------------------------------------
+// PF-002: Config-hash re-validation on config change
+// ---------------------------------------------------------------------------
+
+describe("PF-002: config-hash re-validation", () => {
+  it("re-validates persona mappings when config changes", async () => {
+    // Account with bcqProfile — bcqAuthStatus returns unauthenticated to trigger early return
+    // (validation happens before auth check)
+    vi.mocked(bcqAuthStatus).mockResolvedValue({ data: { authenticated: false }, raw: "" });
+    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(makeAccount() as any);
+
+    // First call: config with bad persona mapping
+    const cfg1 = {
+      channels: {
+        basecamp: {
+          accounts: { test: { personId: "42", token: "tok" } },
+          personas: { "agent-1": "nonexistent-account" },
+        },
+      },
+    };
+    const ctx1 = makeCtx(cfg1);
+    await basecampChannel.gateway!.startAccount!(ctx1 as any);
+
+    // Should warn about the bad persona
+    expect(ctx1.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('persona "agent-1"'),
+    );
+
+    // Second call: same config → should NOT re-validate
+    const ctx2 = makeCtx(cfg1);
+    await basecampChannel.gateway!.startAccount!(ctx2 as any);
+
+    const personaWarns2 = vi.mocked(ctx2.log.warn).mock.calls.filter(
+      (c) => String(c[0]).includes("persona"),
+    );
+    expect(personaWarns2).toHaveLength(0);
+
+    // Third call: different config → should re-validate
+    const cfg3 = {
+      channels: {
+        basecamp: {
+          accounts: { test: { personId: "42", token: "tok" } },
+          personas: { "agent-2": "also-missing" },
+        },
+      },
+    };
+    const ctx3 = makeCtx(cfg3);
+    await basecampChannel.gateway!.startAccount!(ctx3 as any);
+
+    expect(ctx3.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('persona "agent-2"'),
+    );
+  });
+
+  it("re-validates when accounts change even if personas are the same", async () => {
+    vi.mocked(bcqAuthStatus).mockResolvedValue({ data: { authenticated: false }, raw: "" });
+    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(makeAccount() as any);
+
+    // Config where persona target exists
+    const cfg1 = {
+      channels: {
+        basecamp: {
+          accounts: { test: {}, other: {} },
+          personas: { "agent-1": "other" },
+        },
+      },
+    };
+    const ctx1 = makeCtx(cfg1);
+    await basecampChannel.gateway!.startAccount!(ctx1 as any);
+
+    // Now remove the "other" account — persona should fail validation
+    const cfg2 = {
+      channels: {
+        basecamp: {
+          accounts: { test: {} },
+          personas: { "agent-1": "other" },
+        },
+      },
+    };
+    const ctx2 = makeCtx(cfg2);
+    await basecampChannel.gateway!.startAccount!(ctx2 as any);
+
+    expect(ctx2.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('persona "agent-1"'),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PF-003: bcqAccountId startup warning
+// ---------------------------------------------------------------------------
+
+describe("PF-003: bcqAccountId startup warning", () => {
+  it("warns when bcqAccountId cannot be resolved for non-numeric accountId", async () => {
+    // Account with non-numeric ID and no explicit bcqAccountId
+    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(
+      makeAccount({
+        accountId: "my-org",
+        config: { personId: "42", bcqProfile: "default" },
+      }) as any,
+    );
+    vi.mocked(bcqAuthStatus).mockResolvedValue({ data: { authenticated: true }, raw: "" });
+
+    const ctx = makeCtx({}, "my-org");
+    await basecampChannel.gateway!.startAccount!(ctx as any);
+
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("bcqAccountId could not be resolved"),
+    );
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("my-org"),
+    );
+  });
+
+  it("does not warn when accountId is numeric (implicit bcqAccountId)", async () => {
+    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(
+      makeAccount({
+        accountId: "12345",
+        config: { personId: "42", bcqProfile: "default" },
+      }) as any,
+    );
+    vi.mocked(bcqAuthStatus).mockResolvedValue({ data: { authenticated: true }, raw: "" });
+
+    const ctx = makeCtx({}, "12345");
+    await basecampChannel.gateway!.startAccount!(ctx as any);
+
+    const bcqWarns = vi.mocked(ctx.log.warn).mock.calls.filter(
+      (c) => String(c[0]).includes("bcqAccountId"),
+    );
+    expect(bcqWarns).toHaveLength(0);
+  });
+
+  it("does not warn when explicit bcqAccountId is configured", async () => {
+    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(
+      makeAccount({
+        accountId: "my-org",
+        config: { personId: "42", bcqProfile: "default", bcqAccountId: "99" },
+      }) as any,
+    );
+    vi.mocked(bcqAuthStatus).mockResolvedValue({ data: { authenticated: true }, raw: "" });
+
+    const ctx = makeCtx({}, "my-org");
+    await basecampChannel.gateway!.startAccount!(ctx as any);
+
+    const bcqWarns = vi.mocked(ctx.log.warn).mock.calls.filter(
+      (c) => String(c[0]).includes("bcqAccountId"),
+    );
+    expect(bcqWarns).toHaveLength(0);
+  });
+});

--- a/tests/status-enhanced.test.ts
+++ b/tests/status-enhanced.test.ts
@@ -176,7 +176,7 @@ describe("auditAccount", () => {
     expect(audit.personasMapped).toBe(2);
     expect(audit.personasValid).toBe(1);
     expect(audit.errors).toContainEqual(
-      expect.stringContaining("agent-2"),
+      expect.objectContaining({ kind: "config", message: expect.stringContaining("agent-2") }),
     );
   });
 
@@ -191,7 +191,7 @@ describe("auditAccount", () => {
 
     expect(audit.projectsAccessible).toBe(0);
     expect(audit.errors).toContainEqual(
-      expect.stringContaining("Failed to verify project access"),
+      expect.objectContaining({ kind: "runtime", message: expect.stringContaining("Failed to verify project access") }),
     );
   });
 });
@@ -596,6 +596,213 @@ describe("collectStatusIssues (operational)", () => {
       errors: [],
       pollerLag: { activity: 60, readings: 30, assignments: 120 },
       circuitBreakers: { outbound: { state: "closed", failures: 0 } },
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PF-004: collectStatusIssues — missing personId
+// ---------------------------------------------------------------------------
+
+describe("collectStatusIssues (personId)", () => {
+  it("flags accounts where personIdSet is false", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [],
+      personIdSet: false,
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "no-person",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const personIdIssues = issues.filter((i) => i.message.includes("personId"));
+    expect(personIdIssues).toHaveLength(1);
+    expect(personIdIssues[0]!.kind).toBe("config");
+    expect(personIdIssues[0]!.message).toContain("self-message filtering disabled");
+    expect(personIdIssues[0]!.fix).toContain("no-person");
+  });
+
+  it("does not flag accounts where personIdSet is true", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [],
+      personIdSet: true,
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "has-person",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const personIdIssues = issues.filter((i) => i.message.includes("personId"));
+    expect(personIdIssues).toHaveLength(0);
+  });
+
+  it("does not flag when audit is absent", () => {
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "no-audit",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+      },
+    ]);
+
+    const personIdIssues = issues.filter((i) => i.message.includes("personId"));
+    expect(personIdIssues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PF-005: collectStatusIssues — audit.errors surfaced
+// ---------------------------------------------------------------------------
+
+describe("collectStatusIssues (audit.errors)", () => {
+  it("surfaces config-kind audit errors as config issues", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 1,
+      personasValid: 0,
+      errors: [
+        { kind: "config", message: 'Persona "agent-1" \u2192 account "missing": account does not exist' },
+      ],
+      personIdSet: true,
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const errorIssues = issues.filter((i) => i.message.includes("Persona"));
+    expect(errorIssues).toHaveLength(1);
+    expect(errorIssues[0]!.kind).toBe("config");
+    expect(errorIssues[0]!.message).toContain("agent-1");
+  });
+
+  it("surfaces runtime-kind audit errors as runtime issues", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 0,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [
+        { kind: "runtime", message: "Failed to verify project access: Error: forbidden" },
+      ],
+      personIdSet: true,
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const errorIssues = issues.filter((i) => i.message.includes("Failed to verify"));
+    expect(errorIssues).toHaveLength(1);
+    expect(errorIssues[0]!.kind).toBe("runtime");
+  });
+
+  it("surfaces multiple audit errors", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 0,
+      personasMapped: 2,
+      personasValid: 0,
+      errors: [
+        { kind: "config", message: 'Persona "a" \u2192 account "x": no auth' },
+        { kind: "config", message: 'Persona "b" \u2192 account "y": does not exist' },
+        { kind: "runtime", message: "Failed to verify project access: timeout" },
+      ],
+      personIdSet: true,
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const configIssues = issues.filter((i) => i.kind === "config");
+    const runtimeIssues = issues.filter((i) => i.kind === "runtime");
+    expect(configIssues.length).toBe(2);
+    expect(runtimeIssues.length).toBe(1);
+  });
+
+  it("handles empty audit.errors gracefully", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [],
+      personIdSet: true,
     };
 
     const issues = basecampStatusAdapter.collectStatusIssues!([


### PR DESCRIPTION
## Summary

Five targeted production-readiness fixes closing gaps found during H4 audit. All changes are non-blocking (warn-only) and backward-compatible at runtime, with one intentional type change in status JSON output.

- **Poller cursor save timeout** — `saveCursorsWithRetry` wrapped in `withTimeout(5s)` on shutdown so a hung disk/NFS doesn't block `startCompositePoller` return. `dedup.flush()` (sync I/O) stays outside since `Promise.race` can't interrupt it.
- **Config-hash re-validation** — `startupValidationDone` boolean replaced with JSON snapshot comparison so persona/virtualAccount mappings re-validate on runtime config reload, not just first process startup.
- **bcqAccountId startup warning** — non-numeric `accountId` without explicit `bcqAccountId` now warns at startup instead of silently failing at dispatch time.
- **Missing personId in status** — `personIdSet` added to `BasecampAudit`; `collectStatusIssues` surfaces it as a config issue with fix instructions.
- **audit.errors surfaced** — `BasecampAudit.errors` changed from `string[]` to `Array<{kind: "config"|"runtime"; message: string}>` and iterated in `collectStatusIssues`. Breaking change for `openclaw status --json` consumers parsing `audit.errors` as bare strings.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 865 passed, 11 skipped
- [x] `tests/poller-shutdown-timeout.test.ts` — PF-001: cursor save timeout logging
- [x] `tests/startup-validation.test.ts` — PF-002: config-hash re-validation, PF-003: bcqAccountId warning
- [x] `tests/status-enhanced.test.ts` — PF-004: personIdSet issue, PF-005: structured audit.errors