### PR TITLE
Inbound correctness: Ping enrichment, webhook assignments, unknown-kind policy

### DIFF
--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -55,6 +55,10 @@ export type BasecampAudit = {
   dispatchFailures?: number;
   /** Count of events dropped due to full dispatch queue. */
   queueFullDrops?: number;
+  /** Count of events dropped because their kind was not in KIND_TO_RECORDABLE_TYPE. */
+  unknownKindCount?: number;
+  /** Most recent unknown kind string (for diagnostics). */
+  lastUnknownKind?: string | null;
 };
 
 /** Seconds since last successful poll, or null if never succeeded. */
@@ -186,6 +190,10 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
       }
       if (metrics.queueFullDropCount > 0) {
         result.queueFullDrops = metrics.queueFullDropCount;
+      }
+      if (metrics.unknownKindCount > 0) {
+        result.unknownKindCount = metrics.unknownKindCount;
+        result.lastUnknownKind = metrics.lastUnknownKind;
       }
     }
 
@@ -332,6 +340,15 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
           kind: "runtime",
           message: `${audit.queueFullDrops} event(s) dropped due to full dispatch queue`,
           fix: "Check for slow agent responses or increase dispatch concurrency",
+        });
+      }
+      if (audit?.unknownKindCount && audit.unknownKindCount > 0) {
+        issues.push({
+          channel: "basecamp",
+          accountId: s.accountId,
+          kind: "runtime",
+          message: `${audit.unknownKindCount} event(s) dropped with unknown kind (last: ${audit.lastUnknownKind ?? "?"})`,
+          fix: "Add the kind to KIND_TO_RECORDABLE_TYPE in normalize.ts, or upgrade the plugin",
         });
       }
     }

--- a/src/bcq.ts
+++ b/src/bcq.ts
@@ -411,23 +411,45 @@ export async function bcqMarkReadingsRead(
 }
 
 /**
+ * Circle (Ping) info returned from the Basecamp Circle API.
+ * GET /circles/<bucketId>.json returns the full circle including members.
+ */
+export interface CircleInfo {
+  transcriptId: string | undefined;
+  /** Total participant count including the caller (people.length + 1). */
+  participantCount: number;
+}
+
+/**
+ * Fetch a Circle (Ping) and return its transcript ID + participant count.
+ * GET /circles/<bucketId>.json — the `people` array excludes the
+ * authenticated caller, so total = people.length + 1.
+ */
+export async function bcqGetCircle(
+  bucketId: string,
+  opts: BcqOptions = {},
+): Promise<CircleInfo> {
+  const result = await bcqGet<{ room_url?: string; people?: Array<{ id: number }> }>(
+    `/circles/${bucketId}.json`,
+    opts,
+  );
+  const roomUrl = result.data?.room_url;
+  const transcriptId = roomUrl ? /\/chats\/(\d+)/.exec(roomUrl)?.[1] : undefined;
+  // people array excludes the authenticated caller
+  const participantCount = (result.data?.people?.length ?? 0) + 1;
+  return { transcriptId, participantCount };
+}
+
+/**
  * Resolve a Ping (Circle) to its chat transcript ID.
- * Fetches GET /circles/<bucketId>.json and extracts the transcript ID
- * from the room_url field (format: /buckets/<id>/chats/<transcriptId>).
+ * Convenience wrapper around bcqGetCircle for callers that only need transcriptId.
  */
 export async function bcqResolvePingTranscript(
   bucketId: string,
   opts: BcqOptions = {},
 ): Promise<string | undefined> {
-  const result = await bcqGet<{ room_url?: string }>(
-    `/circles/${bucketId}.json`,
-    opts,
-  );
-  const roomUrl = result.data?.room_url;
-  if (!roomUrl) return undefined;
-  // room_url format: /buckets/<bucketId>/chats/<transcriptId>
-  const match = /\/chats\/(\d+)/.exec(roomUrl);
-  return match ? match[1] : undefined;
+  const info = await bcqGetCircle(bucketId, opts);
+  return info.transcriptId;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -16,9 +16,10 @@ import {
   resolveDefaultBasecampAccountId,
   resolveBasecampAllowFrom,
   resolveWebhooksConfig,
+  resolveAccountForBucket,
 } from "./config.js";
 import { getBasecampRuntime } from "./runtime.js";
-import { sendBasecampText } from "./outbound/send.js";
+import { sendBasecampText, sendBasecampMedia } from "./outbound/send.js";
 import { dispatchBasecampEvent } from "./dispatch.js";
 import { bcqAuthStatus, execBcqAuthLogin } from "./bcq.js";
 import { basecampOnboardingAdapter } from "./adapters/onboarding.js";
@@ -188,6 +189,10 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       const result = await sendBasecampText({ to, text, accountId });
       return { channel: "basecamp", messageId: result.messageId };
     },
