### PR TITLE
Bump openclaw SDK to 2026.2.19-2, spec bcq→SDK migration

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,13 @@ import { setBasecampRuntime } from "./src/runtime.js";
 import { handleBasecampWebhook } from "./src/inbound/webhooks.js";
 import { getSurfacePrompt } from "./src/hooks/agent-prompt-context.js";
 
-const plugin = {
+const plugin: {
+  id: string;
+  name: string;
+  description: string;
+  configSchema: ReturnType<typeof emptyPluginConfigSchema>;
+  register: (api: OpenClawPluginApi) => void;
+} = {
   id: "openclaw-basecamp",
   name: "Basecamp",
   description: "Basecamp channel — Campfire, cards, todos, check-ins, pings",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,14 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "openclaw": ">=2026.2.0",
+        "openclaw": "2026.2.19-2",
         "vitest": "3"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.13.1.tgz",
-      "integrity": "sha512-6byvu+F/xc96GBkdAx4hq6/tB3vT63DSBO4i3gYCz8nuyZMerVFna2Gkhm8EHNpZX0J9DjUxzZCW+rnHXUg0FA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.14.1.tgz",
+      "integrity": "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.71.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
-      "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -198,47 +198,47 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock": {
-      "version": "3.983.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.983.0.tgz",
-      "integrity": "sha512-ekD8QyD49YMRILNarCOxjJCcG3sgPgjSHA+a82U3NhKn3FC0zjb5uYm4CpEPAK9ZjSVVKaOtWlWsY/oPxUKU6A==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.995.0.tgz",
+      "integrity": "sha512-ONw5c7pOeHe78kC+jK2j73hP727Kqp7cc9lZqkfshlBD8MWxXmZM9GihIQLrNBCSUKRhc19NH7DUM6B7uN0mMQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/credential-provider-node": "^3.972.10",
         "@aws-sdk/middleware-host-header": "^3.972.3",
         "@aws-sdk/middleware-logger": "^3.972.3",
         "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
         "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/token-providers": "3.983.0",
+        "@aws-sdk/token-providers": "3.995.0",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.983.0",
+        "@aws-sdk/util-endpoints": "3.995.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
+        "@aws-sdk/util-user-agent-node": "^3.972.10",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
+        "@smithy/core": "^3.23.2",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-retry": "^4.4.33",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/node-http-handler": "^4.4.10",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-defaults-mode-browser": "^4.3.32",
+        "@smithy/util-defaults-mode-node": "^4.2.35",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -250,31 +250,31 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.983.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.983.0.tgz",
-      "integrity": "sha512-uur/DX7OKtWe05gSZ2PGCHIhV0etoi12h8EGDht5blmtI4njLzD/gL6vX2L8CUgsy+4/KGIpH7KV7naWKAKANQ==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.995.0.tgz",
+      "integrity": "sha512-nI7tT11L9s34AKr95GHmxs6k2+3ie+rEOew2cXOwsMC9k/5aifrZwh0JjAkBop4FqbmS8n0ZjCKDjBZFY/0YxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
-        "@aws-sdk/eventstream-handler-node": "^3.972.4",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/credential-provider-node": "^3.972.10",
+        "@aws-sdk/eventstream-handler-node": "^3.972.5",
         "@aws-sdk/middleware-eventstream": "^3.972.3",
         "@aws-sdk/middleware-host-header": "^3.972.3",
         "@aws-sdk/middleware-logger": "^3.972.3",
         "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/middleware-websocket": "^3.972.4",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
+        "@aws-sdk/middleware-websocket": "^3.972.6",
         "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/token-providers": "3.983.0",
+        "@aws-sdk/token-providers": "3.995.0",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.983.0",
+        "@aws-sdk/util-endpoints": "3.995.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
+        "@aws-sdk/util-user-agent-node": "^3.972.10",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
+        "@smithy/core": "^3.23.2",
         "@smithy/eventstream-serde-browser": "^4.2.8",
         "@smithy/eventstream-serde-config-resolver": "^4.3.8",
         "@smithy/eventstream-serde-node": "^4.2.8",
@@ -282,25 +282,25 @@
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-retry": "^4.4.33",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/node-http-handler": "^4.4.10",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-defaults-mode-browser": "^4.3.32",
+        "@smithy/util-defaults-mode-node": "^4.2.35",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
+        "@smithy/util-stream": "^4.5.12",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -309,45 +309,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.982.0.tgz",
-      "integrity": "sha512-qJrIiivmvujdGqJ0ldSUvhN3k3N7GtPesoOI1BSt0fNXovVnMz4C/JmnkhZihU7hJhDvxJaBROLYTU+lpild4w==",
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.993.0.tgz",
+      "integrity": "sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/core": "^3.973.11",
         "@aws-sdk/middleware-host-header": "^3.972.3",
         "@aws-sdk/middleware-logger": "^3.972.3",
         "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
+        "@aws-sdk/util-endpoints": "3.993.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
+        "@aws-sdk/util-user-agent-node": "^3.972.9",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
+        "@smithy/core": "^3.23.2",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-retry": "^4.4.33",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/node-http-handler": "^4.4.10",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-defaults-mode-browser": "^4.3.32",
+        "@smithy/util-defaults-mode-node": "^4.2.35",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
-      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -376,20 +376,20 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.6.tgz",
-      "integrity": "sha512-pz4ZOw3BLG0NdF25HoB9ymSYyPbMiIjwQJ2aROXRhAzt+b+EOxStfFv8s5iZyP6Kiw7aYhyWxj5G3NhmkoOTKw==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.11.tgz",
+      "integrity": "sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/xml-builder": "^3.972.4",
-        "@smithy/core": "^3.22.0",
+        "@aws-sdk/xml-builder": "^3.972.5",
+        "@smithy/core": "^3.23.2",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-middleware": "^4.2.8",
@@ -401,13 +401,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.4.tgz",
-      "integrity": "sha512-/8dnc7+XNMmViEom2xsNdArQxQPSgy4Z/lm6qaFPTrMFesT1bV3PsBhb19n09nmxHdrtQskYmViddUIjUQElXg==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.9.tgz",
+      "integrity": "sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/core": "^3.973.11",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/types": "^4.12.0",
@@ -418,21 +418,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.6.tgz",
-      "integrity": "sha512-5ERWqRljiZv44AIdvIRQ3k+EAV0Sq2WeJHvXuK7gL7bovSxOf8Al7MLH7Eh3rdovH4KHFnlIty7J71mzvQBl5Q==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.11.tgz",
+      "integrity": "sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/core": "^3.973.11",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/node-http-handler": "^4.4.10",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.10",
+        "@smithy/util-stream": "^4.5.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -440,20 +440,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.4.tgz",
-      "integrity": "sha512-eRUg+3HaUKuXWn/lEMirdiA5HOKmEl8hEHVuszIDt2MMBUKgVX5XNGmb3XmbgU17h6DZ+RtjbxQpjhz3SbTjZg==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.9.tgz",
+      "integrity": "sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-env": "^3.972.4",
-        "@aws-sdk/credential-provider-http": "^3.972.6",
-        "@aws-sdk/credential-provider-login": "^3.972.4",
-        "@aws-sdk/credential-provider-process": "^3.972.4",
-        "@aws-sdk/credential-provider-sso": "^3.972.4",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.4",
-        "@aws-sdk/nested-clients": "3.982.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/credential-provider-env": "^3.972.9",
+        "@aws-sdk/credential-provider-http": "^3.972.11",
+        "@aws-sdk/credential-provider-login": "^3.972.9",
+        "@aws-sdk/credential-provider-process": "^3.972.9",
+        "@aws-sdk/credential-provider-sso": "^3.972.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.9",
+        "@aws-sdk/nested-clients": "3.993.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/property-provider": "^4.2.8",
@@ -466,14 +466,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.4.tgz",
-      "integrity": "sha512-nLGjXuvWWDlQAp505xIONI7Gam0vw2p7Qu3P6on/W2q7rjJXtYjtpHbcsaOjJ/pAju3eTvEQuSuRedcRHVQIAQ==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.9.tgz",
+      "integrity": "sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/nested-clients": "3.993.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
@@ -486,18 +486,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.5.tgz",
-      "integrity": "sha512-VWXKgSISQCI2GKN3zakTNHSiZ0+mux7v6YHmmbLQp/o3fvYUQJmKGcLZZzg2GFA+tGGBStplra9VFNf/WwxpYg==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.10.tgz",
+      "integrity": "sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.4",
-        "@aws-sdk/credential-provider-http": "^3.972.6",
-        "@aws-sdk/credential-provider-ini": "^3.972.4",
-        "@aws-sdk/credential-provider-process": "^3.972.4",
-        "@aws-sdk/credential-provider-sso": "^3.972.4",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.4",
+        "@aws-sdk/credential-provider-env": "^3.972.9",
+        "@aws-sdk/credential-provider-http": "^3.972.11",
+        "@aws-sdk/credential-provider-ini": "^3.972.9",
+        "@aws-sdk/credential-provider-process": "^3.972.9",
+        "@aws-sdk/credential-provider-sso": "^3.972.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.9",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/property-provider": "^4.2.8",
@@ -510,13 +510,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.4.tgz",
-      "integrity": "sha512-TCZpWUnBQN1YPk6grvd5x419OfXjHvhj5Oj44GYb84dOVChpg/+2VoEj+YVA4F4E/6huQPNnX7UYbTtxJqgihw==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.9.tgz",
+      "integrity": "sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/core": "^3.973.11",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -528,15 +528,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.4.tgz",
-      "integrity": "sha512-wzsGwv9mKlwJ3vHLyembBvGE/5nPUIwRR2I51B1cBV4Cb4ql9nIIfpmHzm050XYTY5fqTOKJQnhLj7zj89VG8g==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.9.tgz",
+      "integrity": "sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.982.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/token-providers": "3.982.0",
+        "@aws-sdk/client-sso": "3.993.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/token-providers": "3.993.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -548,14 +548,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.982.0.tgz",
-      "integrity": "sha512-v3M0KYp2TVHYHNBT7jHD9lLTWAdS9CaWJ2jboRKt0WAB65bA7iUEpR+k4VqKYtpQN4+8kKSc4w+K6kUNZkHKQw==",
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.993.0.tgz",
+      "integrity": "sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/nested-clients": "3.993.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -567,14 +567,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.4.tgz",
-      "integrity": "sha512-hIzw2XzrG8jzsUSEatehmpkd5rWzASg5IHUfA+m01k/RtvfAML7ZJVVohuKdhAYx+wV2AThLiQJVzqn7F0khrw==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.9.tgz",
+      "integrity": "sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/nested-clients": "3.993.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.4.tgz",
-      "integrity": "sha512-LPIN505kUqL3xwtoGYgYkctkUUuVUD4pzZfSo+CahavNft+zty5xWYWhKfnZOKBkYCMUl2Hl/9mkoPeYwxfQvQ==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.5.tgz",
+      "integrity": "sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -666,16 +666,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.6.tgz",
-      "integrity": "sha512-TehLN8W/kivl0U9HcS+keryElEWORROpghDXZBLfnb40DXM7hx/i+7OOjkogXQOF3QtUraJVRkHQ07bPhrWKlw==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.11.tgz",
+      "integrity": "sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/core": "^3.973.11",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
-        "@smithy/core": "^3.22.0",
+        "@aws-sdk/util-endpoints": "3.993.0",
+        "@smithy/core": "^3.23.2",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -685,9 +685,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
-      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -702,9 +702,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.4.tgz",
-      "integrity": "sha512-0lHsBuO5eVkWiirSHWVDHLHSghyajcVxSGvmv/6tYFdzaXx2PDvqNdfXhKdDZpOOHGCxuY5d3u11SKbVAtB0+Q==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.6.tgz",
+      "integrity": "sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -716,7 +716,9 @@
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/signature-v4": "^5.3.8",
         "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
         "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -724,45 +726,45 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.982.0.tgz",
-      "integrity": "sha512-VVkaH27digrJfdVrT64rjkllvOp4oRiZuuJvrylLXAKl18ujToJR7AqpDldL/LS63RVne3QWIpkygIymxFtliQ==",
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.993.0.tgz",
+      "integrity": "sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/core": "^3.973.11",
         "@aws-sdk/middleware-host-header": "^3.972.3",
         "@aws-sdk/middleware-logger": "^3.972.3",
         "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
+        "@aws-sdk/util-endpoints": "3.993.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
+        "@aws-sdk/util-user-agent-node": "^3.972.9",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
+        "@smithy/core": "^3.23.2",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-retry": "^4.4.33",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/node-http-handler": "^4.4.10",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-defaults-mode-browser": "^4.3.32",
+        "@smithy/util-defaults-mode-node": "^4.2.35",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -774,9 +776,9 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.982.0.tgz",
-      "integrity": "sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==",
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -808,14 +810,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.983.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.983.0.tgz",
-      "integrity": "sha512-HR9MBAAEeQRpZAQ96XUalr8PhJG1Kr6JRs7Lk3u9MMN6tXFICxbn9s2rThGIJEPnU0t/edc+5F5tgTtQxsqBuQ==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.995.0.tgz",
+      "integrity": "sha512-lYSadNdZZ513qCKoj/KlJ+PgCycL3n8ZNS37qLVFC0t7TbHzoxvGquu9aD2n9OCERAn43OMhQ7dXjYDYdjAXzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.983.0",
+        "@aws-sdk/core": "^3.973.11",
+        "@aws-sdk/nested-clients": "3.995.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -827,45 +829,45 @@
       }
     },
     "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.983.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.983.0.tgz",
-      "integrity": "sha512-4bUzDkJlSPwfegO23ZSBrheuTI8UyAgNzptm1K6fZAIOIc1vnFl12TonecbssAfmM0/UdyTn5QDomwEfIdmJkQ==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.995.0.tgz",
+      "integrity": "sha512-7gq9gismVhESiRsSt0eYe1y1b6jS20LqLk+e/YSyPmGi9yHdndHQLIq73RbEJnK/QPpkQGFqq70M1mI46M1HGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
+        "@aws-sdk/core": "^3.973.11",
         "@aws-sdk/middleware-host-header": "^3.972.3",
         "@aws-sdk/middleware-logger": "^3.972.3",
         "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.983.0",
+        "@aws-sdk/util-endpoints": "3.995.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
+        "@aws-sdk/util-user-agent-node": "^3.972.10",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
+        "@smithy/core": "^3.23.2",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-retry": "^4.4.33",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/node-http-handler": "^4.4.10",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-defaults-mode-browser": "^4.3.32",
+        "@smithy/util-defaults-mode-node": "^4.2.35",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -891,9 +893,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.983.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.983.0.tgz",
-      "integrity": "sha512-t/VbL2X3gvDEjC4gdySOeFFOZGQEBKwa23pRHeB7hBLBZ119BB/2OEFtTFWKyp3bnMQgxpeVeGS7/hxk6wpKJw==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.995.0.tgz",
+      "integrity": "sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -950,13 +952,13 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.4.tgz",
-      "integrity": "sha512-3WFCBLiM8QiHDfosQq3Py+lIMgWlFWwFQliUHUqwEiRqLnKyhgbU3AKa7AWJF7lW2Oc/2kFNY4MlAYVnVc0i8A==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.10.tgz",
+      "integrity": "sha512-LVXzICPlsheET+sE6tkcS47Q5HkSTrANIlqL1iFxGAY/wRQ236DX/PCAK56qMh9QJoXAfXfoRW0B0Og4R+X7Nw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.11",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
@@ -975,14 +977,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.4.tgz",
-      "integrity": "sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.5.tgz",
+      "integrity": "sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.3.4",
+        "fast-xml-parser": "5.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1089,9 +1091,9 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0.tgz",
-      "integrity": "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1100,13 +1102,13 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0.tgz",
-      "integrity": "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.1.tgz",
+      "integrity": "sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.0.0",
+        "@clack/core": "1.0.1",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
       }
