### PR TITLE
Per-bucket sender gates and webhook project scoping

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -17,6 +17,7 @@ import {
   resolveBasecampAllowFrom,
   resolveWebhooksConfig,
   resolveAccountForBucket,
+  scopeWebhookProjects,
 } from "./config.js";
 import { getBasecampRuntime } from "./runtime.js";
 import { sendBasecampText, sendBasecampMedia } from "./outbound/send.js";
@@ -322,17 +323,11 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       // projects are only eligible when there is exactly one concrete account
       // (single-account mode) — otherwise skip + warn to prevent cross-account
       // delete/recreate churn.
-      const concreteAccountIds = listBasecampAccountIds(ctx.cfg);
-      const isSingleAccount = concreteAccountIds.length <= 1;
-      const accountProjects = whConfig.projects.filter((projectId) => {
-        const owner = resolveAccountForBucket(ctx.cfg, projectId);
-        if (owner) return owner === account.accountId;
-        if (isSingleAccount) return true;
-        ctx.log?.warn(
-          `[${account.accountId}] skipping unmapped webhook project ${projectId} — ` +
-          `add a virtualAccounts entry to assign it to an account`,
-        );
-        return false;
+      const accountProjects = scopeWebhookProjects({
+        cfg: ctx.cfg,
+        projects: whConfig.projects,
+        accountId: account.accountId,
+        log: ctx.log,
       });
       let webhookActiveProjects: Set<string> | undefined;
       if (whConfig.autoRegister && whConfig.payloadUrl && accountProjects.length > 0) {
@@ -465,3 +460,4 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
     },
   },
 };
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -389,3 +389,32 @@ export function resolveAccountForBucket(
   // No virtual account mapping for this bucket
   return undefined;
 }