+    sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+      const result = await sendBasecampMedia({ to, text, mediaUrl, accountId });
+      return { channel: "basecamp", messageId: result.messageId };
+    },
   },
 
   gateway: {
@@ -312,14 +317,31 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
 
       // Auto-register webhooks for configured projects
       const whConfig = resolveWebhooksConfig(ctx.cfg);
+      // Scope projects to this account. In multi-account mode, only reconcile
+      // projects that map to the current account via virtualAccounts. Unmapped
+      // projects are only eligible when there is exactly one concrete account
+      // (single-account mode) — otherwise skip + warn to prevent cross-account
+      // delete/recreate churn.
+      const concreteAccountIds = listBasecampAccountIds(ctx.cfg);
+      const isSingleAccount = concreteAccountIds.length <= 1;
+      const accountProjects = whConfig.projects.filter((projectId) => {
+        const owner = resolveAccountForBucket(ctx.cfg, projectId);
+        if (owner) return owner === account.accountId;
+        if (isSingleAccount) return true;
+        ctx.log?.warn(
+          `[${account.accountId}] skipping unmapped webhook project ${projectId} — ` +
+          `add a virtualAccounts entry to assign it to an account`,
+        );
+        return false;
+      });
       let webhookActiveProjects: Set<string> | undefined;
-      if (whConfig.autoRegister && whConfig.payloadUrl && whConfig.projects.length > 0) {
+      if (whConfig.autoRegister && whConfig.payloadUrl && accountProjects.length > 0) {
         const registry = getWebhookSecretRegistry(account.accountId);
         try {
           const result = await reconcileWebhooks(
             {
               payloadUrl: whConfig.payloadUrl,
-              projects: whConfig.projects,
+              projects: accountProjects,
               types: whConfig.types,
               bcqOpts: { accountId: bcqAccountId, profile: account.bcqProfile },
             },
@@ -332,10 +354,12 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
             } : undefined,
           );
           ctx.log?.info(
-            `[${account.accountId}] webhook reconciliation: ${result.created.length} created, ${result.existing.length} existing, ${result.failed.length} failed`,
+            `[${account.accountId}] webhook reconciliation: ` +
+            `${result.created.length} created, ${result.existing.length} existing, ` +
+            `${result.recovered.length} recovered, ${result.failed.length} failed`,
           );
-          // Projects with active webhooks (created or already existing)
-          const active = [...result.created, ...result.existing];
+          // Projects with active webhooks (created, already existing, or recovered)
+          const active = [...result.created, ...result.existing, ...result.recovered];
           if (active.length > 0) {
             webhookActiveProjects = new Set(active);
           }

--- a/src/inbound/activity.ts
+++ b/src/inbound/activity.ts
@@ -69,8 +69,10 @@ export async function pollActivityFeed(
     }
 
     try {
-      const normalized = normalizeActivityEvent(raw, account);
-      events.push(normalized);
+      const normalized = await normalizeActivityEvent(raw, account);
+      if (normalized) {
+        events.push(normalized);
+      }
 
       if (!newestAt || raw.created_at > newestAt) {
         newestAt = raw.created_at;

--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -20,10 +20,13 @@ import type {
   BasecampRecordableType,
   BasecampSender,
   BasecampWebhookPayload,
+  WebhookEventDetails,
   ResolvedBasecampAccount,
 } from "../types.js";
 import { mentionsAgent, extractAttachmentSgids, htmlToPlainText } from "../mentions/parse.js";
 import { EventDedup } from "./dedup.js";
+import { recordUnknownKind } from "../metrics.js";
+import { resolveCircleInfoCached } from "../outbound/send.js";
 
 // ---------------------------------------------------------------------------
 // event.kind → recordableType mapping (expanded from TimelinesApiHelper)
@@ -85,6 +88,11 @@ const KIND_TO_RECORDABLE_TYPE: Record<string, BasecampRecordableType> = {
   inbox_reply_created: "Comment",
   client_reply_created: "Comment",
   client_forward_created: "Message",
+
+  // Assignments (via BC3 Recording::Assignable — kind is *_assignment_changed)
+  todo_assignment_changed: "Todo",
+  kanban_card_assignment_changed: "Kanban::Card",
+  kanban_step_assignment_changed: "Kanban::Card",
 };
 
 /** Map event.kind to a normalized eventKind for our domain model. */
@@ -96,6 +104,7 @@ function resolveEventKind(kind: string): string {
   if (kind.endsWith("_rollup")) return "created";
   if (kind.endsWith("_rescheduled")) return "edited";
   if (kind.endsWith("_moved")) return "moved";
+  if (kind.endsWith("_assignment_changed")) return "assigned";
   if (kind.endsWith("_assigned")) return "assigned";
   if (kind.endsWith("_unassigned")) return "assigned";
   return kind;
@@ -193,7 +202,7 @@ export function parseRecordingIdFromIdentifier(identifier: string): string | und
  *
  * - Chat::Line → parent transcript: recording:<transcriptId>
  * - Comment → parent recording: recording:<parentRecordingId>
- * - Pings → ping:<circleBucketId> (dm if participant count known ≤2, else group)
+ * - Pings → ping:<circleBucketId> (group if participant count known >2, else dm — fail-closed)
  * - Everything else → recording:<recordingId>
  */
 export function resolveBasecampPeer(params: {
@@ -208,11 +217,13 @@ export function resolveBasecampPeer(params: {
     params;
 
   if (isPing) {
-    // Default to "group" when participant count is unknown (undefined/0).
-    // Only classify as "dm" when we positively know there are ≤2 participants.
-    const kind = participantCount != null && participantCount > 0 && participantCount <= 2
-      ? "dm"
-      : "group";
+    // Fail closed: when participant count is unknown (Circle API failure),
+    // default to "dm" so DM policy applies. This prevents API outages from
+    // relaxing DM gating on actual 1:1 Pings by misclassifying them as group.
+    // When count is known: ≤2 = dm, >2 = group.
+    const kind = participantCount != null && participantCount > 2
+      ? "group"
+      : "dm";
     return { kind, id: `ping:${bucketId}` };
   }
 
@@ -255,6 +266,32 @@ export function isSelfMessage(
 }
 
 // ---------------------------------------------------------------------------
+// Webhook assignment detail helpers
+// ---------------------------------------------------------------------------
+
+/** True when the BC3 event kind represents an assignment change. */
+function isAssignmentChangedKind(kind: string): boolean {
+  return kind.endsWith("_assignment_changed");
+}
+
+/**
+ * Parse assignment person IDs from webhook event details.
+ * BC3 Event::Detail::PeopleChanges writes `added_person_ids` and
+ * `removed_person_ids` as integer arrays. Validates each element.
+ */
+function parseAssignmentDetails(details: WebhookEventDetails | undefined): {
+  addedPersonIds: number[];
+  removedPersonIds: number[];
+} {
+  const addedRaw = details?.added_person_ids;
+  const removedRaw = details?.removed_person_ids;
+  return {
+    addedPersonIds: Array.isArray(addedRaw) ? addedRaw.filter((id): id is number => typeof id === "number") : [],
+    removedPersonIds: Array.isArray(removedRaw) ? removedRaw.filter((id): id is number => typeof id === "number") : [],
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Activity feed normalization
 // ---------------------------------------------------------------------------
 
@@ -266,14 +303,20 @@ export function isSelfMessage(
  * `parent_recording_id`, `summary_excerpt`, `title`, etc.
  * Recording ID must be parsed from `app_url`.
  */
-export function normalizeActivityEvent(
+export async function normalizeActivityEvent(
   raw: BasecampActivityEvent,
   account: ResolvedBasecampAccount,
-): BasecampInboundMessage {
+): Promise<BasecampInboundMessage | null> {
   const recordableType = resolveRecordableType(
     raw.kind,
     raw.recording?.recordable_type ?? raw.recording?.type,
   );
+
+  // Unknown kind → drop with metric rather than misclassifying as Document
+  if (!recordableType) {
+    recordUnknownKind(account.accountId, raw.kind);
+    return null;
+  }
 
   const bucketId = String(raw.bucket.id);
 
@@ -313,8 +356,6 @@ export function normalizeActivityEvent(
     avatarUrl: raw.creator.avatar_url,
   };
 
-  const effectiveRecordableType = recordableType ?? "Document";
-
   // Detect Pings: activity events for Pings use /circles/<id> URLs
   // instead of /buckets/<id>. Also check recording.type if available.
   const isPing =
@@ -322,32 +363,40 @@ export function normalizeActivityEvent(
     raw.recording?.type === "Ping" ||
     raw.recording?.recordable_type === "Ping";
 
+  // Enrich Ping participant count via Circle API (activity feed lacks it).
+  // Defaults to undefined → resolveBasecampPeer conservatively uses "group".
+  let participantCount: number | undefined;
+  if (isPing) {
+    const bcqAccountId = account.config.bcqAccountId ?? account.accountId;
+    const circleInfo = await resolveCircleInfoCached(bucketId, bcqAccountId, account.bcqProfile);
+    participantCount = circleInfo?.participantCount;
+  }
+
   const peer = resolveBasecampPeer({
-    recordableType: effectiveRecordableType,
+    recordableType,
     recordingId,
     parentRecordingId,
     bucketId,
     isPing,
+    participantCount,
   });
 
   const parentPeer = resolveParentPeer(bucketId, isPing);
 
-  // Detect assignment events directed at the agent.
-  // bc3 assignment event kinds put the assignee's display name in `target`.
-  const isAssignmentKind = raw.kind.endsWith("_assigned") || raw.kind.endsWith("_unassigned");
-  const isAssignedToAgent = isAssignmentKind &&
-    typeof raw.target === "string" &&
-    typeof account.displayName === "string" &&
-    raw.target === account.displayName;
+  // Assignment detection is NOT possible from the activity feed:
+  // - BC3 emits kind "todo_assignment_changed" (not _assigned/_unassigned suffixes)
+  // - The activity feed's `target` field is the recording title, not the assignee name
+  //   (timeline_api_event_title() falls through to event.recording.title for assignment_changed)
+  // - The activity feed doesn't carry `details` (no added_person_ids)
+  // Assignments are detected via: (1) webhook details.added_person_ids, (2) pollAssignments set-diff.
 
   const meta: BasecampInboundMeta = {
     bucketId,
     recordingId,
-    recordableType: effectiveRecordableType,
+    recordableType,
     eventKind: resolveEventKind(raw.kind) as BasecampInboundMeta["eventKind"],
     mentions: sgids,
     mentionsAgent: isAgentMentioned,
-    assignedToAgent: isAssignedToAgent || undefined,
     attachments: (raw.attachments ?? []).map((a) => ({
       sgid: a.sgid ?? "",
       url: a.url,
@@ -358,13 +407,8 @@ export function normalizeActivityEvent(
     sources: ["activity_feed"],
   };
 
-  if (effectiveRecordableType === "Comment" || effectiveRecordableType === "Chat::Line") {
+  if (recordableType === "Comment" || recordableType === "Chat::Line") {
     meta.messageId = recordingId;
-  }
-
-  // Preserve the raw kind for unknown types so dispatch/agents can inspect it
-  if (!recordableType) {
-    meta.matchedPatterns = [`unknown_kind:${raw.kind}`];
   }
 
   const dedupPrimary = EventDedup.primaryKey("activity", String(raw.id));
@@ -409,8 +453,16 @@ export function normalizeReadingsEvent(
   }
 
   const recordableType = normalizeRecordingType(raw.type);
+
+  // Unknown type → drop with metric rather than misclassifying as Document
+  if (!recordableType) {
+    recordUnknownKind(account.accountId, raw.type);
+    return null;
+  }
+
   const isPing = raw.type === "Ping";
-  const participantCount = raw.participants?.length;
+  // readings participants uses other_circle_people() which excludes the caller — add 1.
+  const participantCount = raw.participants ? raw.participants.length + 1 : undefined;
 
   const text = raw.content_excerpt ? htmlToPlainText(raw.content_excerpt) : (raw.title ?? "");
   const html = raw.content_excerpt ?? "";
@@ -429,10 +481,8 @@ export function normalizeReadingsEvent(
       }
     : { id: "unknown", name: "Unknown" };
 
-  const effectiveRecordableType = recordableType ?? "Document";
-
   const peer = resolveBasecampPeer({
-    recordableType: effectiveRecordableType,
+    recordableType,
     recordingId,
     bucketId,
     isPing,
@@ -444,7 +494,7 @@ export function normalizeReadingsEvent(
   const meta: BasecampInboundMeta = {
     bucketId,
     recordingId,
-    recordableType: effectiveRecordableType,
+    recordableType,
     eventKind: "created" as BasecampInboundMeta["eventKind"],
     mentions: sgids,
     mentionsAgent: isAgentMentioned,
@@ -455,11 +505,6 @@ export function normalizeReadingsEvent(
     })),
     sources: ["readings"],
   };
-
-  // Preserve unknown type info
-  if (!recordableType) {
-    meta.matchedPatterns = [`unknown_type:${raw.type}`];
-  }
 
   const dedupPrimary = EventDedup.primaryKey("reading", String(raw.id));
 
@@ -558,12 +603,18 @@ export function normalizeAssignmentTodo(
 // Webhook normalization
 // ---------------------------------------------------------------------------
 
-export function normalizeWebhookPayload(
+export async function normalizeWebhookPayload(
   raw: BasecampWebhookPayload,
   account: ResolvedBasecampAccount,
-): BasecampInboundMessage {
+): Promise<BasecampInboundMessage | null> {
   const recordableType = resolveRecordableType(raw.kind, raw.recording.type);
-  const effectiveRecordableType = recordableType ?? "Document";
+
+  // Unknown kind → drop with metric rather than misclassifying as Document
+  if (!recordableType) {
+    recordUnknownKind(account.accountId, raw.kind);
+    return null;
+  }
+
   const recordingId = String(raw.recording.id);
   const parentRecordingId = raw.recording.parent
     ? String(raw.recording.parent.id)
@@ -583,19 +634,34 @@ export function normalizeWebhookPayload(
     email: raw.creator.email_address,
   };
 
+  // Detect Pings via bucket type. BC3 webhook recording.type is the recordable_type
+  // (e.g. "Chat::Transcript"), not "Ping". The definitive signal is the bucket's
+  // bucketable_type: "Circle" for Pings, "Project" for project campfires.
+  const isPing = raw.recording.bucket.type === "Circle";
+
+  // Enrich Ping participant count via Circle API (webhooks lack it)
+  let participantCount: number | undefined;
+  if (isPing) {
+    const bcqAccountId = account.config.bcqAccountId ?? account.accountId;
+    const circleInfo = await resolveCircleInfoCached(bucketId, bcqAccountId, account.bcqProfile);
+    participantCount = circleInfo?.participantCount;
+  }
+
   const peer = resolveBasecampPeer({
-    recordableType: effectiveRecordableType,
+    recordableType,
     recordingId,
     parentRecordingId,
     bucketId,
+    isPing,
+    participantCount,
   });
 
-  const parentPeer = resolveParentPeer(bucketId, false);
+  const parentPeer = resolveParentPeer(bucketId, isPing);
 
   const meta: BasecampInboundMeta = {
     bucketId,
     recordingId,
-    recordableType: effectiveRecordableType,
+    recordableType,
     eventKind: resolveEventKind(raw.kind) as BasecampInboundMeta["eventKind"],
     mentions: sgids,
     mentionsAgent: isAgentMentioned,
@@ -603,8 +669,28 @@ export function normalizeWebhookPayload(
     sources: ["webhook"],
   };
 
-  if (!recordableType) {
-    meta.matchedPatterns = [`unknown_kind:${raw.kind}`];
+  // Detect assignment events from webhook details.
+  // BC3 emits details.added_person_ids / details.removed_person_ids for
+  // *_assignment_changed events (person IDs, not names).
+  if (isAssignmentChangedKind(raw.kind) && raw.details) {
+    const { addedPersonIds, removedPersonIds } = parseAssignmentDetails(raw.details);
+    const agentPersonId = account.personId ? Number(account.personId) : undefined;
+
+    if (addedPersonIds.length > 0) {
+      meta.assignees = addedPersonIds.map(String);
+    }
+
+    if (agentPersonId != null) {
+      if (addedPersonIds.includes(agentPersonId)) {
+        meta.assignedToAgent = true;
+      }
+      // Unassignment: agent was explicitly removed from assignees.
+      // classifyEngagement sees assignedToAgent=undefined; dispatch
+      // can inspect meta.matchedPatterns for "unassigned_from_agent".
+      if (removedPersonIds.includes(agentPersonId)) {
+        meta.matchedPatterns = [...(meta.matchedPatterns ?? []), "unassigned_from_agent"];
+      }
+    }
   }
 
   const dedupPrimary = raw.id

--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -364,10 +364,11 @@ export async function normalizeActivityEvent(
     raw.recording?.recordable_type === "Ping";
 
   // Enrich Ping participant count via Circle API (activity feed lacks it).
-  // Defaults to undefined → resolveBasecampPeer conservatively uses "group".
+  // Defaults to undefined → resolveBasecampPeer fail-closed uses "dm".
   let participantCount: number | undefined;
   if (isPing) {
-    const bcqAccountId = account.config.bcqAccountId ?? account.accountId;
+    const bcqAccountId = account.config.bcqAccountId ??
+      (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
     const circleInfo = await resolveCircleInfoCached(bucketId, bcqAccountId, account.bcqProfile);
     participantCount = circleInfo?.participantCount;
   }
@@ -642,7 +643,8 @@ export async function normalizeWebhookPayload(
   // Enrich Ping participant count via Circle API (webhooks lack it)
   let participantCount: number | undefined;
   if (isPing) {
-    const bcqAccountId = account.config.bcqAccountId ?? account.accountId;
+    const bcqAccountId = account.config.bcqAccountId ??
+      (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
     const circleInfo = await resolveCircleInfoCached(bucketId, bcqAccountId, account.bcqProfile);
     participantCount = circleInfo?.participantCount;
   }

--- a/src/inbound/readings.ts
+++ b/src/inbound/readings.ts
@@ -79,18 +79,20 @@ export async function pollReadings(
   for (const raw of filtered) {
     try {
       const normalized = normalizeReadingsEvent(raw, account);
-      if (!normalized) continue;
 
-      events.push(normalized);
-
+      // Always mark the item as processed regardless of normalization outcome.
+      // Unknown types return null (dropped with metric), but the unread must still
+      // be recorded to prevent infinite re-polling of the same item every cycle.
       if (raw.readable_sgid) {
         processedSgids.push(raw.readable_sgid);
       }
-
       const ts = raw.unread_at ?? raw.created_at;
       if (!newestAt || ts > newestAt) {
         newestAt = ts;
       }
+
+      if (!normalized) continue;
+      events.push(normalized);
     } catch (err) {
       log?.warn?.(
         `[${account.accountId}] failed to normalize reading id=${raw.id}: ${String(err)}`,

--- a/src/inbound/webhook-lifecycle.ts
+++ b/src/inbound/webhook-lifecycle.ts
@@ -39,6 +39,7 @@ function typesMatch(webhookTypes: string[] | undefined, configTypes: string[]): 
 export interface ReconcileResult {
   created: string[];
   existing: string[];
+  recovered: string[];
   failed: string[];
 }
 
@@ -57,7 +58,7 @@ export async function reconcileWebhooks(
   registry: WebhookSecretRegistry,
   log?: StructuredLog,
 ): Promise<ReconcileResult> {
-  const result: ReconcileResult = { created: [], existing: [], failed: [] };
+  const result: ReconcileResult = { created: [], existing: [], recovered: [], failed: [] };
 
   for (const projectId of config.projects) {
     try {
@@ -76,6 +77,8 @@ export async function reconcileWebhooks(
         (wh) => wh.payload_url === config.payloadUrl && wh.active,
       );
 
+      let secretRecovery = false;
+
       if (urlMatch && typesMatch(urlMatch.types, config.types)) {
         log?.debug("webhook_exists", {
           project: projectId,
@@ -88,18 +91,42 @@ export async function reconcileWebhooks(
         if (!registry.get(projectId)) {
           registry.set(projectId, {
             webhookId: String(urlMatch.id),
-            secret: "", // Unknown — created before lifecycle management
+            secret: "",
             payloadUrl: urlMatch.payload_url,
             types: urlMatch.types ?? [],
           });
         }
 
-        result.existing.push(projectId);
-        continue;
+        const entry = registry.get(projectId);
+        if (entry && entry.secret === "" && !entry.recoveryFailed) {
+          // Secret is missing and recovery hasn't been attempted or hasn't
+          // permanently failed. Delete the stale webhook and recreate to
+          // mint a fresh HMAC secret.
+          log?.info("webhook_secret_recovery", {
+            project: projectId,
+            webhookId: urlMatch.id,
+          });
+          try {
+            await bcqWebhookDelete(projectId, String(urlMatch.id), config.bcqOpts ?? {});
+            registry.remove(projectId);
+            secretRecovery = true;
+          } catch (delErr) {
+            log?.error("webhook_secret_recovery_delete_failed", {
+              project: projectId,
+              error: String(delErr),
+            });
+            result.failed.push(projectId);
+            continue;
+          }
+          // Fall through to create path
+        } else {
+          result.existing.push(projectId);
+          continue;
+        }
       }
 
       // URL matches but types differ — delete stale webhook before creating new one
-      if (urlMatch) {
+      if (!secretRecovery && urlMatch) {
         log?.info("webhook_types_changed", {
           project: projectId,
           webhookId: urlMatch.id,
@@ -148,15 +175,36 @@ export async function reconcileWebhooks(
         secret: webhook.secret ?? "",
         payloadUrl: webhook.payload_url ?? config.payloadUrl,
         types: webhook.types ?? config.types,
+        recoveryFailed: !webhook.secret || undefined,
       });
 
-      log?.info("webhook_created", {
-        project: projectId,
-        webhookId: webhook.id,
-        hasSecret: Boolean(webhook.secret),
-      });
+      if (!webhook.secret) {
+        // BC3 returned webhook without secret — HMAC verification will fail.
+        // Mark recoveryFailed to prevent repeated delete/recreate churn on
+        // subsequent reconciliation cycles.
+        log?.error("webhook_create_no_secret", {
+          project: projectId,
+          webhookId: webhook.id,
+          recovery: secretRecovery,
+          reason: "BC3 returned webhook without secret — HMAC will fail",
+        });
+        result.failed.push(projectId);
+        continue;
+      }
 
-      result.created.push(projectId);
+      if (secretRecovery) {
+        result.recovered.push(projectId);
+        log?.info("webhook_secret_recovered", {
+          project: projectId,
+          webhookId: webhook.id,
+        });
+      } else {
+        log?.info("webhook_created", {
+          project: projectId,
+          webhookId: webhook.id,
+        });
+        result.created.push(projectId);
+      }
     } catch (err) {
       log?.error("webhook_reconcile_failed", {
         project: projectId,

--- a/src/inbound/webhook-secrets.ts
+++ b/src/inbound/webhook-secrets.ts
@@ -16,6 +16,8 @@ export interface WebhookSecretEntry {
   secret: string;
   payloadUrl: string;
   types: string[];
+  /** Set when secret recovery was attempted but BC3 returned no secret. Prevents retry churn. */
+  recoveryFailed?: boolean;
 }
 
 export type WebhookSecretSnapshot = Record<string, WebhookSecretEntry>;

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -430,10 +430,16 @@ export async function handleBasecampWebhook(
   // Normalize
   let msg;
   try {
-    msg = normalizeWebhookPayload(payload, account);
+    msg = await normalizeWebhookPayload(payload, account);
   } catch (err) {
     slog.error("normalization_error", { error: String(err), stack: err instanceof Error ? err.stack : undefined });
     recordWebhookError(account.accountId);
+    return;
+  }
+
+  if (!msg) {
+    slog.warn("unknown_kind_dropped", { kind: payload.kind });
+    recordWebhookDropped(account.accountId);
     return;
   }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -44,6 +44,8 @@ export interface AccountMetrics {
   webhookDedupSize: number;
   dispatchFailureCount: number;
   queueFullDropCount: number;
+  unknownKindCount: number;
+  lastUnknownKind: string | null;
 }
 
 function emptySourceMetrics(): PollerSourceMetrics {
@@ -88,6 +90,8 @@ function getOrCreate(accountId: string): AccountMetrics {
       webhookDedupSize: 0,
       dispatchFailureCount: 0,
       queueFullDropCount: 0,
+      unknownKindCount: 0,
+      lastUnknownKind: null,
     };
     metricsRegistry.set(accountId, m);
   }
@@ -172,6 +176,12 @@ export function recordDispatchFailure(accountId: string): void {
 export function recordQueueFullDrop(accountId: string): void {
   const m = getOrCreate(accountId);
   m.queueFullDropCount++;
+}
+
+export function recordUnknownKind(accountId: string, rawKind: string): void {
+  const m = getOrCreate(accountId);
+  m.unknownKindCount++;
+  m.lastUnknownKind = rawKind;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -11,9 +11,6 @@
 import type { BasecampRecordableType } from "../types.js";
 import { bcqPost, bcqApiPost, withRetry, isRetryableError, BcqError, bcqGetCircle } from "../bcq.js";
 import type { CircuitBreaker, CircleInfo } from "../bcq.js";
-import { markdownToBasecampHtml } from "./format.js";
-import { getBasecampRuntime } from "../runtime.js";
-import { resolveBasecampAccount } from "../config.js";
 
 // ---------------------------------------------------------------------------
 // Circle info cache — LRU-bounded to avoid unbounded growth.
@@ -280,67 +277,34 @@ export async function postReplyToEvent(params: {
 }
 
 // ---------------------------------------------------------------------------
-// OpenClaw ChannelOutboundAdapter.sendText
+// OpenClaw ChannelOutboundAdapter.sendText / sendMedia
 // ---------------------------------------------------------------------------
 
 /**
- * Send text to a Basecamp peer.
- *
- * The `to` field in the outbound context is the peer ID
- * (e.g. "recording:123", "ping:456"). We need to resolve the bucket ID
- * and determine the correct endpoint.
+ * Basecamp does not support direct outbound delivery via the SDK pipeline.
+ * Agent replies flow through the dispatch bridge (dispatchBasecampEvent →
+ * postReplyToEvent). This stub satisfies the SDK contract so outbound is
+ * not treated as unconfigured (which causes opaque "Outbound not configured").
  */
 export async function sendBasecampText(params: {
   to: string;
   text: string;
   accountId?: string | null;
 }): Promise<{ channel: "basecamp"; messageId: string }> {
-  const runtime = getBasecampRuntime();
-  const cfg = runtime.config.loadConfig();
-  const { to, text } = params;
-
-  // Resolve persona account to get effective accountId
-  const effectiveAccountId = params.accountId ?? undefined;
-  const account = resolveBasecampAccount(cfg, effectiveAccountId);
-
-  // Parse the peer ID to determine target
-  const parsed = parsePeerId(to);
-
-  // sendBasecampText operates with limited context — only a peer ID string,
-  // no bucketId. The dispatch bridge (dispatch.ts → postReplyToEvent) has
-  // full context and is the primary outbound path. This function handles
-  // ChannelOutboundAdapter.sendText for direct CLI messaging.
-
-  if (parsed.prefix === "ping") {
-    // Pings: peer ID is ping:<circleBucketId>. We can't resolve the
-    // transcript recording ID from just the circle bucket ID without
-    // an additional API call. For now, reject with a clear error.
-    throw new Error(
-      `sendBasecampText: cannot send to ping peer "${to}" directly. ` +
-      `Ping replies require transcript context (use dispatch bridge instead).`,
-    );
-  }
-
-  if (parsed.prefix === "recording") {
-    // We don't have the bucketId from just the peer ID. Without it,
-    // the API path is invalid. Reject clearly rather than 404 at runtime.
-    throw new Error(
-      `sendBasecampText: cannot resolve bucketId for recording peer "${to}". ` +
-      `Direct sendText to recording: peers is not yet supported. ` +
-      `Use the dispatch bridge (dispatchBasecampEvent) for replies.`,
-    );
-  }
-
-  if (parsed.prefix === "bucket") {
-    throw new Error(
-      `sendBasecampText: cannot send to bucket peer "${to}" directly. ` +
-      `Bucket peers represent a project scope, not a specific conversation. ` +
-      `Use a recording: or ping: peer, or the dispatch bridge for replies.`,
-    );
-  }
-
   throw new Error(
-    `sendBasecampText: unsupported peer format "${to}". ` +
-    `Expected "recording:<id>", "ping:<id>", or "bucket:<id>".`,
+    `Basecamp does not support direct outbound delivery to "${params.to}". ` +
+    `Agent replies flow through the dispatch bridge (dispatchBasecampEvent → postReplyToEvent).`,
+  );
+}
+
+export async function sendBasecampMedia(params: {
+  to: string;
+  text: string;
+  mediaUrl?: string;
+  accountId?: string | null;
+}): Promise<{ channel: "basecamp"; messageId: string }> {
+  throw new Error(
+    `Basecamp does not support direct media delivery to "${params.to}". ` +
+    `Media sharing is available via agent tools (basecamp_api_write).`,
   );
 }

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -9,14 +9,15 @@
  */
 
 import type { BasecampRecordableType } from "../types.js";
-import { bcqPost, bcqApiPost, withRetry, isRetryableError, BcqError, bcqResolvePingTranscript } from "../bcq.js";
-import type { CircuitBreaker } from "../bcq.js";
+import { bcqPost, bcqApiPost, withRetry, isRetryableError, BcqError, bcqGetCircle } from "../bcq.js";
+import type { CircuitBreaker, CircleInfo } from "../bcq.js";
 import { markdownToBasecampHtml } from "./format.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount } from "../config.js";
 
 // ---------------------------------------------------------------------------
-// Ping transcript cache — LRU-bounded to avoid unbounded growth
+// Circle info cache — LRU-bounded to avoid unbounded growth.
+// Stores both transcript ID and participant count from a single API call.
 // ---------------------------------------------------------------------------
 
 const PING_CACHE_MAX = 500;
@@ -53,21 +54,46 @@ class LruCache<K, V> {
   }
 }
 
-const pingTranscriptCache = new LruCache<string, string>(PING_CACHE_MAX);
+const circleInfoCache = new LruCache<string, CircleInfo>(PING_CACHE_MAX);
 
+/** Cache key scoped by account to prevent cross-contamination in multi-account deployments. */
+function circleCacheKey(bucketId: string, accountId?: string): string {
+  return accountId ? `${accountId}:${bucketId}` : bucketId;
+}
+
+/**
+ * Resolve a Circle (Ping) to its info (transcript ID + participant count).
+ * Results are LRU-cached; a single GET /circles/<id>.json call fetches both.
+ * Cache is keyed by accountId:bucketId to avoid cross-account contamination.
+ */
+export async function resolveCircleInfoCached(
+  bucketId: string,
+  accountId?: string,
+  profile?: string,
+): Promise<CircleInfo | undefined> {
+  const key = circleCacheKey(bucketId, accountId);
+  const cached = circleInfoCache.get(key);
+  if (cached) return cached;
+  try {
+    const info = await bcqGetCircle(bucketId, { accountId, profile });
+    circleInfoCache.set(key, info);
+    return info;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Convenience: resolve just the transcript ID from the cache. */
 async function resolvePingTranscriptCached(
   bucketId: string,
   accountId?: string,
   profile?: string,
 ): Promise<string | undefined> {
-  const cached = pingTranscriptCache.get(bucketId);
-  if (cached) return cached;
-  const transcriptId = await bcqResolvePingTranscript(bucketId, { accountId, profile });
-  if (transcriptId) pingTranscriptCache.set(bucketId, transcriptId);
-  return transcriptId;
+  const info = await resolveCircleInfoCached(bucketId, accountId, profile);
+  return info?.transcriptId;
 }
 
-export { LruCache, PING_CACHE_MAX };
+export { LruCache, PING_CACHE_MAX, circleInfoCache };
 
 // ---------------------------------------------------------------------------
 // Helpers — Basecamp API write operations via bcq

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,8 @@ export type BasecampActivityEvent = {
   action: string;
   created_at: string;
   title?: string;
+  /** Recording title from timeline_api_event_title(). For most event kinds this is the
+   *  recording's own title, NOT a person name. Do not use for person identification. */
   target?: string;
   summary_excerpt?: string;
   parent_recording_id?: number;
@@ -278,12 +280,26 @@ export type BasecampReadingsEntry = {
 };
 
 /**
+ * Assignment event details (todo_assignment_changed, kanban_card_assignment_changed, etc.).
+ * Populated by BC3 Event::Detail::PeopleChanges — person IDs, not names.
+ */
+export interface AssignmentChangedDetails {
+  added_person_ids?: number[];
+  removed_person_ids?: number[];
+}
+
+/** Webhook event details. Shape varies by event kind; known shapes are intersected. */
+export type WebhookEventDetails = AssignmentChangedDetails & Record<string, unknown>;
+
+/**
  * Raw Basecamp webhook payload.
  */
 export type BasecampWebhookPayload = {
   id?: number;
   kind: string;
   created_at: string;
+  /** Event-specific details. For assignment events: { added_person_ids, removed_person_ids }. */
+  details?: WebhookEventDetails;
   recording: {
     id: number;
     type: string;
@@ -296,6 +312,8 @@ export type BasecampWebhookPayload = {
     bucket: {
       id: number;
       name: string;
+      /** Bucket type from bucketable_type. "Circle" for Pings, "Project" for projects. */
+      type?: string;
     };
   };
   creator: {

--- a/tests/assignments.test.ts
+++ b/tests/assignments.test.ts
@@ -13,6 +13,14 @@ vi.mock("../src/bcq.js", () => ({
   bcqAssignments: vi.fn(),
 }));
 
+vi.mock("../src/metrics.js", () => ({
+  recordUnknownKind: vi.fn(),
+}));
+
+vi.mock("../src/outbound/send.js", () => ({
+  resolveCircleInfoCached: vi.fn(() => undefined),
+}));
+
 import { bcqAssignments } from "../src/bcq.js";
 import { pollAssignments } from "../src/inbound/assignments.js";
 

--- a/tests/correlation-ids.test.ts
+++ b/tests/correlation-ids.test.ts
@@ -14,6 +14,13 @@ vi.mock("../src/mentions/parse.js", () => ({
   htmlToPlainText: vi.fn((s: string) => s),
 }));
 
+vi.mock("../src/metrics.js", () => ({
+  recordUnknownKind: vi.fn(),
+}));
+vi.mock("../src/outbound/send.js", () => ({
+  resolveCircleInfoCached: vi.fn(() => undefined),
+}));
+
 import {
   normalizeActivityEvent,
   normalizeReadingsEvent,
@@ -36,8 +43,8 @@ beforeEach(() => {
 });
 
 describe("correlation IDs", () => {
-  it("normalizeActivityEvent generates a correlationId", () => {
-    const msg = normalizeActivityEvent(
+  it("normalizeActivityEvent generates a correlationId", async () => {
+    const msg = await normalizeActivityEvent(
       {
         id: 1,
         kind: "comment_created",
@@ -50,9 +57,9 @@ describe("correlation IDs", () => {
       mockAccount,
     );
 
-    expect(msg.correlationId).toBeTruthy();
-    expect(typeof msg.correlationId).toBe("string");
-    expect(msg.correlationId.length).toBeGreaterThan(0);
+    expect(msg!.correlationId).toBeTruthy();
+    expect(typeof msg!.correlationId).toBe("string");
+    expect(msg!.correlationId.length).toBeGreaterThan(0);
   });
 
   it("normalizeReadingsEvent generates a correlationId", () => {
@@ -85,8 +92,8 @@ describe("correlation IDs", () => {
     expect(typeof msg.correlationId).toBe("string");
   });
 
-  it("normalizeWebhookPayload generates a correlationId", () => {
-    const msg = normalizeWebhookPayload(
+  it("normalizeWebhookPayload generates a correlationId", async () => {
+    const msg = await normalizeWebhookPayload(
       {
         id: 4,
         kind: "comment_created",
@@ -101,12 +108,12 @@ describe("correlation IDs", () => {
       mockAccount,
     );
 
-    expect(msg.correlationId).toBeTruthy();
-    expect(typeof msg.correlationId).toBe("string");
+    expect(msg!.correlationId).toBeTruthy();
+    expect(typeof msg!.correlationId).toBe("string");
   });
 
-  it("each call generates a unique correlationId", () => {
-    const msg1 = normalizeActivityEvent(
+  it("each call generates a unique correlationId", async () => {
+    const msg1 = await normalizeActivityEvent(
       {
         id: 10,
         kind: "comment_created",
@@ -118,7 +125,7 @@ describe("correlation IDs", () => {
       mockAccount,
     );
 
-    const msg2 = normalizeActivityEvent(
+    const msg2 = await normalizeActivityEvent(
       {
         id: 11,
         kind: "comment_created",
@@ -130,6 +137,6 @@ describe("correlation IDs", () => {
       mockAccount,
     );
 
-    expect(msg1.correlationId).not.toBe(msg2.correlationId);
+    expect(msg1!.correlationId).not.toBe(msg2!.correlationId);
   });
 });

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock external deps used by normalize.ts
+vi.mock("../src/metrics.js", () => ({
+  recordUnknownKind: vi.fn(),
+}));
+vi.mock("../src/outbound/send.js", () => ({
+  resolveCircleInfoCached: vi.fn(() => undefined),
+}));
+
 import {
   normalizeActivityEvent,
   normalizeReadingsEvent,
@@ -182,7 +191,7 @@ describe("resolveBasecampPeer", () => {
     expect(peer).toEqual({ kind: "group", id: "ping:200" });
   });
 
-  it("Ping with 0 participants defaults to group (unknown count)", () => {
+  it("Ping with 0 participants defaults to dm (fail-closed)", () => {
     const peer = resolveBasecampPeer({
       recordableType: "Chat::Transcript",
       recordingId: "50",
@@ -190,10 +199,10 @@ describe("resolveBasecampPeer", () => {
       isPing: true,
       participantCount: 0,
     });
-    expect(peer).toEqual({ kind: "group", id: "ping:200" });
+    expect(peer).toEqual({ kind: "dm", id: "ping:200" });
   });
 
-  it("Ping with undefined participants defaults to group", () => {
+  it("Ping with undefined participants defaults to dm (fail-closed)", () => {
     const peer = resolveBasecampPeer({
       recordableType: "Chat::Transcript",
       recordingId: "50",
@@ -201,7 +210,7 @@ describe("resolveBasecampPeer", () => {
       isPing: true,
       participantCount: undefined,
     });
-    expect(peer).toEqual({ kind: "group", id: "ping:200" });
+    expect(peer).toEqual({ kind: "dm", id: "ping:200" });
   });
 
   it("Chat::Line without parentRecordingId falls back to recording:<recordingId>", () => {
@@ -257,84 +266,84 @@ describe("isSelfMessage", () => {
 // ---------------------------------------------------------------------------
 
 describe("normalizeActivityEvent", () => {
-  it("comment_created maps to recordableType Comment and eventKind created", () => {
+  it("comment_created maps to recordableType Comment and eventKind created", async () => {
     const raw = makeActivityEvent({ kind: "comment_created" });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.recordableType).toBe("Comment");
-    expect(msg.meta.eventKind).toBe("created");
+    expect(msg!.meta.recordableType).toBe("Comment");
+    expect(msg!.meta.eventKind).toBe("created");
   });
 
-  it("chat_transcript_rollup maps to Chat::Transcript with eventKind created", () => {
+  it("chat_transcript_rollup maps to Chat::Transcript with eventKind created", async () => {
     const raw = makeActivityEvent({
       kind: "chat_transcript_rollup",
       recording: { id: 201, type: "Chat::Transcript", content: "hello" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.recordableType).toBe("Chat::Transcript");
-    expect(msg.meta.eventKind).toBe("created");
+    expect(msg!.meta.recordableType).toBe("Chat::Transcript");
+    expect(msg!.meta.eventKind).toBe("created");
   });
 
-  it("kanban_card_created maps to Kanban::Card", () => {
+  it("kanban_card_created maps to Kanban::Card", async () => {
     const raw = makeActivityEvent({
       kind: "kanban_card_created",
       recording: { id: 202, type: "Kanban::Card", title: "New card" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.recordableType).toBe("Kanban::Card");
+    expect(msg!.meta.recordableType).toBe("Kanban::Card");
   });
 
-  it("todo_completed maps to Todo with eventKind completed", () => {
+  it("todo_completed maps to Todo with eventKind completed", async () => {
     const raw = makeActivityEvent({
       kind: "todo_completed",
       recording: { id: 203, type: "Todo", title: "Finish task" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.recordableType).toBe("Todo");
-    expect(msg.meta.eventKind).toBe("completed");
+    expect(msg!.meta.recordableType).toBe("Todo");
+    expect(msg!.meta.eventKind).toBe("completed");
   });
 
-  it("message_created maps to Message", () => {
+  it("message_created maps to Message", async () => {
     const raw = makeActivityEvent({
       kind: "message_created",
       recording: { id: 204, type: "Message", title: "Announcement" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.recordableType).toBe("Message");
-    expect(msg.meta.eventKind).toBe("created");
+    expect(msg!.meta.recordableType).toBe("Message");
+    expect(msg!.meta.eventKind).toBe("created");
   });
 
-  it("unknown kind falls back to recording.type when available", () => {
+  it("unknown kind falls back to recognized recording.type", async () => {
     const raw = makeActivityEvent({
       kind: "some_unknown_kind",
       recording: { id: 205, type: "Upload", title: "File" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.recordableType).toBe("Upload");
+    expect(msg!.meta.recordableType).toBe("Upload");
   });
 
-  it("unknown kind with unrecognized recording.type falls back to Document", () => {
+  it("unknown kind with unrecognized recording.type returns null (dropped)", async () => {
     const raw = makeActivityEvent({
       kind: "some_unknown_kind",
       recording: { id: 206, type: "FutureType", title: "Something" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.recordableType).toBe("Document");
+    expect(msg).toBeNull();
   });
 
-  it("sets sender from raw.creator fields", () => {
+  it("sets sender from raw.creator fields", async () => {
     const raw = makeActivityEvent({
       creator: { id: 77, name: "Bob", email_address: "bob@example.com", avatar_url: "https://example.com/bob.png" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.sender).toEqual({
+    expect(msg!.sender).toEqual({
       id: "77",
       name: "Bob",
       email: "bob@example.com",
@@ -342,127 +351,129 @@ describe("normalizeActivityEvent", () => {
     });
   });
 
-  it("dedup key is activity:<event.id>", () => {
+  it("dedup key is activity:<event.id>", async () => {
     const raw = makeActivityEvent({ id: 12345 });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.dedupKey).toBe("activity:12345");
+    expect(msg!.dedupKey).toBe("activity:12345");
   });
 
-  it("parentPeer is always bucket:<bucketId>", () => {
+  it("parentPeer is always bucket:<bucketId>", async () => {
     const raw = makeActivityEvent({ bucket: { id: 777, name: "Project" } });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.parentPeer).toEqual({ kind: "group", id: "bucket:777" });
+    expect(msg!.parentPeer).toEqual({ kind: "group", id: "bucket:777" });
   });
 
-  it("comment_created with parentRecordingId routes peer to parent", () => {
+  it("comment_created with parentRecordingId routes peer to parent", async () => {
     const raw = makeActivityEvent({
       kind: "comment_created",
       parent_recording_id: 99,
       recording: { id: 200, type: "Comment" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.peer).toEqual({ kind: "group", id: "recording:99" });
+    expect(msg!.peer).toEqual({ kind: "group", id: "recording:99" });
   });
 
-  it("extracts mentions from HTML content", () => {
+  it("extracts mentions from HTML content", async () => {
     const html = '<bc-attachment sgid="sgid://bc3/Person/42" content-type="application/vnd.basecamp.mention"></bc-attachment> hello';
     const raw = makeActivityEvent({
       recording: { id: 207, type: "Comment", content: html },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.mentions).toContain("sgid://bc3/Person/42");
+    expect(msg!.meta.mentions).toContain("sgid://bc3/Person/42");
   });
 
-  it("sets mentionsAgent true when content has bc-attachment matching agent SGID", () => {
+  it("sets mentionsAgent true when content has bc-attachment matching agent SGID", async () => {
     const html = '<bc-attachment sgid="sgid://bc3/Person/999" content-type="application/vnd.basecamp.mention"></bc-attachment> hey';
     const raw = makeActivityEvent({
       recording: { id: 208, type: "Comment", content: html },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.mentionsAgent).toBe(true);
+    expect(msg!.meta.mentionsAgent).toBe(true);
   });
 
-  it("sets mentionsAgent false when no agent mention", () => {
+  it("sets mentionsAgent false when no agent mention", async () => {
     const raw = makeActivityEvent({
       recording: { id: 209, type: "Comment", content: "<p>No mentions here</p>" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.mentionsAgent).toBe(false);
+    expect(msg!.meta.mentionsAgent).toBe(false);
   });
 
-  it("sets channel to basecamp and accountId from account", () => {
+  it("sets channel to basecamp and accountId from account", async () => {
     const raw = makeActivityEvent();
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.channel).toBe("basecamp");
-    expect(msg.accountId).toBe("test-acct");
+    expect(msg!.channel).toBe("basecamp");
+    expect(msg!.accountId).toBe("test-acct");
   });
 
-  it("uses raw.created_at as createdAt", () => {
+  it("uses raw.created_at as createdAt", async () => {
     const raw = makeActivityEvent({ created_at: "2025-06-01T08:00:00Z" });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.createdAt).toBe("2025-06-01T08:00:00Z");
+    expect(msg!.createdAt).toBe("2025-06-01T08:00:00Z");
   });
 
-  it("sets messageId on Comment recordableType", () => {
+  it("sets messageId on Comment recordableType", async () => {
     const raw = makeActivityEvent({
       kind: "comment_created",
       recording: { id: 210, type: "Comment" },
     });
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.messageId).toBe("210");
+    expect(msg!.meta.messageId).toBe("210");
   });
 
-  it("sources includes activity_feed", () => {
+  it("sources includes activity_feed", async () => {
     const raw = makeActivityEvent();
-    const msg = normalizeActivityEvent(raw, mockAccount);
+    const msg = await normalizeActivityEvent(raw, mockAccount);
 
-    expect(msg.meta.sources).toContain("activity_feed");
+    expect(msg!.meta.sources).toContain("activity_feed");
   });
 
-  it("sets assignedToAgent when assignment target matches agent displayName", () => {
+  it("activity feed does not detect assignment (no assignedToAgent)", async () => {
     const acct = { ...mockAccount, displayName: "Clawdito" };
     const raw = makeActivityEvent({
       kind: "todo_assigned",
       target: "Clawdito",
       recording: { id: 203, type: "Todo", title: "Do the thing" },
     });
-    const msg = normalizeActivityEvent(raw, acct);
+    const msg = await normalizeActivityEvent(raw, acct);
 
-    expect(msg.meta.assignedToAgent).toBe(true);
-    expect(msg.meta.eventKind).toBe("assigned");
+    // Assignment detection is only via webhook details or pollAssignments;
+    // activity feed target field is the recording title, not the assignee.
+    expect(msg!.meta.assignedToAgent).toBeUndefined();
+    expect(msg!.meta.eventKind).toBe("assigned");
   });
 
-  it("does not set assignedToAgent when target is a different person", () => {
+  it("does not set assignedToAgent when target is a different person", async () => {
     const acct = { ...mockAccount, displayName: "Clawdito" };
     const raw = makeActivityEvent({
       kind: "todo_assigned",
       target: "Alice",
       recording: { id: 203, type: "Todo", title: "Do the thing" },
     });
-    const msg = normalizeActivityEvent(raw, acct);
+    const msg = await normalizeActivityEvent(raw, acct);
 
-    expect(msg.meta.assignedToAgent).toBeUndefined();
+    expect(msg!.meta.assignedToAgent).toBeUndefined();
   });
 
-  it("does not set assignedToAgent for non-assignment event kinds", () => {
+  it("does not set assignedToAgent for non-assignment event kinds", async () => {
     const acct = { ...mockAccount, displayName: "Clawdito" };
     const raw = makeActivityEvent({
       kind: "todo_completed",
       target: "Clawdito",
       recording: { id: 203, type: "Todo", title: "Do the thing" },
     });
-    const msg = normalizeActivityEvent(raw, acct);
+    const msg = await normalizeActivityEvent(raw, acct);
 
-    expect(msg.meta.assignedToAgent).toBeUndefined();
+    expect(msg!.meta.assignedToAgent).toBeUndefined();
   });
 });
 
@@ -501,7 +512,22 @@ describe("normalizeReadingsEvent", () => {
     expect(msg!.meta.recordableType).toBe("Chat::Line");
   });
 
-  it("Ping type with <= 2 participants resolves to dm peer", () => {
+  it("Ping type with 1 other participant (2 total) resolves to dm peer", () => {
+    // BC3 readings participants uses other_circle_people() which excludes the caller.
+    // 1 participant in array + 1 caller = 2 total → dm.
+    const raw = makeReadingsEntry({
+      type: "Ping",
+      participants: [{ id: 1, name: "Alice" }],
+    });
+    const msg = normalizeReadingsEvent(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.peer.kind).toBe("dm");
+    expect(msg!.peer.id).toMatch(/^ping:/);
+  });
+
+  it("Ping type with 2 other participants (3 total) resolves to group peer", () => {
+    // 2 in array + 1 caller = 3 total → group.
     const raw = makeReadingsEntry({
       type: "Ping",
       participants: [
@@ -512,11 +538,11 @@ describe("normalizeReadingsEvent", () => {
     const msg = normalizeReadingsEvent(raw, mockAccount);
 
     expect(msg).not.toBeNull();
-    expect(msg!.peer.kind).toBe("dm");
+    expect(msg!.peer.kind).toBe("group");
     expect(msg!.peer.id).toMatch(/^ping:/);
   });
 
-  it("Ping type with > 2 participants resolves to group peer", () => {
+  it("Ping type with 3+ other participants resolves to group peer", () => {
     const raw = makeReadingsEntry({
       type: "Ping",
       participants: [
@@ -656,18 +682,18 @@ describe("normalizeReadingsEvent", () => {
 // ---------------------------------------------------------------------------
 
 describe("normalizeWebhookPayload", () => {
-  it("normalizes basic webhook with bucket and recording", () => {
+  it("normalizes basic webhook with bucket and recording", async () => {
     const raw = makeWebhookPayload();
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.channel).toBe("basecamp");
-    expect(msg.accountId).toBe("test-acct");
-    expect(msg.meta.bucketId).toBe("100");
-    expect(msg.meta.recordingId).toBe("300");
-    expect(msg.meta.recordableType).toBe("Comment");
+    expect(msg!.channel).toBe("basecamp");
+    expect(msg!.accountId).toBe("test-acct");
+    expect(msg!.meta.bucketId).toBe("100");
+    expect(msg!.meta.recordingId).toBe("300");
+    expect(msg!.meta.recordableType).toBe("Comment");
   });
 
-  it("uses recording.parent for parentRecordingId in peer resolution", () => {
+  it("uses recording.parent for parentRecordingId in peer resolution", async () => {
     const raw = makeWebhookPayload({
       kind: "comment_created",
       recording: {
@@ -678,26 +704,26 @@ describe("normalizeWebhookPayload", () => {
         bucket: { id: 100, name: "Test Project" },
       },
     });
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.peer).toEqual({ kind: "group", id: "recording:150" });
+    expect(msg!.peer).toEqual({ kind: "group", id: "recording:150" });
   });
 
-  it("dedup key uses webhook ID when available", () => {
+  it("dedup key uses webhook ID when available", async () => {
     const raw = makeWebhookPayload({ id: 900 });
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.dedupKey).toBe("webhook:900");
+    expect(msg!.dedupKey).toBe("webhook:900");
   });
 
-  it("dedup key uses composite fallback when webhook ID is missing", () => {
+  it("dedup key uses composite fallback when webhook ID is missing", async () => {
     const raw = makeWebhookPayload({ id: undefined });
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.dedupKey).toMatch(/^webhook:300:comment_created:/);
+    expect(msg!.dedupKey).toMatch(/^webhook:300:comment_created:/);
   });
 
-  it("extracts text from HTML content", () => {
+  it("extracts text from HTML content", async () => {
     const raw = makeWebhookPayload({
       recording: {
         id: 301,
@@ -706,38 +732,38 @@ describe("normalizeWebhookPayload", () => {
         bucket: { id: 100, name: "Test Project" },
       },
     });
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.text).toBe("Hello world");
-    expect(msg.html).toBe("<p>Hello world</p>");
+    expect(msg!.text).toBe("Hello world");
+    expect(msg!.html).toBe("<p>Hello world</p>");
   });
 
-  it("sets sender from raw.creator", () => {
+  it("sets sender from raw.creator", async () => {
     const raw = makeWebhookPayload({
       creator: { id: 55, name: "Dave", email_address: "dave@example.com" },
     });
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.sender.id).toBe("55");
-    expect(msg.sender.name).toBe("Dave");
-    expect(msg.sender.email).toBe("dave@example.com");
+    expect(msg!.sender.id).toBe("55");
+    expect(msg!.sender.name).toBe("Dave");
+    expect(msg!.sender.email).toBe("dave@example.com");
   });
 
-  it("parentPeer is bucket:<bucketId>", () => {
+  it("parentPeer is bucket:<bucketId>", async () => {
     const raw = makeWebhookPayload();
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.parentPeer).toEqual({ kind: "group", id: "bucket:100" });
+    expect(msg!.parentPeer).toEqual({ kind: "group", id: "bucket:100" });
   });
 
-  it("sources includes webhook", () => {
+  it("sources includes webhook", async () => {
     const raw = makeWebhookPayload();
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.meta.sources).toContain("webhook");
+    expect(msg!.meta.sources).toContain("webhook");
   });
 
-  it("detects agent mention in webhook content", () => {
+  it("detects agent mention in webhook content", async () => {
     const raw = makeWebhookPayload({
       recording: {
         id: 302,
@@ -746,12 +772,12 @@ describe("normalizeWebhookPayload", () => {
         bucket: { id: 100, name: "Test Project" },
       },
     });
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.meta.mentionsAgent).toBe(true);
+    expect(msg!.meta.mentionsAgent).toBe(true);
   });
 
-  it("uses recording.title when content is absent", () => {
+  it("uses recording.title when content is absent", async () => {
     const raw = makeWebhookPayload({
       recording: {
         id: 303,
@@ -761,8 +787,277 @@ describe("normalizeWebhookPayload", () => {
         bucket: { id: 100, name: "Test Project" },
       },
     });
-    const msg = normalizeWebhookPayload(raw, mockAccount);
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
 
-    expect(msg.text).toBe("Important Announcement");
+    expect(msg!.text).toBe("Important Announcement");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 4: Ping enrichment via Circle API
+// ---------------------------------------------------------------------------
+
+import { resolveCircleInfoCached } from "../src/outbound/send.js";
+import { recordUnknownKind } from "../src/metrics.js";
+
+describe("Ping participant enrichment", () => {
+  it("activity Ping with Circle lookup returning 2 participants → dm", async () => {
+    vi.mocked(resolveCircleInfoCached).mockResolvedValueOnce({
+      transcriptId: "888",
+      participantCount: 2,
+    });
+    const raw = makeActivityEvent({
+      kind: "chat_transcript_created",
+      app_url: "https://3.basecamp.com/circles/100/chats/200",
+      recording: { id: 200, type: "Ping" },
+    });
+    const msg = await normalizeActivityEvent(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.peer.kind).toBe("dm");
+    expect(msg!.peer.id).toBe("ping:100");
+  });
+
+  it("activity Ping with Circle lookup returning 3 participants → group", async () => {
+    vi.mocked(resolveCircleInfoCached).mockResolvedValueOnce({
+      transcriptId: "888",
+      participantCount: 3,
+    });
+    const raw = makeActivityEvent({
+      kind: "chat_transcript_created",
+      app_url: "https://3.basecamp.com/circles/100/chats/200",
+      recording: { id: 200, type: "Ping" },
+    });
+    const msg = await normalizeActivityEvent(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.peer.kind).toBe("group");
+    expect(msg!.peer.id).toBe("ping:100");
+  });
+
+  it("activity Ping with Circle lookup failure → fail-closed dm fallback", async () => {
+    vi.mocked(resolveCircleInfoCached).mockResolvedValueOnce(undefined);
+    const raw = makeActivityEvent({
+      kind: "chat_transcript_created",
+      app_url: "https://3.basecamp.com/circles/100/chats/200",
+      recording: { id: 200, type: "Ping" },
+    });
+    const msg = await normalizeActivityEvent(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    // Fail closed: unknown participant count → dm, so DM policy applies
+    expect(msg!.peer.kind).toBe("dm");
+  });
+
+  it("webhook Ping with Circle lookup returning 2 participants → dm", async () => {
+    // BC3 webhook recording.type is recordable_type ("Chat::Transcript"), not "Ping".
+    // Ping detection uses recording.bucket.type === "Circle" (from bucketable_type).
+    vi.mocked(resolveCircleInfoCached).mockResolvedValueOnce({
+      transcriptId: "888",
+      participantCount: 2,
+    });
+    const raw = makeWebhookPayload({
+      kind: "chat_transcript_created",
+      recording: {
+        id: 200,
+        type: "Chat::Transcript",
+        content: "hey",
+        bucket: { id: 100, name: "Pings", type: "Circle" },
+      },
+    });
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.peer.kind).toBe("dm");
+    expect(msg!.peer.id).toBe("ping:100");
+  });
+
+  it("webhook Chat::Transcript in Project bucket is NOT a Ping", async () => {
+    vi.mocked(resolveCircleInfoCached).mockClear();
+    const raw = makeWebhookPayload({
+      kind: "chat_transcript_created",
+      recording: {
+        id: 201,
+        type: "Chat::Transcript",
+        content: "campfire message",
+        bucket: { id: 100, name: "My Project", type: "Project" },
+      },
+    });
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    // Project campfire → recording peer, not ping peer
+    expect(msg!.peer.id).toBe("recording:201");
+    expect(msg!.peer.kind).toBe("group");
+    // Circle lookup should NOT have been called
+    expect(resolveCircleInfoCached).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 4: Webhook assignment detection via details
+// ---------------------------------------------------------------------------
+
+describe("webhook assignment detection", () => {
+  it("todo_assignment_changed with added_person_ids matching agent → assignedToAgent", async () => {
+    const raw = makeWebhookPayload({
+      kind: "todo_assignment_changed",
+      details: { added_person_ids: [999, 123] },
+      recording: {
+        id: 400,
+        type: "Todo",
+        title: "Fix bug",
+        bucket: { id: 100, name: "Project" },
+      },
+    });
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.meta.assignedToAgent).toBe(true);
+    expect(msg!.meta.assignees).toEqual(["999", "123"]);
+    expect(msg!.meta.recordableType).toBe("Todo");
+    expect(msg!.meta.eventKind).toBe("assigned");
+  });
+
+  it("todo_assignment_changed with removed_person_ids matching agent → unassigned_from_agent", async () => {
+    const raw = makeWebhookPayload({
+      kind: "todo_assignment_changed",
+      details: { removed_person_ids: [999] },
+      recording: {
+        id: 401,
+        type: "Todo",
+        title: "Fix bug",
+        bucket: { id: 100, name: "Project" },
+      },
+    });
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.meta.assignedToAgent).toBeUndefined();
+    expect(msg!.meta.matchedPatterns).toContain("unassigned_from_agent");
+  });
+
+  it("todo_assignment_changed with non-matching person IDs → no assignment", async () => {
+    const raw = makeWebhookPayload({
+      kind: "todo_assignment_changed",
+      details: { added_person_ids: [123, 456] },
+      recording: {
+        id: 402,
+        type: "Todo",
+        title: "Fix bug",
+        bucket: { id: 100, name: "Project" },
+      },
+    });
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.meta.assignedToAgent).toBeUndefined();
+    expect(msg!.meta.assignees).toEqual(["123", "456"]);
+  });
+
+  it("kanban_card_assignment_changed maps to Kanban::Card with eventKind assigned", async () => {
+    const raw = makeWebhookPayload({
+      kind: "kanban_card_assignment_changed",
+      details: { added_person_ids: [999] },
+      recording: {
+        id: 403,
+        type: "Kanban::Card",
+        title: "Card",
+        bucket: { id: 100, name: "Project" },
+      },
+    });
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.meta.recordableType).toBe("Kanban::Card");
+    expect(msg!.meta.eventKind).toBe("assigned");
+    expect(msg!.meta.assignedToAgent).toBe(true);
+  });
+
+  it("assignment event without details field → no assignment detection", async () => {
+    const raw = makeWebhookPayload({
+      kind: "todo_assignment_changed",
+      recording: {
+        id: 404,
+        type: "Todo",
+        title: "Fix bug",
+        bucket: { id: 100, name: "Project" },
+      },
+    });
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.meta.assignedToAgent).toBeUndefined();
+    expect(msg!.meta.assignees).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 4: Activity feed does not detect assignments
+// ---------------------------------------------------------------------------
+
+describe("activity feed assignment removal", () => {
+  it("todo_assignment_changed in activity feed has no assignedToAgent", async () => {
+    const raw = makeActivityEvent({
+      kind: "todo_assignment_changed",
+      recording: { id: 500, type: "Todo", title: "Fix it" },
+    });
+    const msg = await normalizeActivityEvent(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.meta.assignedToAgent).toBeUndefined();
+    expect(msg!.meta.eventKind).toBe("assigned");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step 4: Unknown kind drop policy
+// ---------------------------------------------------------------------------
+
+describe("unknown kind drop policy", () => {
+  it("activity event with unknown kind and unrecognized recording type returns null", async () => {
+    const raw = makeActivityEvent({
+      kind: "future_quantum_created",
+      recording: { id: 200, type: "FutureQuantum", title: "Quantum" },
+    });
+    const msg = await normalizeActivityEvent(raw, mockAccount);
+
+    expect(msg).toBeNull();
+    expect(recordUnknownKind).toHaveBeenCalledWith("test-acct", "future_quantum_created");
+  });
+
+  it("webhook event with unknown kind returns null", async () => {
+    const raw = makeWebhookPayload({
+      kind: "future_quantum_created",
+      recording: {
+        id: 600,
+        type: "FutureQuantum",
+        title: "Quantum",
+        bucket: { id: 100, name: "Project" },
+      },
+    });
+    const msg = await normalizeWebhookPayload(raw, mockAccount);
+
+    expect(msg).toBeNull();
+    expect(recordUnknownKind).toHaveBeenCalledWith("test-acct", "future_quantum_created");
+  });
+
+  it("readings event with unknown type returns null", () => {
+    const raw = makeReadingsEntry({ type: "FutureQuantum" });
+    const msg = normalizeReadingsEvent(raw, mockAccount);
+
+    expect(msg).toBeNull();
+    expect(recordUnknownKind).toHaveBeenCalledWith("test-acct", "FutureQuantum");
+  });
+
+  it("unknown kind but recognized recording.type still resolves", async () => {
+    const raw = makeActivityEvent({
+      kind: "some_unknown_kind",
+      recording: { id: 601, type: "Upload", title: "A file" },
+    });
+    const msg = await normalizeActivityEvent(raw, mockAccount);
+
+    expect(msg).not.toBeNull();
+    expect(msg!.meta.recordableType).toBe("Upload");
   });
 });

--- a/tests/outbound.test.ts
+++ b/tests/outbound.test.ts
@@ -1,8 +1,33 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   resolveOutboundTarget,
   chunkMarkdownText,
 } from "../src/adapters/outbound.js";
+import { sendBasecampText, sendBasecampMedia } from "../src/outbound/send.js";
+
+// --- Mocks required to import channel.ts without pulling in heavy deps ---
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (v: string | undefined | null) => (v ?? "").trim() || "default",
+  buildChannelConfigSchema: (schema: unknown) => ({ schema: {} }),
+  setAccountEnabledInConfigSection: vi.fn(),
+  deleteAccountFromConfigSection: vi.fn(),
+}));
+vi.mock("../src/runtime.js", () => ({ getBasecampRuntime: vi.fn(() => ({})) }));
+vi.mock("../src/dispatch.js", () => ({ dispatchBasecampEvent: vi.fn() }));
+vi.mock("../src/bcq.js", () => ({ bcqAuthStatus: vi.fn() }));
+vi.mock("../src/adapters/onboarding.js", () => ({ basecampOnboardingAdapter: {} }));
+vi.mock("../src/adapters/setup.js", () => ({ basecampSetupAdapter: {} }));
+vi.mock("../src/adapters/status.js", () => ({ basecampStatusAdapter: {} }));
+vi.mock("../src/adapters/pairing.js", () => ({ basecampPairingAdapter: {} }));
+vi.mock("../src/adapters/directory.js", () => ({ basecampDirectoryAdapter: {} }));
+vi.mock("../src/adapters/messaging.js", () => ({ basecampMessagingAdapter: {} }));
+vi.mock("../src/adapters/resolver.js", () => ({ basecampResolverAdapter: {} }));
+vi.mock("../src/adapters/heartbeat.js", () => ({ basecampHeartbeatAdapter: {} }));
+vi.mock("../src/adapters/groups.js", () => ({ basecampGroupAdapter: {} }));
+vi.mock("../src/adapters/agent-prompt.js", () => ({ basecampAgentPromptAdapter: {} }));
+
+import { basecampChannel } from "../src/channel.js";
 
 // ---------------------------------------------------------------------------
 // resolveOutboundTarget
@@ -130,5 +155,36 @@ describe("outbound.chunkMarkdownText", () => {
     for (const p of paragraphs) {
       expect(rejoined).toContain(p);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendBasecampText / sendBasecampMedia — diagnostic stubs
+// ---------------------------------------------------------------------------
+
+describe("outbound.sendBasecampText", () => {
+  it("throws with diagnostic message for any target", async () => {
+    await expect(
+      sendBasecampText({ to: "recording:123", text: "hello" }),
+    ).rejects.toThrow("dispatch bridge");
+  });
+});
+
+describe("outbound.sendBasecampMedia", () => {
+  it("throws with diagnostic message for any target", async () => {
+    await expect(
+      sendBasecampMedia({ to: "recording:123", text: "hello", mediaUrl: "https://example.com/img.png" }),
+    ).rejects.toThrow("agent tools");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Outbound adapter contract — both sendText and sendMedia must be present
+// ---------------------------------------------------------------------------
+
+describe("outbound adapter contract", () => {
+  it("exposes both sendText and sendMedia on the channel plugin", () => {
+    expect(typeof basecampChannel.outbound!.sendText).toBe("function");
+    expect(typeof (basecampChannel.outbound as any).sendMedia).toBe("function");
   });
 });

--- a/tests/peer.test.ts
+++ b/tests/peer.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/metrics.js", () => ({
+  recordUnknownKind: vi.fn(),
+}));
+vi.mock("../src/outbound/send.js", () => ({
+  resolveCircleInfoCached: vi.fn(() => undefined),
+}));
+
 import { resolveBasecampPeer, resolveParentPeer } from "../src/inbound/normalize.js";
 
 describe("resolveBasecampPeer", () => {

--- a/tests/readings.test.ts
+++ b/tests/readings.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  BasecampReadingsEntry,
+  ResolvedBasecampAccount,
+} from "../src/types.js";
+
+vi.mock("../src/bcq.js", () => ({
+  bcqReadings: vi.fn(),
+}));
+vi.mock("../src/metrics.js", () => ({
+  recordUnknownKind: vi.fn(),
+}));
+vi.mock("../src/outbound/send.js", () => ({
+  resolveCircleInfoCached: vi.fn(() => undefined),
+}));
+
+import { bcqReadings } from "../src/bcq.js";
+import { recordUnknownKind } from "../src/metrics.js";
+import { pollReadings } from "../src/inbound/readings.js";
+
+const mockAccount: ResolvedBasecampAccount = {
+  accountId: "test-acct",
+  enabled: true,
+  personId: "999",
+  token: "test-token",
+  tokenSource: "config",
+  config: { personId: "999" },
+};
+
+const log = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+};
+
+function makeReading(overrides: Partial<BasecampReadingsEntry> = {}): BasecampReadingsEntry {
+  return {
+    id: 1,
+    created_at: "2025-01-15T10:00:00Z",
+    type: "Comment",
+    title: "A comment",
+    app_url: "https://3.basecamp.com/2914079/buckets/100/comments/200",
+    readable_sgid: "sgid://bc3/Comment/200",
+    creator: { id: 42, name: "Alice" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("pollReadings", () => {
+  it("normalizes known types and collects processedSgids", async () => {
+    vi.mocked(bcqReadings).mockResolvedValue({
+      data: {
+        unreads: [makeReading({ id: 1 }), makeReading({ id: 2, readable_sgid: "sgid://bc3/Comment/201" })],
+      },
+      raw: "",
+    });
+
+    const result = await pollReadings({ account: mockAccount, log });
+
+    expect(result.events).toHaveLength(2);
+    expect(result.processedSgids).toEqual(["sgid://bc3/Comment/200", "sgid://bc3/Comment/201"]);
+    expect(result.newestAt).toBe("2025-01-15T10:00:00Z");
+  });
+
+  it("unknown reading type: returns no event but still marks SGID as processed", async () => {
+    const unknownReading = makeReading({
+      id: 10,
+      type: "FutureWidget",
+      readable_sgid: "sgid://bc3/FutureWidget/10",
+      unread_at: "2025-01-16T08:00:00Z",
+    });
+    vi.mocked(bcqReadings).mockResolvedValue({
+      data: { unreads: [unknownReading] },
+      raw: "",
+    });
+
+    const result = await pollReadings({ account: mockAccount, log });
+
+    // No events emitted (unknown type is dropped)
+    expect(result.events).toHaveLength(0);
+    // But the SGID is collected — prevents re-polling the same item next cycle
+    expect(result.processedSgids).toContain("sgid://bc3/FutureWidget/10");
+    // And newestAt is advanced
+    expect(result.newestAt).toBe("2025-01-16T08:00:00Z");
+    // And the unknown kind metric was recorded
+    expect(recordUnknownKind).toHaveBeenCalledWith("test-acct", "FutureWidget");
+  });
+
+  it("mix of known and unknown types: both advance cursor", async () => {
+    vi.mocked(bcqReadings).mockResolvedValue({
+      data: {
+        unreads: [
+          makeReading({ id: 1, unread_at: "2025-01-15T10:00:00Z" }),
+          makeReading({
+            id: 2,
+            type: "FutureWidget",
+            readable_sgid: "sgid://bc3/FutureWidget/2",
+            unread_at: "2025-01-16T12:00:00Z",
+          }),
+        ],
+      },
+      raw: "",
+    });
+
+    const result = await pollReadings({ account: mockAccount, log });
+
+    expect(result.events).toHaveLength(1); // only the Comment
+    expect(result.processedSgids).toHaveLength(2); // both marked processed
+    // newestAt should be the later timestamp from the unknown item
+    expect(result.newestAt).toBe("2025-01-16T12:00:00Z");
+  });
+
+  it("empty unreads returns empty result", async () => {
+    vi.mocked(bcqReadings).mockResolvedValue({
+      data: { unreads: [] },
+      raw: "",
+    });
+
+    const result = await pollReadings({ account: mockAccount, log });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.processedSgids).toHaveLength(0);
+    expect(result.newestAt).toBeUndefined();
+  });
+
+  it("null response returns empty result", async () => {
+    vi.mocked(bcqReadings).mockResolvedValue({ data: null, raw: "" });
+
+    const result = await pollReadings({ account: mockAccount, log });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.processedSgids).toHaveLength(0);
+  });
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -11,7 +11,15 @@
  * Run with: OPENCLAW_INTEGRATION=1 npx vitest run tests/smoke.test.ts
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/metrics.js", () => ({
+  recordUnknownKind: vi.fn(),
+}));
+vi.mock("../src/outbound/send.js", () => ({
+  resolveCircleInfoCached: vi.fn(() => undefined),
+}));
+
 import { bcqGet, bcqMe, bcqTimeline, bcqReadings, bcqApiGet } from "../src/bcq.js";
 import { pollActivityFeed } from "../src/inbound/activity.js";
 import { pollReadings } from "../src/inbound/readings.js";

--- a/tests/status-enhanced.test.ts
+++ b/tests/status-enhanced.test.ts
@@ -835,4 +835,65 @@ describe("collectStatusIssues (audit.errors)", () => {
 
     expect(issues).toHaveLength(0);
   });
+
+  it("PF-006: surfaces unknownKindCount as runtime issue", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [],
+      personIdSet: true,
+      unknownKindCount: 5,
+      lastUnknownKind: "future_quantum_created",
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const unknownIssues = issues.filter((i) => i.message.includes("unknown kind"));
+    expect(unknownIssues.length).toBe(1);
+    expect(unknownIssues[0].kind).toBe("runtime");
+    expect(unknownIssues[0].message).toContain("5 event(s)");
+    expect(unknownIssues[0].message).toContain("future_quantum_created");
+  });
+
+  it("PF-006: no unknownKind issue when count is 0", () => {
+    const audit: BasecampAudit = {
+      projectsAccessible: 1,
+      personasMapped: 0,
+      personasValid: 0,
+      errors: [],
+      personIdSet: true,
+      unknownKindCount: 0,
+      lastUnknownKind: null,
+    };
+
+    const issues = basecampStatusAdapter.collectStatusIssues!([
+      {
+        accountId: "test",
+        running: true,
+        configured: true,
+        enabled: true,
+        lastStartAt: Date.now(),
+        lastStopAt: null,
+        lastError: null,
+        probe: { ok: true, authenticated: true },
+        audit,
+      },
+    ]);
+
+    const unknownIssues = issues.filter((i) => i.message.includes("unknown kind"));
+    expect(unknownIssues.length).toBe(0);
+  });
 });

--- a/tests/webhook-lifecycle.test.ts
+++ b/tests/webhook-lifecycle.test.ts
@@ -73,7 +73,7 @@ describe("reconcileWebhooks", () => {
     expect(bcqWebhookCreate).toHaveBeenCalledTimes(2);
   });
 
-  it("skips projects that already have a matching active webhook", async () => {
+  it("recovers secret for pre-existing webhook with no registry entry", async () => {
     vi.mocked(bcqWebhookList).mockResolvedValue({
       data: [
         {
@@ -85,20 +85,36 @@ describe("reconcileWebhooks", () => {
       ],
       raw: "[]",
     });
+    vi.mocked(bcqWebhookDelete).mockResolvedValue({ data: null, raw: "" });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 43,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        types: ["Todo", "Comment"],
+        secret: "recovered-secret",
+      },
+      raw: "{}",
+    });
 
     const registry = new WebhookSecretRegistry();
     const log = mockLog();
     const result = await reconcileWebhooks(makeConfig(), registry, log);
 
-    expect(result.existing).toEqual(["100", "200"]);
+    // First encounter with pre-existing webhook triggers recovery
+    expect(result.recovered).toEqual(["100", "200"]);
+    expect(result.existing).toEqual([]);
     expect(result.created).toEqual([]);
-    expect(bcqWebhookCreate).not.toHaveBeenCalled();
 
-    // Should still store the webhook ID (without secret since it's pre-existing)
+    // Delete old, create new
+    expect(bcqWebhookDelete).toHaveBeenCalledTimes(2);
+    expect(bcqWebhookCreate).toHaveBeenCalledTimes(2);
+
+    // Registry should now have the recovered secret
     const entry = registry.get("100");
     expect(entry).toBeDefined();
-    expect(entry!.webhookId).toBe("42");
-    expect(entry!.secret).toBe("");
+    expect(entry!.secret).toBe("recovered-secret");
+    expect(entry!.webhookId).toBe("43");
   });
 
   it("does not overwrite existing registry entries for matched webhooks", async () => {
@@ -172,6 +188,36 @@ describe("reconcileWebhooks", () => {
     expect(registry.get("100")!.secret).toBe("new-secret");
     expect(registry.get("100")!.webhookId).toBe("43");
     expect(log.info).toHaveBeenCalledWith("webhook_types_changed", expect.any(Object));
+  });
+
+  it("marks fresh create as failed when BC3 returns no secret", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({ data: [], raw: "[]" });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 50,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        types: ["Todo", "Comment"],
+        // No secret
+      },
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    const log = mockLog();
+    const result = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+      log,
+    );
+
+    expect(result.failed).toEqual(["100"]);
+    expect(result.created).toEqual([]);
+    expect(registry.get("100")!.recoveryFailed).toBe(true);
+    expect(log.error).toHaveBeenCalledWith("webhook_create_no_secret", expect.objectContaining({
+      project: "100",
+      recovery: false,
+    }));
   });
 
   it("records failed projects when create returns no ID", async () => {
@@ -291,6 +337,132 @@ describe("reconcileWebhooks", () => {
       ["Todo", "Comment"],
       { accountId: "acct-1", profile: "prod" },
     );
+  });
+
+  it("does not recover when existing secret is non-empty", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({
+      data: [
+        {
+          id: 42,
+          active: true,
+          payload_url: "https://example.com/webhooks/basecamp",
+          types: ["Todo", "Comment"],
+        },
+      ],
+      raw: "[]",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    // Pre-populate with a real secret
+    registry.set("100", {
+      webhookId: "42",
+      secret: "known-secret",
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: ["Todo", "Comment"],
+    });
+
+    const result = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+    );
+
+    expect(result.existing).toEqual(["100"]);
+    expect(result.recovered).toEqual([]);
+    expect(bcqWebhookDelete).not.toHaveBeenCalled();
+    expect(bcqWebhookCreate).not.toHaveBeenCalled();
+    expect(registry.get("100")!.secret).toBe("known-secret");
+  });
+
+  it("records failure when recovery delete fails", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({
+      data: [
+        {
+          id: 42,
+          active: true,
+          payload_url: "https://example.com/webhooks/basecamp",
+          types: ["Todo", "Comment"],
+        },
+      ],
+      raw: "[]",
+    });
+    vi.mocked(bcqWebhookDelete).mockRejectedValue(new Error("delete forbidden"));
+
+    const registry = new WebhookSecretRegistry();
+    const log = mockLog();
+    const result = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+      log,
+    );
+
+    expect(result.failed).toEqual(["100"]);
+    expect(result.recovered).toEqual([]);
+    expect(bcqWebhookCreate).not.toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledWith("webhook_secret_recovery_delete_failed", expect.any(Object));
+  });
+
+  it("marks recoveryFailed and stops retrying when create returns no secret", async () => {
+    vi.mocked(bcqWebhookList).mockResolvedValue({
+      data: [
+        {
+          id: 42,
+          active: true,
+          payload_url: "https://example.com/webhooks/basecamp",
+          types: ["Todo", "Comment"],
+        },
+      ],
+      raw: "[]",
+    });
+    vi.mocked(bcqWebhookDelete).mockResolvedValue({ data: null, raw: "" });
+    vi.mocked(bcqWebhookCreate).mockResolvedValue({
+      data: {
+        id: 99,
+        active: true,
+        payload_url: "https://example.com/webhooks/basecamp",
+        types: ["Todo", "Comment"],
+        // No secret returned
+      },
+      raw: "{}",
+    });
+
+    const registry = new WebhookSecretRegistry();
+    const log = mockLog();
+
+    // First call: recovery attempted, but create returned no secret
+    const result1 = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+      log,
+    );
+
+    expect(result1.failed).toEqual(["100"]);
+    expect(result1.recovered).toEqual([]);
+    expect(registry.get("100")!.recoveryFailed).toBe(true);
+
+    // Second call: should not retry recovery — treat as existing
+    vi.clearAllMocks();
+    vi.mocked(bcqWebhookList).mockResolvedValue({
+      data: [
+        {
+          id: 99,
+          active: true,
+          payload_url: "https://example.com/webhooks/basecamp",
+          types: ["Todo", "Comment"],
+        },
+      ],
+      raw: "[]",
+    });
+
+    const result2 = await reconcileWebhooks(
+      makeConfig({ projects: ["100"] }),
+      registry,
+      log,
+    );
+
+    expect(result2.existing).toEqual(["100"]);
+    expect(result2.recovered).toEqual([]);
+    expect(bcqWebhookDelete).not.toHaveBeenCalled();
+    expect(bcqWebhookCreate).not.toHaveBeenCalled();
   });
 
   it("passes undefined types when config types array is empty", async () => {


### PR DESCRIPTION
## Summary

- **Ping DM/group classification** via Circle API lookup with account-scoped LRU cache. Fail-closed to `dm` when participant count unknown so DM policy applies during API outages. Readings participant count corrected for BC3 `other_circle_people()` exclusion (+1 for caller). Webhook Ping detection uses `recording.bucket.type === "Circle"` (BC3 `bucketable_type`), not `recording.type` which is `recordable_type`.
- **Webhook assignment detection** via `details.added_person_ids` / `removed_person_ids`. Three `*_assignment_changed` kinds added to `KIND_TO_RECORDABLE_TYPE`. Broken activity-feed assignment detection (dead display-name comparison) removed.
- **Unknown event kinds** drop with metric + structured log + status issue surfacing instead of silent Document coercion. Readings unknown-type items still advance cursor and collect `processedSgids` to prevent infinite re-polling.

## Test plan

- [x] `npx tsc --noEmit` clean (pre-existing SDK type errors on main excluded)
- [x] `npx vitest run` — 889 passed, 11 skipped (up from 866)
- [x] New `tests/readings.test.ts` — unknown type marks SGID processed, advances cursor
- [x] Ping enrichment tests: activity dm/group/fallback, webhook Circle bucket detection, Project bucket negative case
- [x] Webhook assignment tests: added/removed person IDs, non-matching, missing details
- [x] Unknown-kind drop tests: all three normalizers return null, metric recorded
- [x] Status issue surfaced for `unknownKindCount > 0`
- [x] Readings participant count +1 regression: 2-element array → group (3 total)