@@ -1594,20 +1596,22 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.34.0.tgz",
-      "integrity": "sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.42.0.tgz",
+      "integrity": "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
         "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.0"
+        "@modelcontextprotocol/sdk": "^1.25.2"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
@@ -1648,9 +1652,9 @@
       }
     },
     "node_modules/@grammyjs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-D3jQ4UWERPsyR3op/YFudMMIPNTU47vy7L51uO9/73tMELmjO/+LX5N36/Y0CG5IQfIsz43MxiHI5rgsK0/k+g==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.24.0.tgz",
+      "integrity": "sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1672,13 +1676,13 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.4.tgz",
-      "integrity": "sha512-qK6ZgGx0wwOubq/MY6eTbhApQHBUQCvCOsTYpQE01uLvfA2/Prm6egySHlZouKaina1RPuDwfLhCmsRCxwHj3Q==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.5.tgz",
+      "integrity": "sha512-f7MAw7YuoEYgJEQ1VyRcLHGuVmCpmXi65GVR8CAtPWPqIZf/HFr4vHzVpOfQMpEQw9Pt5uh07guuLt5HE8ruog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.1",
+        "debug": "^4.4.3",
         "fast-deep-equal": "^3.1.3",
         "source-map-support": "^0.5.21",
         "tslib": "^2.8.1"