+
+/**
+ * Scope webhook projects to a specific account.
+ *
+ * In multi-account mode, only projects mapped to this account via
+ * virtualAccounts are included. Unmapped projects are allowed only when
+ * there is exactly one concrete account (single-account mode).
+ */
+export function scopeWebhookProjects(opts: {
+  cfg: OpenClawConfig;
+  projects: string[];
+  accountId: string;
+  log?: { warn: (msg: string) => void };
+}): string[] {
+  const { cfg, projects, accountId, log } = opts;
+  const concreteAccountIds = listBasecampAccountIds(cfg);
+  const isSingleAccount = concreteAccountIds.length <= 1;
+
+  return projects.filter((projectId) => {
+    const owner = resolveAccountForBucket(cfg, projectId);
+    if (owner) return owner === accountId;
+    if (isSingleAccount) return true;
+    log?.warn(
+      `[${accountId}] skipping unmapped webhook project ${projectId} — ` +
+      `add a virtualAccounts entry to assign it to an account`,
+    );
+    return false;
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ const BasecampBucketConfigSchema = z.object({
   }).optional(),
   enabled: z.boolean().optional(),
   engage: z.array(EngagementTypeSchema).optional(),
+  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
 });
 
 export const BasecampConfigSchema = z.object({
@@ -329,6 +330,17 @@ export function resolveBasecampDmPolicy(cfg: OpenClawConfig) {
 export function resolveBasecampAllowFrom(cfg: OpenClawConfig): string[] {
   const section = getBasecampSection(cfg);
   return (section?.allowFrom ?? []).map((entry) => String(entry));
+}
+
+/** Get the allow-from list for a specific bucket. Returns undefined if unset (all senders allowed). */
+export function resolveBasecampBucketAllowFrom(
+  cfg: OpenClawConfig,
+  bucketId: string,
+): string[] | undefined {
+  const section = getBasecampSection(cfg);
+  const bucketConfig = section?.buckets?.[bucketId] ?? section?.buckets?.["*"];
+  if (!bucketConfig?.allowFrom) return undefined;
+  return bucketConfig.allowFrom.map((entry) => String(entry));
 }
 
 /** Get the webhook secret (undefined = webhooks disabled). */

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -15,7 +15,7 @@ import type { BasecampInboundMessage, BasecampChannelConfig, BasecampEngagementT
 import { DEFAULT_ENGAGE } from "./types.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { getBasecampRuntime } from "./runtime.js";
-import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom, resolveCircuitBreakerConfig } from "./config.js";
+import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom, resolveBasecampBucketAllowFrom, resolveCircuitBreakerConfig } from "./config.js";
 import { postReplyToEvent } from "./outbound/send.js";
 import { markdownToBasecampHtml } from "./outbound/format.js";
 import { chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
@@ -99,6 +99,21 @@ export async function dispatchBasecampEvent(
       type: msg.meta.recordableType,
       peer: msg.peer.id,
       policy: engagePolicy.join(","),
+    });
+    return false;
+  }
+
+  // ----- Per-bucket sender gate -----
+  // When a bucket configures allowFrom, only listed senders can trigger
+  // the agent — regardless of engagement type. This is distinct from the
+  // DM policy allowFrom which only applies to Pings.
+  const bucketAllowFrom = resolveBasecampBucketAllowFrom(cfg, msg.meta.bucketId);
+  if (bucketAllowFrom && !bucketAllowFrom.includes(msg.sender.id)) {
+    slog.debug("bucket_sender_gate_dropped", {
+      correlationId,
+      sender: msg.sender.id,
+      bucket: msg.meta.bucketId,
+      engagement,
     });
     return false;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,6 +400,8 @@ export type BasecampBucketConfig = {
   enabled?: boolean;
   /** Override engagement types for this bucket. */
   engage?: BasecampEngagementType[];
+  /** Sender person IDs allowed to trigger the agent in this bucket. Unset = all senders. */
+  allowFrom?: Array<string | number>;
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -17,6 +17,7 @@ import {
   resolvePollingIntervals,
   resolveBasecampDmPolicy,
   resolveBasecampAllowFrom,
+  resolveBasecampBucketAllowFrom,
   resolveAccountForBucket,
 } from "../src/config.js";
 
@@ -524,6 +525,57 @@ describe("resolveBasecampAllowFrom", () => {
     expect(
       resolveBasecampAllowFrom(cfg({ allowFrom: ["abc", 42, "def"] })),
     ).toEqual(["abc", "42", "def"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBasecampBucketAllowFrom
+// ---------------------------------------------------------------------------
+
+describe("resolveBasecampBucketAllowFrom", () => {
+  it("returns undefined when no buckets configured", () => {
+    expect(resolveBasecampBucketAllowFrom(cfg({}), "456")).toBeUndefined();
+  });
+
+  it("returns string array from exact bucket match", () => {
+    expect(
+      resolveBasecampBucketAllowFrom(
+        cfg({ buckets: { "456": { allowFrom: ["100", "200"] } } }),
+        "456",
+      ),
+    ).toEqual(["100", "200"]);
+  });
+
+  it("falls back to wildcard", () => {
+    expect(
+      resolveBasecampBucketAllowFrom(
+        cfg({ buckets: { "*": { allowFrom: ["111"] } } }),
+        "456",
+      ),
+    ).toEqual(["111"]);
+  });
+
+  it("coerces numbers to strings", () => {
+    expect(
+      resolveBasecampBucketAllowFrom(
+        cfg({ buckets: { "456": { allowFrom: [100, 200] } } }),
+        "456",
+      ),
+    ).toEqual(["100", "200"]);
+  });
+
+  it("exact match takes precedence over wildcard", () => {
+    expect(
+      resolveBasecampBucketAllowFrom(
+        cfg({
+          buckets: {
+            "456": { allowFrom: ["777"] },
+            "*": { allowFrom: ["111"] },
+          },
+        }),
+        "456",
+      ),
+    ).toEqual(["777"]);
   });
 });
 

--- a/tests/dispatch-enhanced.test.ts
+++ b/tests/dispatch-enhanced.test.ts
@@ -18,6 +18,7 @@ vi.mock("../src/config.js", () => ({
   resolvePersonaAccountId: vi.fn(),
   resolveBasecampAccount: vi.fn(),
   resolveCircuitBreakerConfig: vi.fn(() => ({ threshold: 5, cooldownMs: 300000 })),
+  resolveBasecampBucketAllowFrom: vi.fn(() => undefined),
 }));
 vi.mock("../src/outbound/send.js", () => ({
   postReplyToEvent: vi.fn(),

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -22,6 +22,7 @@ vi.mock("../src/config.js", () => ({
   resolveBasecampDmPolicy: vi.fn(() => "open"),
   resolveBasecampAllowFrom: vi.fn(() => []),
   resolveCircuitBreakerConfig: vi.fn(() => ({ threshold: 5, cooldownMs: 300000 })),
+  resolveBasecampBucketAllowFrom: vi.fn(() => undefined),
 }));
 vi.mock("../src/outbound/send.js", () => ({
   postReplyToEvent: vi.fn(),

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -5,7 +5,7 @@ import type {
   ResolvedBasecampAccount,
 } from "../src/types.js";
 import { getBasecampRuntime } from "../src/runtime.js";
-import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom } from "../src/config.js";
+import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom, resolveBasecampBucketAllowFrom } from "../src/config.js";
 import { postReplyToEvent } from "../src/outbound/send.js";
 import { markdownToBasecampHtml } from "../src/outbound/format.js";
 
@@ -22,6 +22,7 @@ vi.mock("../src/config.js", () => ({
   resolveBasecampDmPolicy: vi.fn(() => "open"),
   resolveBasecampAllowFrom: vi.fn(() => []),
   resolveCircuitBreakerConfig: vi.fn(() => ({ threshold: 5, cooldownMs: 300000 })),
+  resolveBasecampBucketAllowFrom: vi.fn(() => undefined),
 }));
 vi.mock("../src/outbound/send.js", () => ({
   postReplyToEvent: vi.fn(),
@@ -89,7 +90,15 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getBasecampRuntime).mockReturnValue(mockRuntime as any);
   vi.mocked(resolvePersonaAccountId).mockReturnValue(undefined);
+  vi.mocked(resolveBasecampBucketAllowFrom).mockReturnValue(undefined);
   vi.mocked(postReplyToEvent).mockResolvedValue({ ok: true });
+  mockRuntime.config.loadConfig.mockReturnValue({
+    channels: {
+      basecamp: {
+        accounts: { "test-acct": { personId: "999" } },
+      },
+    },
+  });
   mockRuntime.channel.routing.resolveAgentRoute.mockReturnValue({
     agentId: "agent-1",
     matchedBy: "peer",
@@ -597,6 +606,111 @@ describe("dispatchBasecampEvent", () => {
     };
 
     const result = await dispatchBasecampEvent(dmMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Per-bucket sender gate
+  // -----------------------------------------------------------------------
+
+  it("drops events when sender not in bucket allowFrom", async () => {
+    vi.mocked(resolveBasecampBucketAllowFrom).mockReturnValue(["111"]);
+
+    const result = await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("allows events when sender is in bucket allowFrom", async () => {
+    vi.mocked(resolveBasecampBucketAllowFrom).mockReturnValue(["777"]);
+
+    const result = await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("bucket allowFrom applies to all engagement types (conversation)", async () => {
+    vi.mocked(resolveBasecampBucketAllowFrom).mockReturnValue(["111"]);
+
+    // Enable conversation for the bucket so engagement gate passes
+    mockRuntime.config.loadConfig.mockReturnValue({
+      channels: {
+        basecamp: {
+          accounts: { "test-acct": { personId: "999" } },
+          buckets: { "456": { engage: ["conversation"], allowFrom: ["111"] } },
+        },
+      },
+    });
+
+    const chatMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(chatMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("wildcard bucket allowFrom gates all buckets", async () => {
+    vi.mocked(resolveBasecampBucketAllowFrom).mockReturnValue(["111"]);
+
+    const result = await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("exact bucket allowFrom overrides wildcard", async () => {
+    // The resolver handles precedence; mock returns the resolved list for bucket 456
+    vi.mocked(resolveBasecampBucketAllowFrom).mockReturnValue(["777"]);
+
+    const result = await dispatchBasecampEvent(mockMsg, { account: mockAccount });
+    expect(result).toBe(true);
+  });
+
+  it("DM policy still applies after bucket sender gate passes", async () => {
+    vi.mocked(resolveBasecampBucketAllowFrom).mockReturnValue(["777"]);
+    vi.mocked(resolveBasecampDmPolicy).mockReturnValue("disabled");
+
+    const dmMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      peer: { kind: "dm", id: "ping:789" },
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(dmMsg, { account: mockAccount });
+    expect(result).toBe(false);
+  });
+
+  it("no bucket allowFrom = all senders pass (existing behavior)", async () => {
+    vi.mocked(resolveBasecampBucketAllowFrom).mockReturnValue(undefined);
+
+    mockRuntime.config.loadConfig.mockReturnValue({
+      channels: {
+        basecamp: {
+          accounts: { "test-acct": { personId: "999" } },
+          buckets: { "456": { engage: ["conversation"] } },
+        },
+      },
+    });
+
+    const chatMsg: BasecampInboundMessage = {
+      ...mockMsg,
+      meta: {
+        ...mockMsg.meta,
+        recordableType: "Chat::Line",
+        mentionsAgent: false,
+        sources: ["activity_feed"],
+      },
+    };
+
+    const result = await dispatchBasecampEvent(chatMsg, { account: mockAccount });
     expect(result).toBe(true);
   });
 });

--- a/tests/dogfooding/dm-policy.test.ts
+++ b/tests/dogfooding/dm-policy.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../src/config.js", () => ({
   resolveBasecampDmPolicy: (...args: unknown[]) => mockResolveDmPolicy(...args),
   resolveBasecampAllowFrom: (...args: unknown[]) => mockResolveAllowFrom(...args),
   resolveCircuitBreakerConfig: vi.fn(() => ({ threshold: 5, cooldownMs: 300000 })),
+  resolveBasecampBucketAllowFrom: vi.fn(() => undefined),
 }));
 
 vi.mock("../../src/outbound/send.js", () => ({

--- a/tests/dogfooding/outbound-cb.test.ts
+++ b/tests/dogfooding/outbound-cb.test.ts
@@ -41,6 +41,7 @@ vi.mock("../../src/config.js", () => ({
   resolveBasecampDmPolicy: vi.fn(() => "open"),
   resolveBasecampAllowFrom: vi.fn(() => []),
   resolveCircuitBreakerConfig: vi.fn(() => ({ threshold: 2, cooldownMs: 50 })),
+  resolveBasecampBucketAllowFrom: vi.fn(() => undefined),
 }));
 
 const mockPostReply = vi.fn();

--- a/tests/webhook-project-scoping.test.ts
+++ b/tests/webhook-project-scoping.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+}));
+
+import {
+  scopeWebhookProjects,
+  resolveAccountForBucket,
+  listBasecampAccountIds,
+} from "../src/config.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function cfg(basecamp?: Record<string, unknown>) {
+  if (!basecamp) return {} as any;
+  return { channels: { basecamp } } as any;
+}
+
+// ---------------------------------------------------------------------------
+// scopeWebhookProjects — startup-time webhook project scoping
+// ---------------------------------------------------------------------------
+
+describe("scopeWebhookProjects", () => {
+  it("includes mapped project when owner matches accountId", () => {
+    const config = cfg({
+      accounts: { "acct-a": { personId: "1" }, "acct-b": { personId: "2" } },
+      virtualAccounts: {
+        "scope-a": { accountId: "acct-a", bucketId: "100" },
+      },
+    });
+
+    const result = scopeWebhookProjects({
+      cfg: config,
+      projects: ["100"],
+      accountId: "acct-a",
+    });
+
+    expect(result).toEqual(["100"]);
+  });
+
+  it("excludes mapped project when owner does not match accountId", () => {
+    const config = cfg({
+      accounts: { "acct-a": { personId: "1" }, "acct-b": { personId: "2" } },
+      virtualAccounts: {
+        "scope-b": { accountId: "acct-b", bucketId: "100" },
+      },
+    });
+
+    const result = scopeWebhookProjects({
+      cfg: config,
+      projects: ["100"],
+      accountId: "acct-a",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips unmapped project in multi-account mode and warns", () => {
+    const config = cfg({
+      accounts: { "acct-a": { personId: "1" }, "acct-b": { personId: "2" } },
+    });
+    const log = { warn: vi.fn() };
+
+    const result = scopeWebhookProjects({
+      cfg: config,
+      projects: ["999"],
+      accountId: "acct-a",
+      log,
+    });
+
+    expect(result).toEqual([]);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn.mock.calls[0][0]).toContain("skipping unmapped webhook project 999");
+  });
+
+  it("allows unmapped project in single-account mode", () => {
+    const config = cfg({
+      accounts: { default: { personId: "1" } },
+    });
+
+    const result = scopeWebhookProjects({
+      cfg: config,
+      projects: ["999"],
+      accountId: "default",
+    });
+
+    expect(result).toEqual(["999"]);
+  });
+
+  it("filters mixed mapped/unmapped projects correctly in multi-account mode", () => {
+    const config = cfg({
+      accounts: { "acct-a": { personId: "1" }, "acct-b": { personId: "2" } },
+      virtualAccounts: {
+        "scope-a": { accountId: "acct-a", bucketId: "100" },
+        "scope-b": { accountId: "acct-b", bucketId: "200" },
+      },
+    });
+
+    const result = scopeWebhookProjects({
+      cfg: config,
+      projects: ["100", "200", "300"],
+      accountId: "acct-a",
+    });
+
+    // 100 → acct-a (match), 200 → acct-b (no match), 300 → unmapped (multi-account: skip)
+    expect(result).toEqual(["100"]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Per-bucket sender gate** — adds `allowFrom` to `BasecampBucketConfig` so operators can restrict which Basecamp person IDs trigger the agent within a specific project. The gate sits between the engagement classifier and DM policy in the 5-gate dispatch pipeline. Unset = all senders pass (existing behavior preserved).
- **Webhook project scoping extraction** — extracts the inline startup-time project filter from `channel.ts` into `scopeWebhookProjects()` in `config.ts`, enabling direct regression coverage for the multi-account skip+warn and single-account pass-through paths.

## Test plan

- [x] 7 new dispatch sender gate tests (drop/allow/wildcard/override/DM-policy-after-gate/no-config)
- [x] 5 new `resolveBasecampBucketAllowFrom` config resolver tests
- [x] 5 new `scopeWebhookProjects` scoping tests (mapped/unmapped/multi-account/single-account/mixed)
- [x] All existing tests pass unchanged (913 passed, 11 skipped)
- [x] tsc errors are pre-existing (status.ts SDK exports, dispatch.ts RoutePeer contravariance)