@@ -2201,29 +2205,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2265,6 +2246,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -2329,9 +2328,9 @@
       "license": "MIT"
     },
     "node_modules/@larksuiteoapi/node-sdk": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.58.0.tgz",
-      "integrity": "sha512-NcQNHdGuHOxOWY3bRGS9WldwpbR6+k7Fi0H1IJXDNNmbSrEB/8rLwqHRC8tAbbj/Mp8TWH/v1O+p487m6xskxw==",
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.59.0.tgz",
+      "integrity": "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2340,8 +2339,8 @@
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0",
         "protobufjs": "^7.2.6",
-        "qs": "^6.13.0",
-        "ws": "^8.16.0"
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
       }
     },
     "node_modules/@line/bot-sdk": {
@@ -2674,28 +2673,28 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.51.3.tgz",
-      "integrity": "sha512-pO5ScRuf7F5GCqS02vuB3gIV/MHR2cskEEUnbVbkSf0RHJb3vTICy/ACQyeI+UYk7yjFmdvQgbSUtVrYJ3q8Ag==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.53.0.tgz",
+      "integrity": "sha512-LswcyVHrW2LfRRGU8xXp69/7oTt6iXCmphZC2w46emPbFNK/lMR10INfkDt1HB59/0UqrLvoZRznutg4wwJriw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.51.3"
+        "@mariozechner/pi-ai": "^0.53.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.51.3.tgz",
-      "integrity": "sha512-NocfuwUPCGeNhWyfzSGKbsTqUvFmP+VihU8+xtzX9FoHvQQVJHQ49Sz8sfLK04BbEWYI9s/gZ7a9xnJ0O4cz8g==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.53.0.tgz",
+      "integrity": "sha512-f6dIzxLoVlB7TrT18N48oEUKzyoTw/ujB5zLxklFtpgaCVj9TRVf5manpT+2OYFwq3B6KANJ8X3WfDNCiKBEhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.71.2",
-        "@aws-sdk/client-bedrock-runtime": "^3.966.0",
-        "@google/genai": "1.34.0",
+        "@anthropic-ai/sdk": "^0.73.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
+        "@google/genai": "^1.40.0",
         "@mistralai/mistralai": "1.10.0",
         "@sinclair/typebox": "^0.34.41",
         "ajv": "^8.17.1",
@@ -2715,22 +2714,23 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.51.3.tgz",
-      "integrity": "sha512-pu/4IxeMZMapYiSO3LWvNRztOXXKLlLNL+drjMvtgWbp9MJ8azP+5Zwsp3/vzrPvM54wCkaSa0voUEThm4Ba/Q==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.53.0.tgz",
+      "integrity": "sha512-phqo3A7WuKUTZ/HVtVQyWfaHrezVgeAdDc0hc9sw9d4gT4djVtCCOrD3cUtkyo6bYvGYKAD+aWL5bi5RMmCQew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.51.3",
-        "@mariozechner/pi-ai": "^0.51.3",
-        "@mariozechner/pi-tui": "^0.51.3",
+        "@mariozechner/pi-agent-core": "^0.53.0",
+        "@mariozechner/pi-ai": "^0.53.0",
+        "@mariozechner/pi-tui": "^0.53.0",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
         "diff": "^8.0.2",
         "file-type": "^21.1.1",
-        "glob": "^11.0.3",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
         "ignore": "^7.0.5",
         "marked": "^15.0.12",
         "minimatch": "^10.1.1",
@@ -2748,15 +2748,16 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.51.3.tgz",
-      "integrity": "sha512-1B9C3oVsAcBSO0rvk4qC3Iq655LveLQDSnlseypCo/KiR5eY39Hw1XRtvq5N05mtxNuo3mRw8FMcYCwIl1BbDg==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.53.0.tgz",
+      "integrity": "sha512-ffma5Xj6DTN8FWA+6jM5tDiFicF/NnyNSwPH0vw2oqkXqlXt1zSSM9FymZIbSjDLW+A/f1zMvAHORhFIeQTBJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
         "chalk": "^5.5.0",
         "get-east-asian-width": "^1.3.0",
+        "koffi": "^2.9.0",
         "marked": "^15.0.12",
         "mime-types": "^3.0.1"
       },
@@ -4366,9 +4367,9 @@
       }
     },
     "node_modules/@slack/types": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.19.0.tgz",
-      "integrity": "sha512-7+QZ38HGcNh/b/7MpvPG6jnw7mliV6UmrquJLqgdxkzJgQEYUcEztvFWRU49z0x4vthF0ixL5lTK601AXrS8IA==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.0.tgz",
+      "integrity": "sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4377,17 +4378,17 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.13.0.tgz",
-      "integrity": "sha512-ERcExbWrnkDN8ovoWWe6Wgt/usanj1dWUd18dJLpctUI4mlPS0nKt81Joh8VI+OPbNnY1lIilVt9gdMBD9U2ig==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.14.1.tgz",
+      "integrity": "sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.0",
-        "@slack/types": "^2.18.0",
+        "@slack/types": "^2.20.0",
         "@types/node": ">=18.0.0",
         "@types/retry": "0.12.0",
-        "axios": "^1.11.0",
+        "axios": "^1.13.5",
         "eventemitter3": "^5.0.1",
         "form-data": "^4.0.4",
         "is-electron": "2.2.2",
@@ -4434,9 +4435,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.22.1.tgz",
-      "integrity": "sha512-x3ie6Crr58MWrm4viHqqy2Du2rHYZjwu8BekasrQx4ca+Y24dzVAwq3yErdqIbc2G3I0kLQA13PQ+/rde+u65g==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.2.tgz",
+      "integrity": "sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4446,7 +4447,7 @@
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.11",
+        "@smithy/util-stream": "^4.5.12",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -4623,13 +4624,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.13.tgz",
-      "integrity": "sha512-x6vn0PjYmGdNuKh/juUJJewZh7MoQ46jYaJ2mvekF4EesMuFfrl4LaW/k97Zjf8PTCPQmPgMvwewg7eNoH9n5w==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.16.tgz",
+      "integrity": "sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.22.1",
+        "@smithy/core": "^3.23.2",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -4643,16 +4644,16 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.30",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.30.tgz",
-      "integrity": "sha512-CBGyFvN0f8hlnqKH/jckRDz78Snrp345+PVk8Ux7pnkUCW97Iinse59lY78hBt04h1GZ6hjBN94BRwZy1xC8Bg==",
+      "version": "4.4.33",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.33.tgz",
+      "integrity": "sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -4709,9 +4710,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.9.tgz",
-      "integrity": "sha512-KX5Wml5mF+luxm1szW4QDz32e3NObgJ4Fyw+irhph4I/2geXwUy4jkIMUs5ZPGflRBeR6BUkC2wqIab4Llgm3w==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
+      "integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4830,18 +4831,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.2.tgz",
-      "integrity": "sha512-SCkGmFak/xC1n7hKRsUr6wOnBTJ3L22Qd4e8H1fQIuKTAjntwgU8lrdMe7uHdiT2mJAOWA/60qaW9tiMu69n1A==",
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.5.tgz",
+      "integrity": "sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.22.1",
-        "@smithy/middleware-endpoint": "^4.4.13",
+        "@smithy/core": "^3.23.2",
+        "@smithy/middleware-endpoint": "^4.4.16",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.11",
+        "@smithy/util-stream": "^4.5.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4945,14 +4946,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.29",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.29.tgz",
-      "integrity": "sha512-nIGy3DNRmOjaYaaKcQDzmWsro9uxlaqUOhZDHQed9MW/GmkBZPtnU70Pu1+GT9IBmUXwRdDuiyaeiy9Xtpn3+Q==",
+      "version": "4.3.32",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.32.tgz",
+      "integrity": "sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -4961,9 +4962,9 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.32",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.32.tgz",
-      "integrity": "sha512-7dtFff6pu5fsjqrVve0YMhrnzJtccCWDacNKOkiZjJ++fmjGExmmSu341x+WU6Oc1IccL7lDuaUj7SfrHpWc5Q==",
+      "version": "4.2.35",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.35.tgz",
+      "integrity": "sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4971,7 +4972,7 @@
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/smithy-client": "^4.11.5",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -5037,14 +5038,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.11.tgz",
-      "integrity": "sha512-lKmZ0S/3Qj2OF5H1+VzvDLb6kRxGzZHq6f3rAsoSu5cTLGsn3v3VQBA8czkNNXlLjoFEtVu3OQT2jEeOtOE2CA==",
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
+      "integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.9",
+        "@smithy/node-http-handler": "^4.4.10",
         "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
@@ -5583,9 +5584,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5753,23 +5754,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -5859,20 +5863,23 @@
       "license": "MIT"
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -6160,24 +6167,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cli-highlight/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/cli-highlight/node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -6245,22 +6234,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -6272,24 +6245,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/cmake-js": {
@@ -6666,9 +6621,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.38",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.38.tgz",
-      "integrity": "sha512-7qcM5IeZrfb+LXW07HvoI5L+j4PQeMZXEkSm1htHAHh4Y9JSMXBWjy/r7zmUCOj4F7zNjMcm7IMWr131MT2h0Q==",
+      "version": "0.38.40",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.40.tgz",
+      "integrity": "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -6735,9 +6690,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -7164,9 +7119,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "dev": true,
       "funding": [
         {
@@ -7176,7 +7131,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -7624,25 +7579,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7698,14 +7646,14 @@
       "license": "ISC"
     },
     "node_modules/grammy": {
-      "version": "1.39.3",
-      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.39.3.tgz",
-      "integrity": "sha512-7arRRoOtOh9UwMwANZ475kJrWV6P3/EGNooeHlY0/SwZv4t3ZZ3Uiz9cAXK8Zg9xSdgmm8T21kx6n7SZaWvOcw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.40.0.tgz",
+      "integrity": "sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@grammyjs/types": "3.23.0",
+        "@grammyjs/types": "3.24.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.4.3",
         "node-fetch": "^2.7.0"
@@ -7831,23 +7779,25 @@
         "node": "*"
       }
     },
-    "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/hookified": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
       "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
@@ -8191,19 +8141,19 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
-      "engines": {
-        "node": "20 || >=22"
-      },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -8381,6 +8331,17 @@
       "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
+      "integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
     "node_modules/libsignal": {
@@ -8632,9 +8593,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8749,16 +8710,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8775,11 +8736,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -8953,9 +8914,9 @@
       }
     },
     "node_modules/node-edge-tts": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.9.tgz",
-      "integrity": "sha512-fvfW1dUgJdZAdTniC6MzLTMwnNUFKGKaUdRJ1OsveOYlfnPUETBU973CG89565txvbBowCQ4Czdeu3qSX8bNOg==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.10.tgz",
+      "integrity": "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9216,61 +9177,61 @@
       }
     },
     "node_modules/openclaw": {
-      "version": "2026.2.3",
-      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.2.3.tgz",
-      "integrity": "sha512-nAYjR0sfZf85h6h9idqWvose0v4fQ+6ATk7uldNg3bQ8EzOpFrPzMCx75rGjAj9bsBFTmT9/9eMAIref+cxVIw==",
+      "version": "2026.2.19-2",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.2.19-2.tgz",
+      "integrity": "sha512-nM6gPesq1rTkJMP0RXQH3iq776Dsoht1Jsv+tKtk40k4qc09aFk3Vfu7OsEFAMmqIO4LJUmh0Z8uZ1VOXvER4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "0.13.1",
-        "@aws-sdk/client-bedrock": "^3.981.0",
+        "@agentclientprotocol/sdk": "0.14.1",
+        "@aws-sdk/client-bedrock": "^3.993.0",
         "@buape/carbon": "0.14.0",
-        "@clack/prompts": "^1.0.0",
+        "@clack/prompts": "^1.0.1",
         "@grammyjs/runner": "^2.0.3",
         "@grammyjs/transformer-throttler": "^1.2.1",
-        "@homebridge/ciao": "^1.3.4",
-        "@larksuiteoapi/node-sdk": "^1.42.0",
+        "@homebridge/ciao": "^1.3.5",
+        "@larksuiteoapi/node-sdk": "^1.59.0",
         "@line/bot-sdk": "^10.6.0",
         "@lydell/node-pty": "1.2.0-beta.3",
-        "@mariozechner/pi-agent-core": "0.51.3",
-        "@mariozechner/pi-ai": "0.51.3",
-        "@mariozechner/pi-coding-agent": "0.51.3",
-        "@mariozechner/pi-tui": "0.51.3",
+        "@mariozechner/pi-agent-core": "0.53.0",
+        "@mariozechner/pi-ai": "0.53.0",
+        "@mariozechner/pi-coding-agent": "0.53.0",
+        "@mariozechner/pi-tui": "0.53.0",
         "@mozilla/readability": "^0.6.0",
         "@sinclair/typebox": "0.34.48",
         "@slack/bolt": "^4.6.0",
-        "@slack/web-api": "^7.13.0",
+        "@slack/web-api": "^7.14.1",
         "@whiskeysockets/baileys": "7.0.0-rc.9",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "chalk": "^5.6.2",
         "chokidar": "^5.0.0",
         "cli-highlight": "^2.1.11",
         "commander": "^14.0.3",
         "croner": "^10.0.1",
-        "discord-api-types": "^0.38.38",
-        "dotenv": "^17.2.3",
+        "discord-api-types": "^0.38.39",
+        "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "file-type": "^21.3.0",
-        "grammy": "^1.39.3",
-        "hono": "4.11.7",
+        "grammy": "^1.40.0",
+        "https-proxy-agent": "^7.0.6",
         "jiti": "^2.6.1",
         "json5": "^2.2.3",
         "jszip": "^3.10.1",
         "linkedom": "^0.18.12",
         "long": "^5.3.2",
-        "markdown-it": "^14.1.0",
-        "node-edge-tts": "^1.2.9",
+        "markdown-it": "^14.1.1",
+        "node-edge-tts": "^1.2.10",
         "osc-progress": "^0.3.0",
         "pdfjs-dist": "^5.4.624",
-        "playwright-core": "1.58.1",
+        "playwright-core": "1.58.2",
         "proper-lockfile": "^4.1.2",
         "qrcode-terminal": "^0.12.0",
         "sharp": "^0.34.5",
         "signal-utils": "^0.21.1",
         "sqlite-vec": "0.1.7-alpha.2",
-        "tar": "7.5.7",
+        "tar": "7.5.9",
         "tslog": "^4.10.2",
-        "undici": "^7.20.0",
+        "undici": "^7.22.0",
         "ws": "^8.19.0",
         "yaml": "^2.8.2",
         "zod": "^4.3.6"
@@ -9320,9 +9281,9 @@
       }
     },
     "node_modules/openclaw/node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9609,9 +9570,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9619,7 +9580,7 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -9729,9 +9690,9 @@
       "license": "MIT"
     },
     "node_modules/playwright-core": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10001,9 +9962,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10180,6 +10141,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/rimraf/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -10200,22 +10178,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/rimraf/node_modules/lru-cache": {
@@ -11460,9 +11422,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
-      "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11795,18 +11757,18 @@
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -11870,29 +11832,43 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "openclaw": ">=2026.2.0",
+    "openclaw": "2026.2.19-2",
     "vitest": "3"
   },
   "openclaw": {

--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ChannelStatusAdapter, ChannelAccountSnapshot, OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, createDefaultChannelRuntimeState, buildBaseChannelStatusSummary } from "openclaw/plugin-sdk";
 import type { ResolvedBasecampAccount, BasecampChannelConfig, BasecampProject } from "../types.js";
 import { bcqAuthStatus, bcqMe, bcqApiGet } from "../bcq.js";
 import type { BcqOptions } from "../bcq.js";
@@ -68,13 +68,7 @@ function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefi
 }
 
 export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount, BasecampProbe, BasecampAudit> = {
-  defaultRuntime: {
-    accountId: DEFAULT_ACCOUNT_ID,
-    running: false,
-    lastStartAt: null,
-    lastStopAt: null,
-    lastError: null,
-  },
+  defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
 
   probeAccount: async ({ account }) => {
     const bcqOpts: BcqOptions = {};
@@ -220,12 +214,8 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
   },
 
   buildChannelSummary: ({ snapshot }) => ({
-    configured: snapshot.configured ?? false,
+    ...buildBaseChannelStatusSummary(snapshot),
     tokenSource: snapshot.tokenSource ?? "none",
-    running: snapshot.running ?? false,
-    lastStartAt: snapshot.lastStartAt ?? null,
-    lastStopAt: snapshot.lastStopAt ?? null,
-    lastError: snapshot.lastError ?? null,
     probe: snapshot.probe,
   }),
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -11,7 +11,7 @@
  *    to send the agent's response back to the correct Basecamp surface
  */
 
-import type { BasecampInboundMessage, BasecampChannelConfig, BasecampEngagementType, ResolvedBasecampAccount } from "./types.js";
+import type { BasecampInboundMessage, BasecampChannelConfig, BasecampEngagementType, BasecampPeer, ResolvedBasecampAccount } from "./types.js";
 import { DEFAULT_ENGAGE } from "./types.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { getBasecampRuntime } from "./runtime.js";
@@ -72,12 +72,17 @@ export async function dispatchBasecampEvent(
   const effectiveAccountId = resolveProjectScopeAccountId(cfg, msg) ?? msg.accountId;
 
   // ----- Route resolution -----
+  // Map Basecamp's "dm" → SDK's "direct" at the boundary.
+  const toRoutePeer = (p: BasecampPeer) => ({
+    ...p,
+    kind: (p.kind === "dm" ? "direct" : p.kind) as "direct" | "group",
+  });
   const route = runtime.channel.routing.resolveAgentRoute({
     cfg,
     channel: "basecamp",
     accountId: effectiveAccountId,
-    peer: msg.peer,
-    parentPeer: msg.parentPeer,
+    peer: toRoutePeer(msg.peer),
+    parentPeer: msg.parentPeer ? toRoutePeer(msg.parentPeer) : undefined,
   });
 
   if (!route) {

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -39,6 +39,20 @@ vi.mock("openclaw/plugin-sdk", () => ({
   buildChannelConfigSchema: (schema: any) => schema,
   PAIRING_APPROVED_MESSAGE:
     "You have been approved to message this agent.",
+  createDefaultChannelRuntimeState: (accountId: string) => ({
+    accountId,
+    running: false,
+    lastStartAt: null,
+    lastStopAt: null,
+    lastError: null,
+  }),
+  buildBaseChannelStatusSummary: (snapshot: Record<string, unknown>) => ({
+    configured: snapshot.configured ?? false,
+    running: snapshot.running ?? false,
+    lastStartAt: snapshot.lastStartAt ?? null,
+    lastStopAt: snapshot.lastStopAt ?? null,
+    lastError: snapshot.lastError ?? null,
+  }),
 }));
 
 // ---------------------------------------------------------------------------

--- a/tests/status-enhanced.test.ts
+++ b/tests/status-enhanced.test.ts
@@ -6,6 +6,20 @@ vi.mock("openclaw/plugin-sdk", () => ({
     const trimmed = (value ?? "").trim();
     return trimmed || "default";
   },
+  createDefaultChannelRuntimeState: (accountId: string) => ({
+    accountId,
+    running: false,
+    lastStartAt: null,
+    lastStopAt: null,
+    lastError: null,
+  }),
+  buildBaseChannelStatusSummary: (snapshot: Record<string, unknown>) => ({
+    configured: snapshot.configured ?? false,
+    running: snapshot.running ?? false,
+    lastStartAt: snapshot.lastStartAt ?? null,
+    lastStopAt: snapshot.lastStopAt ?? null,
+    lastError: snapshot.lastError ?? null,
+  }),
 }));
 
 vi.mock("../src/bcq.js", () => ({


### PR DESCRIPTION
## Summary

- **Bump openclaw** from 2026.2.3 → 2026.2.19-2 (exact pin, 16 patch versions)
- **Adapt to SDK type changes:** map `BasecampPeerKind "dm"` → `ChatType "direct"` at the `resolveAgentRoute` boundary; add explicit plugin export annotation for new `configSchema` types
- **Adopt SDK helpers:** `createDefaultChannelRuntimeState` and `buildBaseChannelStatusSummary` in the status adapter, replacing hand-written literals
- **Add migration spec** (`docs/bcq-to-sdk-migration.md`): five-phase plan to replace `src/bcq.ts` child-process layer with `@basecamp/sdk` typed HTTP client — covers all 19 bcq functions, four risk tiers, every affected file cataloged

### Not adopted (deliberate)
- `rejectNonPostWebhookRequest` — SDK barrel import pulls `json5` transitively, breaks vitest ESM resolution in test files that don't mock the SDK
- `createAccountListHelpers` — doesn't call `normalizeAccountId`, would change behavior
- `readJsonFileWithFallback` / `writeJsonFileAtomically` — async, not drop-in for existing sync stores
- `chunkTextForOutbound` — doesn't preserve fenced code blocks as atomic units
- `createDedupeCache` — simpler than plugin's dual-key persistent dedup

## Test plan
- [x] `npx tsc --noEmit` — clean compilation
- [x] `npm test` — 866 tests pass (50 files, 0 failures)
- [x] Bump-only checkpoint verified before adopting helpers
- [x] Smoke test in live gateway environment