### PR TITLE
Safety net polling, reconciliation, and webhook auth fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@vitest/coverage-v8": "^3.2.4",
         "openclaw": "2026.2.19-2",
         "vitest": "3"
       }
@@ -25,6 +26,20 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1002,12 +1017,62 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1020,6 +1085,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -2290,12 +2365,54 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@keyv/bigmap": {
       "version": "1.3.1",
@@ -5345,6 +5462,40 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -5726,6 +5877,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -8151,6 +8321,67 @@
         "node": ">=16"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -8601,6 +8832,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-it": {
@@ -11187,6 +11446,83 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/test-exclude/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -11637,6 +11973,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^3.2.4",
     "openclaw": "2026.2.19-2",
     "vitest": "3"
   },

--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -40,6 +40,7 @@ export type BasecampAudit = {
     activity: number | null;
     readings: number | null;
     assignments: number | null;
+    safetyNet: number | null;
   };
   /** Circuit breaker states for outbound delivery. */
   circuitBreakers?: Record<string, { state: string; failures: number }>;
@@ -61,6 +62,15 @@ export type BasecampAudit = {
   unknownKindCount?: number;
   /** Most recent unknown kind string (for diagnostics). */
   lastUnknownKind?: string | null;
+  /** Reconciliation pass stats. */
+  reconciliation?: {
+    lastRunAt: number | null;
+    replayed: number;
+    unseen: number;
+    promotedTypes: string[];
+  };
+  /** Webhook auth method distribution. */
+  webhookAuthMethods?: Record<string, number>;
 };
 
 /** Seconds since last successful poll, or null if never succeeded. */
@@ -144,6 +154,7 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
         activity: pollerLagSeconds(metrics.poller.activity),
         readings: pollerLagSeconds(metrics.poller.readings),
         assignments: pollerLagSeconds(metrics.poller.assignments),
+        safetyNet: pollerLagSeconds(metrics.poller.safetyNet),
       };
 
       if (Object.keys(metrics.circuitBreaker).length > 0) {
@@ -172,6 +183,15 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
       if (metrics.unknownKindCount > 0) {
         result.unknownKindCount = metrics.unknownKindCount;
         result.lastUnknownKind = metrics.lastUnknownKind;
+      }
+
+      if (metrics.reconciliation.lastRunAt) {
+        result.reconciliation = metrics.reconciliation;
+      }
+
+      const authMethods = metrics.webhook.authMethods;
+      if (Object.keys(authMethods).length > 0) {
+        result.webhookAuthMethods = authMethods;
       }
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,6 +95,33 @@ export const BasecampConfigSchema = z.object({
       cooldownMs: z.number().positive().optional(),
     })
     .optional(),
+  safetyNet: z
+    .object({
+      projects: z.array(z.string()).optional(),
+      intervalMs: z.number().positive().optional(),
+      tier2: z
+        .object({
+          enabled: z.boolean().optional(),
+          lagThresholdMs: z.number().optional(),
+          rapidIntervalMs: z.number().optional(),
+          businessHours: z
+            .object({
+              start: z.number().optional(),
+              end: z.number().optional(),
+              timezone: z.string().optional(),
+            })
+            .optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  reconciliation: z
+    .object({
+      enabled: z.boolean().optional(),
+      intervalMs: z.number().positive().optional(),
+      gapThreshold: z.number().positive().optional(),
+    })
+    .optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -404,6 +431,52 @@ export function resolveAccountForBucket(
   }
   // No virtual account mapping for this bucket
   return undefined;
+}
+
+/** Resolve safety net config with defaults. */
+export function resolveSafetyNetConfig(cfg: OpenClawConfig): {
+  projects: string[];
+  intervalMs: number;
+  tier2: {
+    enabled: boolean;
+    lagThresholdMs: number;
+    rapidIntervalMs: number;
+    businessHours: { start: number; end: number; timezone: string };
+  };
+} {
+  const section = getBasecampSection(cfg);
+  const sn = section?.safetyNet as { projects?: string[]; intervalMs?: number; tier2?: any } | undefined;
+  const t2 = sn?.tier2 ?? {};
+  const bh = t2?.businessHours ?? {};
+  return {
+    projects: sn?.projects ?? [],
+    intervalMs: sn?.intervalMs ?? 600_000,
+    tier2: {
+      enabled: t2?.enabled ?? false,
+      lagThresholdMs: t2?.lagThresholdMs ?? 600_000,
+      rapidIntervalMs: t2?.rapidIntervalMs ?? 120_000,
+      businessHours: {
+        start: bh?.start ?? 9,
+        end: bh?.end ?? 18,
+        timezone: bh?.timezone ?? "America/Chicago",
+      },
+    },
+  };
+}
+
+/** Resolve reconciliation config with defaults. */
+export function resolveReconciliationConfig(cfg: OpenClawConfig): {
+  enabled: boolean;
+  intervalMs: number;
+  gapThreshold: number;
+} {
+  const section = getBasecampSection(cfg);
+  const rc = section?.reconciliation as { enabled?: boolean; intervalMs?: number; gapThreshold?: number } | undefined;
+  return {
+    enabled: rc?.enabled ?? true,
+    intervalMs: rc?.intervalMs ?? 21_600_000,
+    gapThreshold: rc?.gapThreshold ?? 3,
+  };
 }
 
 /**

--- a/src/inbound/dedup.ts
+++ b/src/inbound/dedup.ts
@@ -188,6 +188,25 @@ export class EventDedup {
     }
   }
 
+  /**
+   * Check if an event has been seen without recording it.
+   * Returns true if found in the window via primary or secondary key.
+   * Used by reconciliation to probe for gaps.
+   */
+  hasSeen(primaryKey: string, secondaryKey?: string): boolean {
+    const now = Date.now();
+    const entry = this.primary.get(primaryKey);
+    if (entry && now - entry.seenAt < this.ttlMs) return true;
+    if (secondaryKey) {
+      const mapped = this.secondary.get(secondaryKey);
+      if (mapped) {
+        const mappedEntry = this.primary.get(mapped);
+        if (mappedEntry && now - mappedEntry.seenAt < this.ttlMs) return true;
+      }
+    }
+    return false;
+  }
+
   /** Number of entries currently tracked. */
   get size(): number {
     return this.primary.size;

--- a/src/inbound/dock-cache.ts
+++ b/src/inbound/dock-cache.ts
@@ -1,0 +1,74 @@
+/**
+ * Dock tool ID resolution via SDK.
+ *
+ * Each Basecamp project has a "dock" — a set of tools (card table, todoset,
+ * questionnaire, etc.) with unique IDs. The safety net needs these IDs to
+ * traverse cards, todos, and check-in questions.
+ *
+ * Results are cached per-project with a 1h TTL. On 404/410 from downstream
+ * calls, invalidate and retry once.
+ */
+
+export interface DockToolIds {
+  cardTableId?: number;
+  todosetId?: number;
+  questionnaireId?: number;
+}
+
+interface CacheEntry {
+  ids: DockToolIds;
+  fetchedAt: number;
+}
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const cache = new Map<number, CacheEntry>();
+
+/**
+ * Resolve dock tool IDs for a project.
+ *
+ * @param client - SDK client instance
+ * @param projectId - Basecamp project (bucket) ID
+ * @returns Tool IDs, or undefined if project is inaccessible
+ */
+export async function resolveDockToolIds(
+  client: { projects: { get(id: number): Promise<any> } },
+  projectId: number,
+): Promise<DockToolIds | undefined> {
+  const now = Date.now();
+  const cached = cache.get(projectId);
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.ids;
+  }
+
+  try {
+    const project = await client.projects.get(projectId);
+    const dock: Array<{ name: string; id: number; enabled?: boolean }> = project?.dock ?? [];
+
+    const ids: DockToolIds = {};
+    for (const item of dock) {
+      if (item.name === "kanban_board" && item.enabled !== false) {
+        ids.cardTableId = item.id;
+      } else if (item.name === "todoset" && item.enabled !== false) {
+        ids.todosetId = item.id;
+      } else if (item.name === "questionnaire" && item.enabled !== false) {
+        ids.questionnaireId = item.id;
+      }
+    }
+
+    cache.set(projectId, { ids, fetchedAt: now });
+    return ids;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Invalidate cached dock for a project. Call on 404/410 from downstream. */
+export function invalidateDockCache(projectId: number): void {
+  cache.delete(projectId);
+}
+
+/** Clear entire dock cache. Exported for tests. */
+export function clearDockCache(): void {
+  cache.clear();
+}

--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -95,6 +95,16 @@ const KIND_TO_RECORDABLE_TYPE: Record<string, BasecampRecordableType> = {
   kanban_step_assignment_changed: "Kanban::Card",
 };
 
+/** Check if a raw event kind is normalizable (has an entry in KIND_TO_RECORDABLE_TYPE). */
+export function isNormalizableKind(kind: string): boolean {
+  return kind in KIND_TO_RECORDABLE_TYPE;
+}
+
+/** Get the recordable type for a raw event kind, or undefined. */
+export function recordableTypeForKind(kind: string): BasecampRecordableType | undefined {
+  return KIND_TO_RECORDABLE_TYPE[kind];
+}
+
 /** Map event.kind to a normalized eventKind for our domain model. */
 function resolveEventKind(kind: string): string {
   if (kind.endsWith("_created")) return "created";

--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -106,7 +106,7 @@ export function recordableTypeForKind(kind: string): BasecampRecordableType | un
 }
 
 /** Map event.kind to a normalized eventKind for our domain model. */
-function resolveEventKind(kind: string): string {
+export function resolveEventKind(kind: string): string {
   if (kind.endsWith("_created")) return "created";
   if (kind.endsWith("_completed")) return "completed";
   if (kind.endsWith("_edited") || kind === "edited") return "edited";

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -225,10 +225,6 @@ export async function startCompositePoller(
 
   let lastReconciliationPoll = 0;
 
-  // Tier-2 escalation state
-  const tier2 = snConfig.tier2;
-  const escalationState = new Map<string, { rapidCycles: number; escalatedAt: number }>();
-
   slog.info("started", {
     activityMs: activityIntervalMs,
     readingsMs: readingsIntervalMs,
@@ -507,7 +503,6 @@ export async function startCompositePoller(
     if (rcConfig.enabled) {
       const rcDue = now - lastReconciliationPoll >= rcConfig.intervalMs;
       if (rcDue) {
-        lastReconciliationPoll = now;
         try {
           const client = getClient(account);
           const result = await runReconciliation({
@@ -519,6 +514,8 @@ export async function startCompositePoller(
             promotionState,
             log,
           });
+
+          lastReconciliationPoll = now;
 
           promotionState = {
             promotions: result.promotions,
@@ -536,6 +533,7 @@ export async function startCompositePoller(
             promotedTypes: result.promotions.map((p) => p.type),
           });
         } catch (err) {
+          // Don't update lastReconciliationPoll — retry on next loop iteration
           slog.error("reconciliation_error", { error: String(err) });
         }
       }
@@ -548,6 +546,9 @@ export async function startCompositePoller(
     const sleepCandidates = [nextActivityDue, nextReadingsDue, nextAssignmentsDue];
     if (accountSnProjects.length > 0) {
       sleepCandidates.push(lastSafetyNetPoll + safetyNetIntervalMs + safetyNetBackoff - Date.now());
+    }
+    if (rcConfig.enabled) {
+      sleepCandidates.push(lastReconciliationPoll + rcConfig.intervalMs - Date.now());
     }
     const sleepMs = Math.max(1000, Math.min(...sleepCandidates));
 

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -18,20 +18,25 @@
  */
 
 import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../types.js";
-import { resolvePollingIntervals, resolveCircuitBreakerConfig } from "../config.js";
+import { resolvePollingIntervals, resolveCircuitBreakerConfig, resolveSafetyNetConfig, resolveReconciliationConfig, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
 import { EventDedup } from "./dedup.js";
 import { getAccountDedup } from "./dedup-registry.js";
 import { CursorStore } from "./cursors.js";
 import { pollActivityFeed } from "./activity.js";
 import { pollReadings } from "./readings.js";
 import { pollAssignments } from "./assignments.js";
+import { pollSafetyNet, deserializeSnapshot, serializeSnapshot, deserializePending, serializePending } from "./safety-net.js";
+import type { SafetyNetSnapshot, DisappearedPending } from "./safety-net.js";
+import { runReconciliation, deserializePromotionState, serializePromotionState } from "./reconciliation.js";
+import type { PromotionState } from "./reconciliation.js";
 import { CircuitBreaker } from "../circuit-breaker.js";
 import { getClient, rawOrThrow } from "../basecamp-client.js";
 import { withCircuitBreaker } from "../retry.js";
 import { isSelfMessage } from "./normalize.js";
 import { createStructuredLog } from "../logging.js";
-import { recordPollAttempt, recordPollSuccess, recordPollError, recordDedupSize, recordCircuitBreakerState } from "../metrics.js";
+import { recordPollAttempt, recordPollSuccess, recordPollError, recordDedupSize, recordCircuitBreakerState, recordReconciliationRun, recordSafetyNetEscalation } from "../metrics.js";
 import { withTimeout } from "../util.js";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
 
 export interface CompositePollerOptions {
   account: ResolvedBasecampAccount;
@@ -176,6 +181,53 @@ export async function startCompositePoller(
       slog.warn("corrupt_assignment_cursor");
     }
   }
+
+  // ----- Safety net state -----
+  const snConfig = resolveSafetyNetConfig(cfg as OpenClawConfig);
+  const rcConfig = resolveReconciliationConfig(cfg as OpenClawConfig);
+
+  // Resolve safety-net projects scoped to this account
+  const allSnProjects = snConfig.projects;
+  let accountSnProjects: number[] = [];
+  if (allSnProjects.length > 0) {
+    const concreteAccountIds = listBasecampAccountIds(cfg as OpenClawConfig);
+    const isSingleAccount = concreteAccountIds.length <= 1;
+    for (const pid of allSnProjects) {
+      const owner = resolveAccountForBucket(cfg as OpenClawConfig, pid);
+      if (owner) {
+        if (owner === account.accountId) accountSnProjects.push(Number(pid));
+      } else if (isSingleAccount) {
+        accountSnProjects.push(Number(pid));
+      } else {
+        slog.warn("unmapped_safetynet_project", { projectId: pid });
+      }
+    }
+  }
+
+  const safetyNetIntervalMs = snConfig.intervalMs;
+  const DEEP_CRAWL_EVERY = 6;
+  let safetyNetCycleCount = 0;
+  let lastSafetyNetPoll = 0;
+  let safetyNetBackoff = 0;
+
+  // Load stored snapshot
+  let safetyNetSnapshot: SafetyNetSnapshot | undefined;
+  let safetyNetPending: DisappearedPending | undefined;
+  const storedSnap = cursors.getCustom("safetyNetSnapshot");
+  if (storedSnap) safetyNetSnapshot = deserializeSnapshot(storedSnap);
+  const storedPending = cursors.getCustom("safetyNetPending");
+  if (storedPending) safetyNetPending = deserializePending(storedPending);
+
+  // Load promotion state for reconciliation
+  let promotionState: PromotionState | undefined;
+  const storedPromotion = cursors.getCustom("reconciliation:promotions");
+  if (storedPromotion) promotionState = deserializePromotionState(storedPromotion);
+
+  let lastReconciliationPoll = 0;
+
+  // Tier-2 escalation state
+  const tier2 = snConfig.tier2;
+  const escalationState = new Map<string, { rapidCycles: number; escalatedAt: number }>();
 
   slog.info("started", {
     activityMs: activityIntervalMs,
@@ -381,11 +433,123 @@ export async function startCompositePoller(
       }
     }
 
+    // ----- Safety net poll -----
+    if (accountSnProjects.length > 0) {
+      const snDue = now - lastSafetyNetPoll >= safetyNetIntervalMs + safetyNetBackoff;
+      if (snDue) {
+        lastSafetyNetPoll = now;
+        safetyNetCycleCount++;
+        const isDeepCrawl = safetyNetCycleCount % DEEP_CRAWL_EVERY === 0;
+        recordPollAttempt(account.accountId, "safetyNet");
+
+        try {
+          const client = getClient(account);
+          const result = await withCircuitBreaker(cb, "safetyNet", () =>
+            pollSafetyNet({
+              account,
+              client,
+              projectIds: accountSnProjects,
+              previousSnapshot: safetyNetSnapshot,
+              previousPending: safetyNetPending,
+              isDeepCrawl,
+              log,
+            }),
+          );
+
+          let dispatched = 0;
+          let dropped = 0;
+          for (const event of result.events) {
+            if (dedup.isDuplicate(event.dedupKey)) continue;
+
+            try {
+              const delivered = await onEvent(event);
+              if (delivered) dispatched++;
+              else dropped++;
+            } catch (err) {
+              slog.error("dispatch_error", { feed: "safetyNet", key: event.dedupKey, error: String(err) });
+            }
+          }
+
+          safetyNetSnapshot = result.snapshot;
+          safetyNetPending = result.pending;
+          cursors.setCustom("safetyNetSnapshot", serializeSnapshot(result.snapshot));
+          cursors.setCustom("safetyNetPending", serializePending(result.pending));
+          await saveCursorsWithRetry(cursors, slog);
+
+          if (dispatched > 0 || dropped > 0) {
+            slog.info("poll_dispatched", {
+              feed: "safetyNet",
+              total: result.events.length,
+              dispatched,
+              dropped,
+              deep: isDeepCrawl,
+            });
+          }
+
+          recordPollSuccess(account.accountId, "safetyNet", dispatched, dropped);
+          recordDedupSize(account.accountId, dedup.size);
+          syncCircuitBreakerMetrics("safetyNet");
+          safetyNetBackoff = 0;
+        } catch (err) {
+          safetyNetBackoff = clamp(
+            safetyNetBackoff === 0 ? safetyNetIntervalMs : safetyNetBackoff * 2,
+            safetyNetIntervalMs,
+            MAX_BACKOFF_MS,
+          );
+          recordPollError(account.accountId, "safetyNet", String(err), safetyNetBackoff);
+          syncCircuitBreakerMetrics("safetyNet");
+          slog.error("poll_error", { feed: "safetyNet", backoff: safetyNetBackoff, error: String(err) });
+        }
+      }
+    }
+
+    // ----- Reconciliation pass -----
+    if (rcConfig.enabled) {
+      const rcDue = now - lastReconciliationPoll >= rcConfig.intervalMs;
+      if (rcDue) {
+        lastReconciliationPoll = now;
+        try {
+          const client = getClient(account);
+          const result = await runReconciliation({
+            account,
+            client,
+            dedup,
+            maxItems: 250,
+            gapThreshold: rcConfig.gapThreshold,
+            promotionState,
+            log,
+          });
+
+          promotionState = {
+            promotions: result.promotions,
+            previousGaps: result.gapsByType,
+          };
+          cursors.setCustom(
+            "reconciliation:promotions",
+            serializePromotionState(result.promotions, result.gapsByType),
+          );
+          await saveCursorsWithRetry(cursors, slog);
+
+          recordReconciliationRun(account.accountId, {
+            replayed: result.replayed,
+            unseen: result.unseen,
+            promotedTypes: result.promotions.map((p) => p.type),
+          });
+        } catch (err) {
+          slog.error("reconciliation_error", { error: String(err) });
+        }
+      }
+    }
+
     // Sleep until next poll
     const nextActivityDue = lastActivityPoll + activityIntervalMs + activityBackoff - Date.now();
     const nextReadingsDue = lastReadingsPoll + readingsIntervalMs + readingsBackoff - Date.now();
     const nextAssignmentsDue = lastAssignmentsPoll + assignmentsIntervalMs + assignmentsBackoff - Date.now();
-    const sleepMs = Math.max(1000, Math.min(nextActivityDue, nextReadingsDue, nextAssignmentsDue));
+    const sleepCandidates = [nextActivityDue, nextReadingsDue, nextAssignmentsDue];
+    if (accountSnProjects.length > 0) {
+      sleepCandidates.push(lastSafetyNetPoll + safetyNetIntervalMs + safetyNetBackoff - Date.now());
+    }
+    const sleepMs = Math.max(1000, Math.min(...sleepCandidates));
 
     await abortableSleep(sleepMs, abortSignal);
   }

--- a/src/inbound/reconciliation.ts
+++ b/src/inbound/reconciliation.ts
@@ -13,8 +13,8 @@
  */
 
 import type { BasecampActivityEvent, BasecampRecordableType, ResolvedBasecampAccount } from "../types.js";
-import type { EventDedup } from "./dedup.js";
-import { isNormalizableKind, recordableTypeForKind } from "./normalize.js";
+import { EventDedup } from "./dedup.js";
+import { isNormalizableKind, recordableTypeForKind, resolveEventKind } from "./normalize.js";
 
 // Which recordable types can be promoted to safety-net direct polling
 const PROMOTABLE_TYPES: Partial<Record<BasecampRecordableType, string>> = {
@@ -128,7 +128,7 @@ export async function runReconciliation(
     const primaryKey = `activity:${event.id}`;
     const recordingId = event.recording?.id;
     const secondaryKey = recordingId
-      ? `${recordingId}:${resolveEventKindFromRaw(event.kind)}:${event.created_at}`
+      ? EventDedup.secondaryKey(String(recordingId), resolveEventKind(event.kind), event.created_at)
       : undefined;
 
     if (!dedup.hasSeen(primaryKey, secondaryKey)) {
@@ -217,16 +217,6 @@ function applyPromotionLogic(opts: {
   }
 
   return result;
-}
-
-/** Simplified event kind resolver (mirrors normalize.ts resolveEventKind). */
-function resolveEventKindFromRaw(kind: string): string {
-  if (kind.endsWith("_created")) return "created";
-  if (kind.endsWith("_completed")) return "completed";
-  if (kind.endsWith("_edited") || kind === "edited") return "edited";
-  if (kind.endsWith("_moved")) return "moved";
-  if (kind.endsWith("_assignment_changed")) return "assigned";
-  return kind;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/inbound/reconciliation.ts
+++ b/src/inbound/reconciliation.ts
@@ -17,11 +17,11 @@ import type { EventDedup } from "./dedup.js";
 import { isNormalizableKind, recordableTypeForKind } from "./normalize.js";
 
 // Which recordable types can be promoted to safety-net direct polling
-const PROMOTABLE_TYPES: Record<BasecampRecordableType, string> = {
+const PROMOTABLE_TYPES: Partial<Record<BasecampRecordableType, string>> = {
   "Kanban::Card": "cards",
   "Todo": "todos",
   "Question::Answer": "checkins",
-} as any;
+};
 
 // ---------------------------------------------------------------------------
 // Promotion state

--- a/src/inbound/reconciliation.ts
+++ b/src/inbound/reconciliation.ts
@@ -1,0 +1,247 @@
+/**
+ * Reconciliation pass — detect gaps in event delivery.
+ *
+ * Periodically fetches recent activity via client.reports.progress() and
+ * checks each event against the dedup store using hasSeen(). Events that
+ * were NOT seen indicate a delivery gap.
+ *
+ * Gap counts per recordable type drive promotion of safety-net direct polling:
+ *   - ≥ gapThreshold gaps in 2 consecutive cycles → promote type to safety net
+ *   - 3 clean cycles → demote
+ *   - Max 3 promoted types at a time
+ *   - 24h TTL on promotions
+ */
+
+import type { BasecampActivityEvent, BasecampRecordableType, ResolvedBasecampAccount } from "../types.js";
+import type { EventDedup } from "./dedup.js";
+import { isNormalizableKind, recordableTypeForKind } from "./normalize.js";
+
+// Which recordable types can be promoted to safety-net direct polling
+const PROMOTABLE_TYPES: Record<BasecampRecordableType, string> = {
+  "Kanban::Card": "cards",
+  "Todo": "todos",
+  "Question::Answer": "checkins",
+} as any;
+
+// ---------------------------------------------------------------------------
+// Promotion state
+// ---------------------------------------------------------------------------
+
+export interface PromotionEntry {
+  type: BasecampRecordableType;
+  promotedAt: number;
+  consecutiveGapCycles: number;
+  consecutiveCleanCycles: number;
+}
+
+export interface PromotionState {
+  promotions: PromotionEntry[];
+  /** Per-type gap history from previous cycle (for 2-consecutive-cycle check). */
+  previousGaps: Record<string, number>;
+}
+
+const MAX_PROMOTIONS = 3;
+const PROMOTION_TTL_MS = 24 * 60 * 60 * 1000;
+const CYCLES_TO_PROMOTE = 2;
+const CYCLES_TO_DEMOTE = 3;
+
+// ---------------------------------------------------------------------------
+// Reconciliation result
+// ---------------------------------------------------------------------------
+
+export interface ReconciliationResult {
+  /** Number of events replayed from the activity feed. */
+  replayed: number;
+  /** Number of events not found in the dedup store (gaps). */
+  unseen: number;
+  /** Gap counts per recordable type. */
+  gapsByType: Record<string, number>;
+  /** Currently promoted types after applying promotion logic. */
+  promotions: PromotionEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Core reconciliation
+// ---------------------------------------------------------------------------
+
+export interface ReconciliationOptions {
+  account: ResolvedBasecampAccount;
+  client: any;
+  dedup: EventDedup;
+  maxItems?: number;
+  windowMs?: number;
+  gapThreshold?: number;
+  promotionState?: PromotionState;
+  log?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    debug?: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+export async function runReconciliation(
+  opts: ReconciliationOptions,
+): Promise<ReconciliationResult> {
+  const {
+    account,
+    client,
+    dedup,
+    log,
+    maxItems = 250,
+    windowMs = 24 * 60 * 60 * 1000,
+    gapThreshold = 3,
+  } = opts;
+
+  const cutoff = new Date(Date.now() - windowMs).toISOString();
+
+  // Fetch recent activity
+  let rawEvents: BasecampActivityEvent[];
+  try {
+    rawEvents = await client.reports.progress({ maxItems }) as BasecampActivityEvent[];
+    if (!Array.isArray(rawEvents)) rawEvents = [];
+  } catch (err) {
+    log?.error?.(`[${account.accountId}] reconciliation: fetch failed: ${String(err)}`);
+    return {
+      replayed: 0,
+      unseen: 0,
+      gapsByType: {},
+      promotions: opts.promotionState?.promotions ?? [],
+    };
+  }
+
+  let replayed = 0;
+  let unseen = 0;
+  const gapsByType: Record<string, number> = {};
+
+  for (const event of rawEvents) {
+    // Client-side window filter
+    if (event.created_at < cutoff) continue;
+
+    // Only count events whose kind we can normalize
+    if (!isNormalizableKind(event.kind)) continue;
+    const recordableType = recordableTypeForKind(event.kind)!;
+
+    replayed++;
+
+    // Check if we've seen this event
+    const primaryKey = `activity:${event.id}`;
+    const recordingId = event.recording?.id;
+    const secondaryKey = recordingId
+      ? `${recordingId}:${resolveEventKindFromRaw(event.kind)}:${event.created_at}`
+      : undefined;
+
+    if (!dedup.hasSeen(primaryKey, secondaryKey)) {
+      unseen++;
+      gapsByType[recordableType] = (gapsByType[recordableType] ?? 0) + 1;
+    }
+  }
+
+  // Apply promotion logic
+  const promotions = applyPromotionLogic({
+    gapsByType,
+    gapThreshold,
+    previousState: opts.promotionState,
+  });
+
+  log?.info?.(
+    `[${account.accountId}] reconciliation: replayed=${replayed} unseen=${unseen} promoted=${promotions.length}`,
+  );
+
+  return { replayed, unseen, gapsByType, promotions };
+}
+
+// ---------------------------------------------------------------------------
+// Promotion logic
+// ---------------------------------------------------------------------------
+
+function applyPromotionLogic(opts: {
+  gapsByType: Record<string, number>;
+  gapThreshold: number;
+  previousState?: PromotionState;
+}): PromotionEntry[] {
+  const { gapsByType, gapThreshold, previousState } = opts;
+  const now = Date.now();
+  const previousGaps = previousState?.previousGaps ?? {};
+  const existing = (previousState?.promotions ?? []).filter(
+    (p) => now - p.promotedAt < PROMOTION_TTL_MS,
+  );
+
+  const result: PromotionEntry[] = [];
+
+  // Process existing promotions: demote or keep
+  for (const entry of existing) {
+    const typeKey = entry.type;
+    const currentGaps = gapsByType[typeKey] ?? 0;
+
+    if (currentGaps < gapThreshold) {
+      const cleanCycles = entry.consecutiveCleanCycles + 1;
+      if (cleanCycles >= CYCLES_TO_DEMOTE) {
+        // Demoted
+        continue;
+      }
+      result.push({
+        ...entry,
+        consecutiveCleanCycles: cleanCycles,
+        consecutiveGapCycles: 0,
+      });
+    } else {
+      result.push({
+        ...entry,
+        consecutiveGapCycles: entry.consecutiveGapCycles + 1,
+        consecutiveCleanCycles: 0,
+      });
+    }
+  }
+
+  // Check for new promotions
+  const promotedTypes = new Set(result.map((p) => p.type));
+  for (const [typeStr, count] of Object.entries(gapsByType)) {
+    const recordableType = typeStr as BasecampRecordableType;
+    if (promotedTypes.has(recordableType)) continue;
+    if (!(recordableType in PROMOTABLE_TYPES)) continue;
+    if (result.length >= MAX_PROMOTIONS) break;
+
+    if (count >= gapThreshold) {
+      const prevCount = previousGaps[typeStr] ?? 0;
+      if (prevCount >= gapThreshold) {
+        // 2 consecutive cycles with gaps → promote
+        result.push({
+          type: recordableType,
+          promotedAt: now,
+          consecutiveGapCycles: CYCLES_TO_PROMOTE,
+          consecutiveCleanCycles: 0,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Simplified event kind resolver (mirrors normalize.ts resolveEventKind). */
+function resolveEventKindFromRaw(kind: string): string {
+  if (kind.endsWith("_created")) return "created";
+  if (kind.endsWith("_completed")) return "completed";
+  if (kind.endsWith("_edited") || kind === "edited") return "edited";
+  if (kind.endsWith("_moved")) return "moved";
+  if (kind.endsWith("_assignment_changed")) return "assigned";
+  return kind;
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+export function serializePromotionState(promotions: PromotionEntry[], gapsByType: Record<string, number>): string {
+  const state: PromotionState = { promotions, previousGaps: gapsByType };
+  return JSON.stringify(state);
+}
+
+export function deserializePromotionState(raw: string): PromotionState | undefined {
+  try {
+    return JSON.parse(raw) as PromotionState;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/inbound/safety-net.ts
+++ b/src/inbound/safety-net.ts
@@ -1,0 +1,524 @@
+/**
+ * Safety net polling source — direct API traversal for delta detection.
+ *
+ * Polls configured projects for cards, todos, and check-in answers via
+ * the Basecamp SDK. Compares against stored snapshots to detect:
+ *   - appeared: new items not in previous snapshot
+ *   - moved: cards whose column changed
+ *   - disappeared: items missing for 2 consecutive deep crawl cycles
+ *   - checkin_answered: increased answer count on a question
+ *
+ * Two cycle modes:
+ *   - Capped (normal): maxItems=50, first-page only. Detects appeared/changed.
+ *   - Deep (every 6th cycle): no cap, full traversal. Enables disappeared detection.
+ */
+
+import crypto from "node:crypto";
+import type {
+  BasecampInboundMessage,
+  BasecampInboundMeta,
+  BasecampEventKind,
+  BasecampRecordableType,
+  ResolvedBasecampAccount,
+} from "../types.js";
+import { EventDedup } from "./dedup.js";
+import { resolveDockToolIds, invalidateDockCache } from "./dock-cache.js";
+
+// ---------------------------------------------------------------------------
+// Snapshot types
+// ---------------------------------------------------------------------------
+
+export interface CardSnapshot {
+  columnId: number;
+  columnName: string;
+  updatedAt: string;
+  /** Person IDs currently assigned to this card. */
+  assignees: string[];
+}
+
+export interface TodoSnapshot {
+  updatedAt: string;
+  /** Person IDs currently assigned to this todo. */
+  assignees: string[];
+}
+
+export interface CheckinSnapshot {
+  /** Individual answer IDs seen for this question. */
+  answerIds: string[];
+}
+
+export interface ProjectSnapshot {
+  cards: Record<string, CardSnapshot>;
+  todos: Record<string, TodoSnapshot>;
+  checkins: Record<string, CheckinSnapshot>;
+}
+
+export interface SafetyNetSnapshot {
+  version: 1;
+  updatedAt: string;
+  projects: Record<string, ProjectSnapshot>;
+}
+
+/** Tracks items pending disappeared confirmation (need 2 deep crawl misses). */
+export interface DisappearedPending {
+  /** Map of "type:id" → number of consecutive deep-crawl misses. */
+  entries: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export interface SafetyNetPollResult {
+  events: BasecampInboundMessage[];
+  snapshot: SafetyNetSnapshot;
+  pending: DisappearedPending;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function changeHash(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex").slice(0, 8);
+}
+
+function buildDeltaMessage(opts: {
+  accountId: string;
+  projectId: number;
+  recordingId: string;
+  recordableType: BasecampRecordableType;
+  eventKind: BasecampEventKind;
+  text: string;
+  dedupKey: string;
+  createdAt: string;
+  extraMeta?: Partial<BasecampInboundMeta>;
+}): BasecampInboundMessage {
+  return {
+    channel: "basecamp",
+    accountId: opts.accountId,
+    peer: { kind: "group", id: `recording:${opts.recordingId}` },
+    parentPeer: { kind: "group", id: `bucket:${opts.projectId}` },
+    sender: { id: "system", name: "Safety Net" },
+    text: opts.text,
+    html: "",
+    meta: {
+      bucketId: String(opts.projectId),
+      recordingId: opts.recordingId,
+      recordableType: opts.recordableType,
+      eventKind: opts.eventKind,
+      mentions: [],
+      mentionsAgent: false,
+      attachments: [],
+      sources: ["direct_poll"],
+      delta: true,
+      ...opts.extraMeta,
+    },
+    dedupKey: opts.dedupKey,
+    createdAt: opts.createdAt,
+    correlationId: crypto.randomUUID(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core poll function
+// ---------------------------------------------------------------------------
+
+export interface SafetyNetPollOptions {
+  account: ResolvedBasecampAccount;
+  client: any; // SDK client
+  projectIds: number[];
+  previousSnapshot: SafetyNetSnapshot | undefined;
+  previousPending: DisappearedPending | undefined;
+  isDeepCrawl: boolean;
+  maxItems?: number;
+  log?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    debug?: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+export async function pollSafetyNet(
+  opts: SafetyNetPollOptions,
+): Promise<SafetyNetPollResult> {
+  const { account, client, projectIds, previousSnapshot, isDeepCrawl, log } = opts;
+  const maxItems = isDeepCrawl ? undefined : (opts.maxItems ?? 50);
+  const events: BasecampInboundMessage[] = [];
+
+  const newSnapshot: SafetyNetSnapshot = {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    projects: {},
+  };
+
+  const pending: DisappearedPending = {
+    entries: { ...(opts.previousPending?.entries ?? {}) },
+  };
+
+  for (const projectId of projectIds) {
+    const dockIds = await resolveDockToolIds(client, projectId);
+    if (!dockIds) {
+      log?.warn?.(`[${account.accountId}] safety_net: project ${projectId} dock inaccessible, skipping`);
+      continue;
+    }
+
+    const prevProject = previousSnapshot?.projects[String(projectId)];
+    const projectSnap: ProjectSnapshot = {
+      cards: {},
+      todos: {},
+      checkins: {},
+    };
+
+    // --- Cards ---
+    if (dockIds.cardTableId != null) {
+      try {
+        const cardSnap = await crawlCards(client, projectId, dockIds.cardTableId, maxItems);
+        projectSnap.cards = cardSnap.cards;
+
+        if (prevProject) {
+          // Detect appeared / moved / assignment changes
+          for (const [cardId, card] of Object.entries(cardSnap.cards)) {
+            const prev = prevProject.cards[cardId];
+            if (!prev) {
+              // Appeared
+              const hash = changeHash(`appeared:${cardId}`);
+              events.push(buildDeltaMessage({
+                accountId: account.accountId,
+                projectId,
+                recordingId: cardId,
+                recordableType: "Kanban::Card",
+                eventKind: "created",
+                text: `Card ${cardId} appeared in ${card.columnName}`,
+                dedupKey: `direct:card:${cardId}:${hash}`,
+                createdAt: card.updatedAt,
+                extraMeta: { column: card.columnName, assignees: card.assignees },
+              }));
+            } else {
+              if (prev.columnId !== card.columnId) {
+                // Moved
+                const hash = changeHash(`moved:${cardId}:${prev.columnId}:${card.columnId}`);
+                events.push(buildDeltaMessage({
+                  accountId: account.accountId,
+                  projectId,
+                  recordingId: cardId,
+                  recordableType: "Kanban::Card",
+                  eventKind: "moved",
+                  text: `Card ${cardId} moved from ${prev.columnName} to ${card.columnName}`,
+                  dedupKey: `direct:card:${cardId}:${hash}`,
+                  createdAt: card.updatedAt,
+                  extraMeta: { column: card.columnName, columnPrevious: prev.columnName },
+                }));
+              }
+              // Assignment diff
+              const added = card.assignees.filter((a) => !prev.assignees.includes(a));
+              const removed = prev.assignees.filter((a) => !card.assignees.includes(a));
+              if (added.length > 0 || removed.length > 0) {
+                const hash = changeHash(`assign:${cardId}:${card.assignees.sort().join(",")}`);
+                const agentAssigned = account.personId ? added.includes(account.personId) : false;
+                events.push(buildDeltaMessage({
+                  accountId: account.accountId,
+                  projectId,
+                  recordingId: cardId,
+                  recordableType: "Kanban::Card",
+                  eventKind: "assigned",
+                  text: `Card ${cardId} assignees changed: +${added.length} -${removed.length}`,
+                  dedupKey: `direct:card:${cardId}:${hash}`,
+                  createdAt: card.updatedAt,
+                  extraMeta: {
+                    assignees: card.assignees,
+                    assignedToAgent: agentAssigned || undefined,
+                  },
+                }));
+              }
+            }
+          }
+
+          // Detect disappeared (deep crawl only, non-truncated)
+          if (isDeepCrawl && !cardSnap.truncated) {
+            for (const cardId of Object.keys(prevProject.cards)) {
+              if (!cardSnap.cards[cardId]) {
+                const pendingKey = `card:${cardId}`;
+                pending.entries[pendingKey] = (pending.entries[pendingKey] ?? 0) + 1;
+                if (pending.entries[pendingKey] >= 2) {
+                  const hash = changeHash(`disappeared:${cardId}`);
+                  events.push(buildDeltaMessage({
+                    accountId: account.accountId,
+                    projectId,
+                    recordingId: cardId,
+                    recordableType: "Kanban::Card",
+                    eventKind: "disappeared",
+                    text: `Card ${cardId} disappeared`,
+                    dedupKey: `direct:card:${cardId}:${hash}`,
+                    createdAt: new Date().toISOString(),
+                  }));
+                  delete pending.entries[pendingKey];
+                }
+              } else {
+                // Still present — reset pending counter
+                delete pending.entries[`card:${cardId}`];
+              }
+            }
+          }
+        }
+      } catch (err) {
+        log?.warn?.(`[${account.accountId}] safety_net: cards crawl failed for project ${projectId}: ${String(err)}`);
+      }
+    }
+
+    // --- Todos ---
+    if (dockIds.todosetId != null) {
+      try {
+        const todoSnap = await crawlTodos(client, projectId, maxItems);
+        projectSnap.todos = todoSnap.todos;
+
+        if (prevProject) {
+          for (const [todoId, todo] of Object.entries(todoSnap.todos)) {
+            const prev = prevProject.todos[todoId];
+            if (!prev) {
+              const hash = changeHash(`appeared:${todoId}`);
+              events.push(buildDeltaMessage({
+                accountId: account.accountId,
+                projectId,
+                recordingId: todoId,
+                recordableType: "Todo",
+                eventKind: "created",
+                text: `Todo ${todoId} appeared`,
+                dedupKey: `direct:todo:${todoId}:${hash}`,
+                createdAt: todo.updatedAt,
+                extraMeta: { assignees: todo.assignees },
+              }));
+            } else {
+              // Assignment diff
+              const added = todo.assignees.filter((a) => !prev.assignees.includes(a));
+              const removed = prev.assignees.filter((a) => !todo.assignees.includes(a));
+              if (added.length > 0 || removed.length > 0) {
+                const hash = changeHash(`assign:${todoId}:${todo.assignees.sort().join(",")}`);
+                const agentAssigned = account.personId ? added.includes(account.personId) : false;
+                events.push(buildDeltaMessage({
+                  accountId: account.accountId,
+                  projectId,
+                  recordingId: todoId,
+                  recordableType: "Todo",
+                  eventKind: "assigned",
+                  text: `Todo ${todoId} assignees changed: +${added.length} -${removed.length}`,
+                  dedupKey: `direct:todo:${todoId}:${hash}`,
+                  createdAt: todo.updatedAt,
+                  extraMeta: {
+                    assignees: todo.assignees,
+                    assignedToAgent: agentAssigned || undefined,
+                  },
+                }));
+              }
+            }
+          }
+
+          if (isDeepCrawl && !todoSnap.truncated) {
+            for (const todoId of Object.keys(prevProject.todos)) {
+              if (!todoSnap.todos[todoId]) {
+                const pendingKey = `todo:${todoId}`;
+                pending.entries[pendingKey] = (pending.entries[pendingKey] ?? 0) + 1;
+                if (pending.entries[pendingKey] >= 2) {
+                  const hash = changeHash(`disappeared:${todoId}`);
+                  events.push(buildDeltaMessage({
+                    accountId: account.accountId,
+                    projectId,
+                    recordingId: todoId,
+                    recordableType: "Todo",
+                    eventKind: "disappeared",
+                    text: `Todo ${todoId} disappeared`,
+                    dedupKey: `direct:todo:${todoId}:${hash}`,
+                    createdAt: new Date().toISOString(),
+                  }));
+                  delete pending.entries[pendingKey];
+                }
+              } else {
+                delete pending.entries[`todo:${todoId}`];
+              }
+            }
+          }
+        }
+      } catch (err) {
+        log?.warn?.(`[${account.accountId}] safety_net: todos crawl failed for project ${projectId}: ${String(err)}`);
+      }
+    }
+
+    // --- Check-ins ---
+    if (dockIds.questionnaireId != null) {
+      try {
+        const checkinSnap = await crawlCheckins(client, projectId, dockIds.questionnaireId);
+        projectSnap.checkins = checkinSnap.checkins;
+
+        if (prevProject) {
+          for (const [questionId, q] of Object.entries(checkinSnap.checkins)) {
+            const prev = prevProject.checkins[questionId];
+            if (prev) {
+              const prevSet = new Set(prev.answerIds);
+              const newAnswerIds = q.answerIds.filter((id) => !prevSet.has(id));
+              for (const answerId of newAnswerIds) {
+                events.push(buildDeltaMessage({
+                  accountId: account.accountId,
+                  projectId,
+                  recordingId: answerId,
+                  recordableType: "Question::Answer",
+                  eventKind: "checkin_answered",
+                  text: `New answer ${answerId} to check-in question ${questionId}`,
+                  dedupKey: `direct:answer:${answerId}`,
+                  createdAt: new Date().toISOString(),
+                }));
+              }
+            }
+          }
+        }
+      } catch (err) {
+        log?.warn?.(`[${account.accountId}] safety_net: checkins crawl failed for project ${projectId}: ${String(err)}`);
+      }
+    }
+
+    newSnapshot.projects[String(projectId)] = projectSnap;
+  }
+
+  return { events, snapshot: newSnapshot, pending };
+}
+
+// ---------------------------------------------------------------------------
+// Resource crawlers
+// ---------------------------------------------------------------------------
+
+interface CardCrawlResult {
+  cards: Record<string, CardSnapshot>;
+  truncated: boolean;
+}
+
+async function crawlCards(
+  client: any,
+  projectId: number,
+  cardTableId: number,
+  maxItems?: number,
+): Promise<CardCrawlResult> {
+  const cards: Record<string, CardSnapshot> = {};
+  let truncated = false;
+
+  // Get card table to discover columns
+  const table = await client.cardTables.get(projectId, cardTableId);
+  const columns: Array<{ id: number; title: string }> = table?.lists ?? [];
+
+  for (const col of columns) {
+    const listOpts: any = {};
+    if (maxItems != null) listOpts.maxItems = maxItems;
+    const result = await client.cards.list(projectId, col.id, listOpts);
+    const items: any[] = Array.isArray(result) ? result : (result?.data ?? []);
+
+    if (result?.meta?.truncated) truncated = true;
+
+    for (const card of items) {
+      const assignees: string[] = Array.isArray(card.assignees)
+        ? card.assignees.map((a: any) => String(a.id))
+        : [];
+      cards[String(card.id)] = {
+        columnId: col.id,
+        columnName: col.title,
+        updatedAt: card.updated_at ?? new Date().toISOString(),
+        assignees,
+      };
+    }
+  }
+
+  return { cards, truncated };
+}
+
+interface TodoCrawlResult {
+  todos: Record<string, TodoSnapshot>;
+  truncated: boolean;
+}
+
+async function crawlTodos(
+  client: any,
+  projectId: number,
+  maxItems?: number,
+): Promise<TodoCrawlResult> {
+  const todos: Record<string, TodoSnapshot> = {};
+  let truncated = false;
+
+  const listOpts: any = { bucket: [projectId] };
+  if (maxItems != null) listOpts.maxItems = maxItems;
+
+  const result = await client.recordings.list("Todo", listOpts);
+  const items: any[] = Array.isArray(result) ? result : (result?.data ?? []);
+
+  if (result?.meta?.truncated) truncated = true;
+
+  for (const todo of items) {
+    const assignees: string[] = Array.isArray(todo.assignees)
+      ? todo.assignees.map((a: any) => String(a.id))
+      : [];
+    todos[String(todo.id)] = {
+      updatedAt: todo.updated_at ?? new Date().toISOString(),
+      assignees,
+    };
+  }
+
+  return { todos, truncated };
+}
+
+interface CheckinCrawlResult {
+  checkins: Record<string, CheckinSnapshot>;
+}
+
+async function crawlCheckins(
+  client: any,
+  projectId: number,
+  questionnaireId: number,
+): Promise<CheckinCrawlResult> {
+  const checkins: Record<string, CheckinSnapshot> = {};
+
+  const questions = await client.checkins.listQuestions(projectId, questionnaireId);
+  const qItems: any[] = Array.isArray(questions) ? questions : (questions?.data ?? []);
+
+  for (const q of qItems) {
+    const questionId = String(q.id);
+    // Fetch individual answers to get their IDs for cross-source dedup
+    let answerIds: string[] = [];
+    try {
+      const answers = await client.checkins.listAnswers(projectId, Number(questionId));
+      const aItems: any[] = Array.isArray(answers) ? answers : (answers?.data ?? []);
+      answerIds = aItems.map((a: any) => String(a.id));
+    } catch {
+      // Fall back to empty — we'll detect new answers next cycle
+    }
+    checkins[questionId] = { answerIds };
+  }
+
+  return { checkins };
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot serialization
+// ---------------------------------------------------------------------------
+
+export function serializeSnapshot(snap: SafetyNetSnapshot): string {
+  return JSON.stringify(snap);
+}
+
+export function deserializeSnapshot(raw: string): SafetyNetSnapshot | undefined {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed?.version !== 1) return undefined;
+    return parsed as SafetyNetSnapshot;
+  } catch {
+    return undefined;
+  }
+}
+
+export function serializePending(pending: DisappearedPending): string {
+  return JSON.stringify(pending);
+}
+
+export function deserializePending(raw: string): DisappearedPending | undefined {
+  try {
+    return JSON.parse(raw) as DisappearedPending;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/inbound/webhook-lifecycle.ts
+++ b/src/inbound/webhook-lifecycle.ts
@@ -90,8 +90,6 @@ export async function reconcileWebhooks(
         (wh) => wh.payload_url === config.payloadUrl && wh.active,
       );
 
-      let secretRecovery = false;
-
       if (urlMatch && typesMatch(urlMatch.types, config.types)) {
         log?.debug("webhook_exists", {
           project: projectId,
@@ -109,36 +107,12 @@ export async function reconcileWebhooks(
           });
         }
 
-        const entry = registry.get(projectId);
-        if (entry && entry.secret === "" && !entry.recoveryFailed) {
-          // Secret is missing and recovery hasn't been attempted or hasn't
-          // permanently failed. Delete the stale webhook and recreate to
-          // mint a fresh HMAC secret.
-          log?.info("webhook_secret_recovery", {
-            project: projectId,
-            webhookId: urlMatch.id,
-          });
-          try {
-            await client.webhooks.delete(numId("project", projectId), urlMatch.id);
-            registry.remove(projectId);
-            secretRecovery = true;
-          } catch (delErr) {
-            log?.error("webhook_secret_recovery_delete_failed", {
-              project: projectId,
-              error: String(delErr),
-            });
-            result.failed.push(projectId);
-            continue;
-          }
-          // Fall through to create path
-        } else {
-          result.existing.push(projectId);
-          continue;
-        }
+        result.existing.push(projectId);
+        continue;
       }
 
       // URL matches but types differ — delete stale webhook before creating new one
-      if (!secretRecovery && urlMatch) {
+      if (urlMatch) {
         log?.info("webhook_types_changed", {
           project: projectId,
           webhookId: urlMatch.id,
@@ -186,39 +160,29 @@ export async function reconcileWebhooks(
         continue;
       }
 
-      // Persist the secret — it's only returned on create
+      // Persist the secret — it's only returned on create.
+      // BC3 never returns a secret, so empty string is expected.
+      // Token auth via ?token= handles verification instead.
       registry.set(projectId, {
         webhookId: String(webhook.id),
         secret: webhook.secret ?? "",
         payloadUrl: webhook.payload_url ?? config.payloadUrl,
         types: webhook.types ?? config.types,
-        recoveryFailed: !webhook.secret || undefined,
       });
 
       if (!webhook.secret) {
-        log?.error("webhook_create_no_secret", {
+        log?.info("webhook_create_no_secret", {
           project: projectId,
           webhookId: webhook.id,
-          recovery: secretRecovery,
-          reason: "BC3 returned webhook without secret — HMAC will fail",
+          note: "BC3 does not return secrets — token auth will be used",
         });
-        result.failed.push(projectId);
-        continue;
       }
 
-      if (secretRecovery) {
-        result.recovered.push(projectId);
-        log?.info("webhook_secret_recovered", {
-          project: projectId,
-          webhookId: webhook.id,
-        });
-      } else {
-        log?.info("webhook_created", {
-          project: projectId,
-          webhookId: webhook.id,
-        });
-        result.created.push(projectId);
-      }
+      log?.info("webhook_created", {
+        project: projectId,
+        webhookId: webhook.id,
+      });
+      result.created.push(projectId);
     } catch (err) {
       log?.error("webhook_reconcile_failed", {
         project: projectId,

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -23,7 +23,7 @@ import { dispatchBasecampEvent } from "../dispatch.js";
 import { getBasecampRuntime } from "../runtime.js";
 import { resolveBasecampAccount, resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
 import { createConsoleStructuredLog } from "../logging.js";
-import { recordWebhookReceived, recordWebhookDispatched, recordWebhookDropped, recordWebhookError, recordWebhookDedupSize, recordQueueFullDrop } from "../metrics.js";
+import { recordWebhookReceived, recordWebhookDispatched, recordWebhookDropped, recordWebhookError, recordWebhookDedupSize, recordQueueFullDrop, recordWebhookAuthMethod } from "../metrics.js";
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter
@@ -239,71 +239,63 @@ export async function handleBasecampWebhook(
   }
 
   // ----- Authentication -----
-  // Try HMAC signature verification first (X-Basecamp-Signature header),
-  // then fall back to query-string token (?token=<secret>).
-  // At least one method must be configured and pass.
-  const hmacSignature = req.headers["x-basecamp-signature"] as string | undefined;
-  const hmacTimestamp = req.headers["x-basecamp-timestamp"] as string | undefined;
+  // Try query-string token first (?token=<secret>), then fall back to HMAC
+  // signature verification (X-Basecamp-Signature header). Token is primary
+  // because BC3 never returns HMAC secrets on webhook creation.
   const webhookSecret = resolveWebhookSecret(cfg);
 
   let authenticated = false;
+  let authMethod: "token" | "hmac" | undefined;
 
-  if (hmacSignature && hmacTimestamp) {
-    // HMAC path: scope verification to the specific bucket/account when possible.
-    // Parse the payload first to extract bucketId, then use only the secrets
-    // for the account that owns that bucket. Falls back to all secrets if
-    // bucket resolution fails.
-    //
-    // Uses getWebhookSecretRegistry() (not secretRegistries.get()) so that
-    // persisted secrets are eagerly loaded from disk even if the registry
-    // wasn't previously instantiated in this process.
-    let candidateSecrets: string[] = [];
-    let bucketResolved = false;
-    try {
-      const parsed = JSON.parse(rawBody) as { recording?: { bucket?: { id?: number } } };
-      const bucketId = parsed?.recording?.bucket?.id;
-      if (bucketId != null) {
-        // resolveAccountForBucket returns the concrete account ID (not the
-        // virtual alias), matching the key used in getWebhookSecretRegistry.
-        const bucketAccountId = resolveAccountForBucket(cfg, String(bucketId));
-        if (bucketAccountId) {
-          bucketResolved = true;
-          const registry = getWebhookSecretRegistry(bucketAccountId);
-          candidateSecrets = registry.getAllSecrets().filter(s => s.length > 0);
-        }
-      }
-    } catch {
-      // JSON parse failed — fall through to all secrets
-    }
-
-    // Only fall back to all known secrets when bucket resolution itself failed
-    // (no virtualAccounts mapping, no bucketId in payload, or parse error).
-    // If resolution succeeded but the scoped registry is empty, fail closed —
-    // don't let another account's secret authenticate this bucket's request.
-    if (!bucketResolved && candidateSecrets.length === 0) {
-      for (const accountId of listBasecampAccountIds(cfg)) {
-        const registry = getWebhookSecretRegistry(accountId);
-        candidateSecrets.push(...registry.getAllSecrets().filter(s => s.length > 0));
-      }
-    }
-
-    if (candidateSecrets.length > 0) {
-      authenticated = verifyWebhookSignature({
-        signature: hmacSignature,
-        timestamp: hmacTimestamp,
-        rawBody,
-        secrets: candidateSecrets,
-      });
+  // Token path (primary): check query-string ?token=<webhookSecret>
+  if (webhookSecret) {
+    const urlObj = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    const providedToken = urlObj.searchParams.get("token");
+    if (providedToken && providedToken === webhookSecret) {
+      authenticated = true;
+      authMethod = "token";
     }
   }
 
+  // HMAC path (secondary): X-Basecamp-Signature + X-Basecamp-Timestamp
   if (!authenticated) {
-    // Query-string token fallback
-    if (webhookSecret) {
-      const urlObj = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
-      const providedToken = urlObj.searchParams.get("token");
-      if (providedToken && providedToken === webhookSecret) {
-        authenticated = true;
+    const hmacSignature = req.headers["x-basecamp-signature"] as string | undefined;
+    const hmacTimestamp = req.headers["x-basecamp-timestamp"] as string | undefined;
+
+    if (hmacSignature && hmacTimestamp) {
+      // HMAC path: scope verification to the specific bucket/account when possible.
+      let candidateSecrets: string[] = [];
+      let bucketResolved = false;
+      try {
+        const parsed = JSON.parse(rawBody) as { recording?: { bucket?: { id?: number } } };
+        const bucketId = parsed?.recording?.bucket?.id;
+        if (bucketId != null) {
+          const bucketAccountId = resolveAccountForBucket(cfg, String(bucketId));
+          if (bucketAccountId) {
+            bucketResolved = true;
+            const registry = getWebhookSecretRegistry(bucketAccountId);
+            candidateSecrets = registry.getAllSecrets().filter(s => s.length > 0);
+          }
+        }
+      } catch {
+        // JSON parse failed — fall through to all secrets
+      }
+
+      if (!bucketResolved && candidateSecrets.length === 0) {
+        for (const accountId of listBasecampAccountIds(cfg)) {
+          const registry = getWebhookSecretRegistry(accountId);
+          candidateSecrets.push(...registry.getAllSecrets().filter(s => s.length > 0));
+        }
+      }
+
+      if (candidateSecrets.length > 0) {
+        authenticated = verifyWebhookSignature({
+          signature: hmacSignature,
+          timestamp: hmacTimestamp,
+          rawBody,
+          secrets: candidateSecrets,
+        });
+        if (authenticated) authMethod = "hmac";
       }
     }
   }
@@ -382,6 +374,7 @@ export async function handleBasecampWebhook(
 
   const slog = createConsoleStructuredLog({ accountId: account.accountId, source: "webhook" });
   recordWebhookReceived(account.accountId);
+  if (authMethod) recordWebhookAuthMethod(account.accountId, authMethod);
 
   // Normalize
   let msg;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -32,14 +32,29 @@ export interface CircuitBreakerMetrics {
   trippedAt: number | null;
 }
 
+export interface ReconciliationMetrics {
+  lastRunAt: number | null;
+  replayed: number;
+  unseen: number;
+  promotedTypes: string[];
+}
+
+export interface SafetyNetEscalation {
+  escalatedAt: number | null;
+  deescalatedAt: number | null;
+}
+
 export interface AccountMetrics {
   poller: {
     activity: PollerSourceMetrics;
     readings: PollerSourceMetrics;
     assignments: PollerSourceMetrics;
+    safetyNet: PollerSourceMetrics;
   };
-  webhook: WebhookMetrics;
+  webhook: WebhookMetrics & { authMethods: Record<string, number> };
   circuitBreaker: Record<string, CircuitBreakerMetrics>;
+  reconciliation: ReconciliationMetrics;
+  safetyNet: { escalations: Record<string, SafetyNetEscalation> };
   dedupSize: number;
   webhookDedupSize: number;
   dispatchFailureCount: number;
@@ -83,9 +98,12 @@ function getOrCreate(accountId: string): AccountMetrics {
         activity: emptySourceMetrics(),
         readings: emptySourceMetrics(),
         assignments: emptySourceMetrics(),
+        safetyNet: emptySourceMetrics(),
       },
-      webhook: emptyWebhookMetrics(),
+      webhook: { ...emptyWebhookMetrics(), authMethods: {} },
       circuitBreaker: {},
+      reconciliation: { lastRunAt: null, replayed: 0, unseen: 0, promotedTypes: [] },
+      safetyNet: { escalations: {} },
       dedupSize: 0,
       webhookDedupSize: 0,
       dispatchFailureCount: 0,
@@ -102,7 +120,7 @@ function getOrCreate(accountId: string): AccountMetrics {
 // Writers — called by operational components
 // ---------------------------------------------------------------------------
 
-export type PollerSource = "activity" | "readings" | "assignments";
+export type PollerSource = "activity" | "readings" | "assignments" | "safetyNet";
 
 export function recordPollAttempt(accountId: string, source: PollerSource): void {
   const m = getOrCreate(accountId);
@@ -176,6 +194,31 @@ export function recordDispatchFailure(accountId: string): void {
 export function recordQueueFullDrop(accountId: string): void {
   const m = getOrCreate(accountId);
   m.queueFullDropCount++;
+}
+
+export function recordWebhookAuthMethod(accountId: string, method: "token" | "hmac"): void {
+  const m = getOrCreate(accountId);
+  m.webhook.authMethods[method] = (m.webhook.authMethods[method] ?? 0) + 1;
+}
+
+export function recordReconciliationRun(accountId: string, result: { replayed: number; unseen: number; promotedTypes: string[] }): void {
+  const m = getOrCreate(accountId);
+  m.reconciliation.lastRunAt = Date.now();
+  m.reconciliation.replayed = result.replayed;
+  m.reconciliation.unseen = result.unseen;
+  m.reconciliation.promotedTypes = result.promotedTypes;
+}
+
+export function recordSafetyNetEscalation(accountId: string, key: string, action: "escalate" | "deescalate"): void {
+  const m = getOrCreate(accountId);
+  if (!m.safetyNet.escalations[key]) {
+    m.safetyNet.escalations[key] = { escalatedAt: null, deescalatedAt: null };
+  }
+  if (action === "escalate") {
+    m.safetyNet.escalations[key].escalatedAt = Date.now();
+  } else {
+    m.safetyNet.escalations[key].deescalatedAt = Date.now();
+  }
 }
 
 export function recordUnknownKind(accountId: string, rawKind: string): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,8 @@ export type BasecampEventKind =
   | "checkin_resumed"
   // Messages / Documents
   | "edited"
+  // Direct poll
+  | "disappeared"
   // Global
   | "subscription_changed"
   | "visibility_changed"
@@ -167,6 +169,8 @@ export type BasecampInboundMeta = {
   matchedPatterns?: string[];
   /** Source(s) that delivered this event. */
   sources: BasecampEventSource[];
+  /** True for events synthesized by direct-poll diff (safety net). */
+  delta?: boolean;
 };
 
 /**
@@ -522,6 +526,27 @@ export type BasecampChannelConfig = {
   circuitBreaker?: {
     threshold?: number;
     cooldownMs?: number;
+  };
+  /** Safety net direct-polling config. */
+  safetyNet?: {
+    projects?: string[];
+    intervalMs?: number;
+    tier2?: {
+      enabled?: boolean;
+      lagThresholdMs?: number;
+      rapidIntervalMs?: number;
+      businessHours?: {
+        start?: number;
+        end?: number;
+        timezone?: string;
+      };
+    };
+  };
+  /** Reconciliation pass config. */
+  reconciliation?: {
+    enabled?: boolean;
+    intervalMs?: number;
+    gapThreshold?: number;
   };
 };
 

--- a/tests/activity.test.ts
+++ b/tests/activity.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests: pollActivityFeed
+ *
+ * Validates SDK-based activity polling, cursor filtering,
+ * normalization failure tolerance, and newest-first ordering.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+const mockClient = {
+  reports: {
+    progress: vi.fn(),
+  },
+  raw: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+};
+
+vi.mock("../src/basecamp-client.js", () => ({
+  getClient: vi.fn(() => mockClient),
+  rawOrThrow: vi.fn(async (result: any) => result?.data),
+  numId: (_label: string, value: string | number) => Number(value),
+  BasecampError: class BasecampError extends Error {
+    code: string;
+    constructor(msg: string, code: string) { super(msg); this.code = code; }
+  },
+}));
+
+vi.mock("../src/retry.js", () => ({
+  withCircuitBreaker: vi.fn(async (_cb: any, _key: string, fn: () => Promise<any>) => fn()),
+}));
+
+const normalizeStub = vi.fn();
+const isSelfMessageStub = vi.fn().mockReturnValue(false);
+vi.mock("../src/inbound/normalize.js", () => ({
+  normalizeActivityEvent: (...args: any[]) => normalizeStub(...args),
+  isSelfMessage: (...args: any[]) => isSelfMessageStub(...args),
+}));
+
+vi.mock("../src/metrics.js", () => ({
+  recordUnknownKind: vi.fn(),
+}));
+
+import { pollActivityFeed } from "../src/inbound/activity.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeRawEvent(id: number, createdAt: string, kind = "todo_created") {
+  return {
+    id,
+    kind,
+    created_at: createdAt,
+    recording: { id: id * 100, type: "Todo", title: `Test ${id}`, url: "" },
+    creator: { id: 42, name: "Test User" },
+    bucket: { id: 1, name: "Project", type: "Project" },
+    excerpt: "",
+  };
+}
+
+function fakeNormalized(id: number, createdAt: string): any {
+  return {
+    channel: "basecamp",
+    accountId: "test",
+    peer: { kind: "group", id: `recording:${id * 100}` },
+    sender: { id: "42", name: "Test User" },
+    text: `Test ${id}`,
+    html: "",
+    meta: {
+      bucketId: "1",
+      recordingId: String(id * 100),
+      recordableType: "Todo",
+      eventKind: "created",
+      mentions: [],
+      mentionsAgent: false,
+      attachments: [],
+      sources: ["activity"],
+    },
+    dedupKey: `activity:${id}`,
+    createdAt,
+    correlationId: "corr",
+  };
+}
+
+const account = {
+  accountId: "test-act",
+  personId: "99",
+  enabled: true,
+  token: "tok",
+  tokenSource: "config" as const,
+  bcqProfile: undefined,
+  config: { personId: "99" },
+} as any;
+
+const log = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("pollActivityFeed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches via SDK, normalizes events, and returns newestAt", async () => {
+    const raw1 = fakeRawEvent(1, "2025-06-01T12:00:00Z");
+    const raw2 = fakeRawEvent(2, "2025-06-01T11:00:00Z");
+    mockClient.reports.progress.mockResolvedValue([raw1, raw2]);
+
+    normalizeStub
+      .mockResolvedValueOnce(fakeNormalized(1, "2025-06-01T12:00:00Z"))
+      .mockResolvedValueOnce(fakeNormalized(2, "2025-06-01T11:00:00Z"));
+
+    const result = await pollActivityFeed({ account, log });
+
+    expect(mockClient.reports.progress).toHaveBeenCalled();
+    expect(result.events).toHaveLength(2);
+    expect(result.newestAt).toBe("2025-06-01T12:00:00Z");
+  });
+
+  it("returns empty on empty feed", async () => {
+    mockClient.reports.progress.mockResolvedValue([]);
+
+    const result = await pollActivityFeed({ account, log });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.newestAt).toBeUndefined();
+  });
+
+  it("filters events at or before cursor", async () => {
+    const raw1 = fakeRawEvent(1, "2025-06-01T12:00:00Z");
+    const raw2 = fakeRawEvent(2, "2025-06-01T10:00:00Z"); // at cursor
+    const raw3 = fakeRawEvent(3, "2025-06-01T09:00:00Z"); // before cursor
+    mockClient.reports.progress.mockResolvedValue([raw1, raw2, raw3]);
+
+    normalizeStub.mockResolvedValue(fakeNormalized(1, "2025-06-01T12:00:00Z"));
+
+    const result = await pollActivityFeed({
+      account,
+      since: "2025-06-01T10:00:00Z",
+      log,
+    });
+
+    // raw2 is at cursor (<=) so it and raw3 are excluded
+    expect(result.events).toHaveLength(1);
+    expect(normalizeStub).toHaveBeenCalledTimes(1);
+    expect(result.newestAt).toBe("2025-06-01T12:00:00Z");
+  });
+
+  it("skips events that fail normalization without crashing", async () => {
+    const raw1 = fakeRawEvent(1, "2025-06-01T12:00:00Z");
+    const raw2 = fakeRawEvent(2, "2025-06-01T11:00:00Z");
+    mockClient.reports.progress.mockResolvedValue([raw1, raw2]);
+
+    normalizeStub
+      .mockRejectedValueOnce(new Error("bad event"))
+      .mockResolvedValueOnce(fakeNormalized(2, "2025-06-01T11:00:00Z"));
+
+    const result = await pollActivityFeed({ account, log });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].dedupKey).toBe("activity:2");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("failed to normalize"),
+    );
+    // newestAt only tracks successfully processed events (tracking is inside try block)
+    expect(result.newestAt).toBe("2025-06-01T11:00:00Z");
+  });
+
+  it("events are newest-first, newestAt is chronologically latest", async () => {
+    // Intentionally out of order to verify tracking
+    const raw1 = fakeRawEvent(1, "2025-06-01T09:00:00Z");
+    const raw2 = fakeRawEvent(2, "2025-06-01T12:00:00Z");
+    mockClient.reports.progress.mockResolvedValue([raw1, raw2]);
+
+    normalizeStub
+      .mockResolvedValueOnce(fakeNormalized(1, "2025-06-01T09:00:00Z"))
+      .mockResolvedValueOnce(fakeNormalized(2, "2025-06-01T12:00:00Z"));
+
+    const result = await pollActivityFeed({ account, log });
+
+    expect(result.events).toHaveLength(2);
+    expect(result.newestAt).toBe("2025-06-01T12:00:00Z");
+  });
+
+  it("returns null-normalized events as dropped (normalize returns null)", async () => {
+    const raw1 = fakeRawEvent(1, "2025-06-01T12:00:00Z", "unknown_kind");
+    mockClient.reports.progress.mockResolvedValue([raw1]);
+
+    normalizeStub.mockResolvedValueOnce(null); // unknown kind → null
+
+    const result = await pollActivityFeed({ account, log });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.newestAt).toBe("2025-06-01T12:00:00Z");
+  });
+
+  it("handles non-array API response gracefully", async () => {
+    mockClient.reports.progress.mockResolvedValue(null);
+
+    const result = await pollActivityFeed({ account, log });
+
+    expect(result.events).toHaveLength(0);
+    expect(result.newestAt).toBeUndefined();
+  });
+});

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests: basecampPairingAdapter
+ *
+ * Validates allowlist entry normalization and approval notification.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (v: string | undefined) => (v ?? "").trim() || "default",
+  PAIRING_APPROVED_MESSAGE: "You have been approved!",
+}));
+
+const mockClient = {
+  raw: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
+  },
+};
+
+vi.mock("../src/basecamp-client.js", () => ({
+  getClient: vi.fn(() => mockClient),
+  rawOrThrow: vi.fn(async (result: any) => result?.data),
+  numId: (_label: string, value: string | number) => Number(value),
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveBasecampAccount: vi.fn(() => ({
+    accountId: "default",
+    personId: "99",
+    token: "tok",
+    tokenSource: "config",
+    enabled: true,
+    config: { personId: "99" },
+  })),
+}));
+
+import { basecampPairingAdapter } from "../src/adapters/pairing.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("basecampPairingAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("normalizeAllowEntry", () => {
+    it("strips 'basecamp:' prefix", () => {
+      expect(basecampPairingAdapter.normalizeAllowEntry("basecamp:12345")).toBe("12345");
+    });
+
+    it("strips 'BC:' prefix (case-insensitive)", () => {
+      expect(basecampPairingAdapter.normalizeAllowEntry("BC:67890")).toBe("67890");
+      expect(basecampPairingAdapter.normalizeAllowEntry("bc:67890")).toBe("67890");
+    });
+
+    it("strips 'Basecamp:' mixed case", () => {
+      expect(basecampPairingAdapter.normalizeAllowEntry("Basecamp:42")).toBe("42");
+    });
+
+    it("passes plain numeric ID through", () => {
+      expect(basecampPairingAdapter.normalizeAllowEntry("99999")).toBe("99999");
+    });
+
+    it("trims whitespace", () => {
+      expect(basecampPairingAdapter.normalizeAllowEntry("basecamp:  111 ")).toBe("111");
+    });
+  });
+
+  describe("notifyApproval", () => {
+    it("calls SDK client to post a Ping message", async () => {
+      mockClient.raw.POST.mockResolvedValue({
+        data: { id: 1 },
+        response: { ok: true, headers: new Map() },
+      });
+
+      await basecampPairingAdapter.notifyApproval!({
+        cfg: {} as any,
+        id: "42",
+      });
+
+      expect(mockClient.raw.POST).toHaveBeenCalledWith(
+        expect.stringContaining("/circles/people/42/lines.json"),
+        expect.objectContaining({
+          body: expect.objectContaining({
+            content: expect.stringContaining("You have been approved!"),
+          }),
+        }),
+      );
+    });
+
+    it("swallows errors silently", async () => {
+      mockClient.raw.POST.mockRejectedValue(new Error("network error"));
+
+      // Should not throw
+      await expect(
+        basecampPairingAdapter.notifyApproval!({ cfg: {} as any, id: "42" }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/poller-circuit-breaker.test.ts
+++ b/tests/poller-circuit-breaker.test.ts
@@ -25,6 +25,10 @@ vi.mock("../src/config.js", () => ({
     threshold: 1,
     cooldownMs: 60_000,
   }),
+  resolveSafetyNetConfig: () => ({ projects: [], intervalMs: 600_000, tier2: { enabled: false, lagThresholdMs: 600_000, rapidIntervalMs: 120_000, businessHours: { start: 9, end: 18, timezone: "America/Chicago" } } }),
+  resolveReconciliationConfig: () => ({ enabled: false, intervalMs: 21_600_000, gapThreshold: 3 }),
+  resolveAccountForBucket: () => undefined,
+  listBasecampAccountIds: () => ["default"],
 }));
 
 vi.mock("../src/logging.js", () => ({

--- a/tests/poller-dispatch.test.ts
+++ b/tests/poller-dispatch.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests: Poller dispatch flow
+ *
+ * Validates end-to-end dispatch wiring in startCompositePoller:
+ * - Activity poll → dedup → onEvent → cursor advance
+ * - Readings poll → dedup → onEvent → mark-read
+ * - Assignments bootstrap (no events) and set-diff (new events)
+ * - Dedup filters duplicates
+ * - Self-message filtering
+ * - Webhook-active → 5x activity interval (via log assertion)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// State dir mock — point dedup-registry to test tmpDir for isolation
+const testStateDir = mkdtempSync(join(tmpdir(), "pd-state-"));
+vi.mock("../src/inbound/state-dir.js", () => ({
+  resolvePluginStateDir: () => testStateDir,
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolvePollingIntervals: () => ({
+    activityIntervalMs: 50,
+    readingsIntervalMs: 50,
+    assignmentsIntervalMs: 50,
+  }),
+  resolveCircuitBreakerConfig: () => ({
+    threshold: 5,
+    cooldownMs: 30_000,
+  }),
+  resolveSafetyNetConfig: () => ({
+    projects: [],
+    intervalMs: 600_000,
+    tier2: {
+      enabled: false,
+      lagThresholdMs: 600_000,
+      rapidIntervalMs: 120_000,
+      businessHours: { start: 9, end: 18, timezone: "America/Chicago" },
+    },
+  }),
+  resolveReconciliationConfig: () => ({
+    enabled: false,
+    intervalMs: 21_600_000,
+    gapThreshold: 3,
+  }),
+  resolveAccountForBucket: () => undefined,
+  listBasecampAccountIds: () => ["default"],
+}));
+
+const mockClient = {
+  raw: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn().mockResolvedValue({ data: null, response: { ok: true, headers: new Map() } }),
+    DELETE: vi.fn(),
+  },
+};
+
+vi.mock("../src/basecamp-client.js", () => ({
+  getClient: vi.fn(() => mockClient),
+  rawOrThrow: vi.fn(async (result: any) => result?.data),
+  numId: (_label: string, value: string | number) => Number(value),
+  BasecampError: class BasecampError extends Error {
+    code: string;
+    constructor(msg: string, code: string) { super(msg); this.code = code; }
+  },
+  clearClients: vi.fn(),
+}));
+
+// Track what the mocks return — configurable per test
+let activityEvents: any[] = [];
+let readingsEvents: any[] = [];
+let readingsSgids: string[] = [];
+let assignmentsEvents: any[] = [];
+let assignmentsKnownIds = new Set<string>();
+
+vi.mock("../src/inbound/activity.js", () => ({
+  pollActivityFeed: vi.fn(async () => ({
+    events: activityEvents,
+    newestAt: activityEvents.length > 0 ? activityEvents[0].createdAt : undefined,
+  })),
+}));
+
+vi.mock("../src/inbound/readings.js", () => ({
+  pollReadings: vi.fn(async () => ({
+    events: readingsEvents,
+    newestAt: readingsEvents.length > 0 ? readingsEvents[0].createdAt : undefined,
+    processedSgids: readingsSgids,
+  })),
+}));
+
+vi.mock("../src/inbound/assignments.js", () => ({
+  pollAssignments: vi.fn(async () => ({
+    events: assignmentsEvents,
+    knownIds: assignmentsKnownIds,
+  })),
+}));
+
+vi.mock("../src/inbound/normalize.js", () => ({
+  isSelfMessage: vi.fn((senderId: string, account: any) => senderId === account.personId),
+}));
+
+import { CursorStore } from "../src/inbound/cursors.js";
+import { startCompositePoller } from "../src/inbound/poller.js";
+import { closeAccountDedup } from "../src/inbound/dedup-registry.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let eventCounter = 0;
+
+function makeEvent(tag: string, opts?: { senderId?: string; recordingId?: string; createdAt?: string }): any {
+  eventCounter++;
+  const uid = `${tag}-${eventCounter}-${Date.now()}`;
+  return {
+    channel: "basecamp",
+    accountId: "test-dispatch",
+    peer: { kind: "group", id: `recording:${opts?.recordingId ?? uid}` },
+    sender: { id: opts?.senderId ?? "42", name: "Test User" },
+    text: `Event ${uid}`,
+    html: "",
+    meta: {
+      bucketId: "1",
+      recordingId: opts?.recordingId ?? uid,
+      recordableType: "Todo",
+      eventKind: "created",
+      mentions: [],
+      mentionsAgent: false,
+      attachments: [],
+      sources: ["activity"],
+    },
+    dedupKey: `test:${uid}`,
+    createdAt: opts?.createdAt ?? "2025-06-01T12:00:00Z",
+    correlationId: `corr-${uid}`,
+  };
+}
+
+const baseAccount = {
+  accountId: "test-dispatch",
+  personId: "99",
+  enabled: true,
+  token: "tok",
+  tokenSource: "config" as const,
+  bcqProfile: "default",
+  config: { personId: "99", bcqProfile: "default" },
+} as any;
+
+const log = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("poller dispatch flow", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "poller-dispatch-"));
+    eventCounter = 0;
+    activityEvents = [];
+    readingsEvents = [];
+    readingsSgids = [];
+    assignmentsEvents = [];
+    assignmentsKnownIds = new Set();
+    vi.clearAllMocks();
+    // Close any cached dedup for isolation
+    closeAccountDedup(baseAccount.accountId);
+  });
+
+  afterEach(async () => {
+    closeAccountDedup(baseAccount.accountId);
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("dispatches activity events and advances cursor", async () => {
+    const ev = makeEvent("act", { createdAt: "2025-06-01T12:00:00Z" });
+    activityEvents = [ev];
+
+    const dispatched: any[] = [];
+    const ac = new AbortController();
+
+    const pollerPromise = startCompositePoller({
+      account: baseAccount,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      log,
+      stateDir: tmpDir,
+    });
+
+    await new Promise((r) => setTimeout(r, 150));
+    ac.abort();
+    await pollerPromise;
+
+    expect(dispatched.length).toBeGreaterThanOrEqual(1);
+    expect(dispatched[0].dedupKey).toBe(ev.dedupKey);
+  });
+
+  it("dispatches readings events and triggers mark-read", async () => {
+    const ev = makeEvent("read");
+    readingsEvents = [ev];
+    readingsSgids = ["sgid://bc3/Recording/1"];
+
+    const dispatched: any[] = [];
+    const ac = new AbortController();
+
+    const pollerPromise = startCompositePoller({
+      account: baseAccount,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      log,
+      stateDir: tmpDir,
+    });
+
+    await new Promise((r) => setTimeout(r, 150));
+    ac.abort();
+    await pollerPromise;
+
+    expect(dispatched.length).toBeGreaterThanOrEqual(1);
+    expect(mockClient.raw.PUT).toHaveBeenCalled();
+  });
+
+  it("dedup filters duplicate dedupKeys", async () => {
+    // Same event object returned on every poll cycle — same dedupKey
+    const ev = makeEvent("dup");
+    activityEvents = [ev];
+
+    const dispatched: any[] = [];
+    const ac = new AbortController();
+
+    const pollerPromise = startCompositePoller({
+      account: baseAccount,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      log,
+      stateDir: tmpDir,
+    });
+
+    // Let multiple poll cycles run (min sleep is 1s, so just wait for 1st cycle)
+    await new Promise((r) => setTimeout(r, 150));
+    ac.abort();
+    await pollerPromise;
+
+    // Should dispatch exactly once (dedup prevents re-dispatch on subsequent polls)
+    expect(dispatched.length).toBe(1);
+  });
+
+  it("self-message filtering: sender.id === account.personId → not dispatched", async () => {
+    const ev = makeEvent("self", { senderId: "99" }); // matches account.personId
+    activityEvents = [ev];
+
+    const dispatched: any[] = [];
+    const ac = new AbortController();
+
+    const pollerPromise = startCompositePoller({
+      account: baseAccount,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      log,
+      stateDir: tmpDir,
+    });
+
+    await new Promise((r) => setTimeout(r, 150));
+    ac.abort();
+    await pollerPromise;
+
+    expect(dispatched.length).toBe(0);
+  });
+
+  it("assignments bootstrap: no events emitted, IDs stored", async () => {
+    assignmentsEvents = [];
+    assignmentsKnownIds = new Set(["100", "200"]);
+
+    const dispatched: any[] = [];
+    const ac = new AbortController();
+
+    const pollerPromise = startCompositePoller({
+      account: baseAccount,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      log,
+      stateDir: tmpDir,
+    });
+
+    await new Promise((r) => setTimeout(r, 150));
+    ac.abort();
+    await pollerPromise;
+
+    // Bootstrap emits no events
+    expect(dispatched.length).toBe(0);
+  });
+
+  it("assignments set-diff: new ID → event emitted", async () => {
+    // Pre-seed cursor store so poller thinks it's already bootstrapped
+    const cursors = new CursorStore(tmpDir, baseAccount.accountId);
+    cursors.setCustom("assignmentIds", JSON.stringify(["100"]));
+    await cursors.save();
+
+    const ev = makeEvent("assign");
+    assignmentsEvents = [ev];
+    assignmentsKnownIds = new Set(["100", "200"]);
+
+    const dispatched: any[] = [];
+    const ac = new AbortController();
+
+    const pollerPromise = startCompositePoller({
+      account: baseAccount,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      log,
+      stateDir: tmpDir,
+    });
+
+    await new Promise((r) => setTimeout(r, 150));
+    ac.abort();
+    await pollerPromise;
+
+    expect(dispatched.some((d) => d.dedupKey === ev.dedupKey)).toBe(true);
+  });
+
+  it("webhook-active mode logs extended activity interval", async () => {
+    const ac = new AbortController();
+    ac.abort(); // Pre-abort — we only need the started log
+
+    await startCompositePoller({
+      account: baseAccount,
+      cfg: {},
+      abortSignal: ac.signal,
+      onEvent: async () => true,
+      log,
+      stateDir: tmpDir,
+      webhookActiveProjects: new Set(["100"]),
+    });
+
+    // The "started" structured log includes activityMs
+    const startedCalls = log.info.mock.calls
+      .map((c: any) => c[0] as string)
+      .filter((m: string) => m.includes("started"));
+    expect(startedCalls.length).toBeGreaterThanOrEqual(1);
+    // With webhookActive, activityMs = 50 * 5 = 250
+    expect(startedCalls[0]).toContain('"activityMs":250');
+    expect(startedCalls[0]).toContain('"mode":"reconciliation"');
+  });
+});

--- a/tests/poller-shutdown-timeout.test.ts
+++ b/tests/poller-shutdown-timeout.test.ts
@@ -13,6 +13,10 @@ vi.mock("../src/config.js", () => ({
     threshold: 5,
     cooldownMs: 30_000,
   }),
+  resolveSafetyNetConfig: () => ({ projects: [], intervalMs: 600_000, tier2: { enabled: false, lagThresholdMs: 600_000, rapidIntervalMs: 120_000, businessHours: { start: 9, end: 18, timezone: "America/Chicago" } } }),
+  resolveReconciliationConfig: () => ({ enabled: false, intervalMs: 21_600_000, gapThreshold: 3 }),
+  resolveAccountForBucket: () => undefined,
+  listBasecampAccountIds: () => ["default"],
 }));
 
 vi.mock("../src/basecamp-client.js", () => ({

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests: basecampSetupAdapter
+ *
+ * Validates account ID normalization, input validation,
+ * and config application for the setup flow.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  DEFAULT_ACCOUNT_ID: "default",
+  normalizeAccountId: (value: string | undefined | null): string => {
+    const trimmed = (value ?? "").trim();
+    return trimmed || "default";
+  },
+  applyAccountNameToChannelSection: ({ cfg, channelKey, accountId, name }: any) => {
+    const section = cfg.channels?.[channelKey] ?? {};
+    const accounts = section.accounts ?? {};
+    const acct = accounts[accountId] ?? {};
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        [channelKey]: {
+          ...section,
+          accounts: {
+            ...accounts,
+            [accountId]: { ...acct, displayName: name },
+          },
+        },
+      },
+    };
+  },
+}));
+
+import { basecampSetupAdapter } from "../src/adapters/setup.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("basecampSetupAdapter", () => {
+  describe("resolveAccountId", () => {
+    it("normalizes DEFAULT_ACCOUNT_ID to 'default'", () => {
+      expect(basecampSetupAdapter.resolveAccountId({ accountId: "" })).toBe("default");
+    });
+
+    it("normalizes undefined to 'default'", () => {
+      expect(basecampSetupAdapter.resolveAccountId({ accountId: undefined as any })).toBe("default");
+    });
+
+    it("preserves custom account ID", () => {
+      expect(basecampSetupAdapter.resolveAccountId({ accountId: "my-team" })).toBe("my-team");
+    });
+
+    it("trims whitespace", () => {
+      expect(basecampSetupAdapter.resolveAccountId({ accountId: "  team-a  " })).toBe("team-a");
+    });
+  });
+
+  describe("validateInput", () => {
+    it("returns null (no-op)", () => {
+      expect(basecampSetupAdapter.validateInput!({} as any)).toBeNull();
+    });
+  });
+
+  describe("applyAccountConfig", () => {
+    const baseCfg = { channels: {} } as any;
+
+    it("applies tokenFile path", () => {
+      const result = basecampSetupAdapter.applyAccountConfig({
+        cfg: baseCfg,
+        accountId: "default",
+        input: { name: "Test", tokenFile: "/path/to/token" } as any,
+      });
+
+      const acct = result.channels.basecamp.accounts.default;
+      expect(acct.tokenFile).toBe("/path/to/token");
+      expect(acct.token).toBeUndefined();
+      expect(acct.enabled).toBe(true);
+    });
+
+    it("applies inline token", () => {
+      const result = basecampSetupAdapter.applyAccountConfig({
+        cfg: baseCfg,
+        accountId: "default",
+        input: { name: "Test", token: "my-secret-token" } as any,
+      });
+
+      const acct = result.channels.basecamp.accounts.default;
+      expect(acct.token).toBe("my-secret-token");
+      expect(acct.tokenFile).toBeUndefined();
+    });
+
+    it("preserves existing account keys", () => {
+      const cfgWithExisting = {
+        channels: {
+          basecamp: {
+            accounts: {
+              default: { personId: "42", bcqProfile: "main" },
+            },
+          },
+        },
+      } as any;
+
+      const result = basecampSetupAdapter.applyAccountConfig({
+        cfg: cfgWithExisting,
+        accountId: "default",
+        input: { name: "Test", tokenFile: "/tok" } as any,
+      });
+
+      const acct = result.channels.basecamp.accounts.default;
+      expect(acct.personId).toBe("42");
+      expect(acct.bcqProfile).toBe("main");
+      expect(acct.tokenFile).toBe("/tok");
+    });
+
+    it("sets channel and account enabled", () => {
+      const result = basecampSetupAdapter.applyAccountConfig({
+        cfg: baseCfg,
+        accountId: "new-acct",
+        input: { name: "New" } as any,
+      });
+
+      expect(result.channels.basecamp.enabled).toBe(true);
+      expect(result.channels.basecamp.accounts["new-acct"].enabled).toBe(true);
+    });
+
+    it("applies with no token or tokenFile", () => {
+      const result = basecampSetupAdapter.applyAccountConfig({
+        cfg: baseCfg,
+        accountId: "default",
+        input: { name: "Minimal" } as any,
+      });
+
+      const acct = result.channels.basecamp.accounts.default;
+      expect(acct.token).toBeUndefined();
+      expect(acct.tokenFile).toBeUndefined();
+      expect(acct.enabled).toBe(true);
+    });
+  });
+});

--- a/tests/webhook-lifecycle.test.ts
+++ b/tests/webhook-lifecycle.test.ts
@@ -97,7 +97,7 @@ describe("reconcileWebhooks", () => {
     expect(mockClient.raw.POST).toHaveBeenCalledTimes(2);
   });
 
-  it("recovers secret for pre-existing webhook with no registry entry", async () => {
+  it("registers pre-existing webhook with no registry entry as existing", async () => {
     mockClient.webhooks.list.mockResolvedValue([
       {
         id: 42,
@@ -106,37 +106,25 @@ describe("reconcileWebhooks", () => {
         types: ["Todo", "Comment"],
       },
     ]);
-    mockClient.webhooks.delete.mockResolvedValue(undefined);
-    mockClient.raw.POST.mockResolvedValue({
-      data: {
-        id: 43,
-        active: true,
-        payload_url: "https://example.com/webhooks/basecamp",
-        types: ["Todo", "Comment"],
-        secret: "recovered-secret",
-      },
-      error: undefined,
-      response: { ok: true, headers: new Headers() },
-    });
 
     const registry = new WebhookSecretRegistry();
     const log = mockLog();
     const result = await reconcileWebhooks(makeConfig(), registry, log);
 
-    // First encounter with pre-existing webhook triggers recovery
-    expect(result.recovered).toEqual(["100", "200"]);
-    expect(result.existing).toEqual([]);
+    // Pre-existing webhook is recorded as existing (no secret recovery)
+    expect(result.existing).toEqual(["100", "200"]);
+    expect(result.recovered).toEqual([]);
     expect(result.created).toEqual([]);
 
-    // Delete old, create new
-    expect(mockClient.webhooks.delete).toHaveBeenCalledTimes(2);
-    expect(mockClient.raw.POST).toHaveBeenCalledTimes(2);
+    // No delete/recreate — just register what we found
+    expect(mockClient.webhooks.delete).not.toHaveBeenCalled();
+    expect(mockClient.raw.POST).not.toHaveBeenCalled();
 
-    // Registry should now have the recovered secret
+    // Registry should have entry with empty secret
     const entry = registry.get("100");
     expect(entry).toBeDefined();
-    expect(entry!.secret).toBe("recovered-secret");
-    expect(entry!.webhookId).toBe("43");
+    expect(entry!.secret).toBe("");
+    expect(entry!.webhookId).toBe("42");
   });
 
   it("does not overwrite existing registry entries for matched webhooks", async () => {
@@ -207,7 +195,7 @@ describe("reconcileWebhooks", () => {
     expect(log.info).toHaveBeenCalledWith("webhook_types_changed", expect.any(Object));
   });
 
-  it("marks fresh create as failed when BC3 returns no secret", async () => {
+  it("succeeds when BC3 returns no secret (token auth expected)", async () => {
     mockClient.webhooks.list.mockResolvedValue([]);
     mockClient.raw.POST.mockResolvedValue({
       data: {
@@ -215,7 +203,7 @@ describe("reconcileWebhooks", () => {
         active: true,
         payload_url: "https://example.com/webhooks/basecamp",
         types: ["Todo", "Comment"],
-        // No secret
+        // No secret — expected for BC3
       },
       error: undefined,
       response: { ok: true, headers: new Headers() },
@@ -229,12 +217,12 @@ describe("reconcileWebhooks", () => {
       log,
     );
 
-    expect(result.failed).toEqual(["100"]);
-    expect(result.created).toEqual([]);
-    expect(registry.get("100")!.recoveryFailed).toBe(true);
-    expect(log.error).toHaveBeenCalledWith("webhook_create_no_secret", expect.objectContaining({
+    // No-secret is not a failure — BC3 never returns secrets
+    expect(result.created).toEqual(["100"]);
+    expect(result.failed).toEqual([]);
+    expect(registry.get("100")!.secret).toBe("");
+    expect(log.info).toHaveBeenCalledWith("webhook_create_no_secret", expect.objectContaining({
       project: "100",
-      recovery: false,
     }));
   });
 
@@ -378,7 +366,7 @@ describe("reconcileWebhooks", () => {
     expect(registry.get("100")!.secret).toBe("known-secret");
   });
 
-  it("records failure when recovery delete fails", async () => {
+  it("treats empty-secret existing webhook as existing without recovery attempt", async () => {
     mockClient.webhooks.list.mockResolvedValue([
       {
         id: 42,
@@ -387,9 +375,16 @@ describe("reconcileWebhooks", () => {
         types: ["Todo", "Comment"],
       },
     ]);
-    mockClient.webhooks.delete.mockRejectedValue(new Error("delete forbidden"));
 
     const registry = new WebhookSecretRegistry();
+    // Pre-populate with empty secret (BC3 behavior)
+    registry.set("100", {
+      webhookId: "42",
+      secret: "",
+      payloadUrl: "https://example.com/webhooks/basecamp",
+      types: ["Todo", "Comment"],
+    });
+
     const log = mockLog();
     const result = await reconcileWebhooks(
       makeConfig({ projects: ["100"] }),
@@ -397,13 +392,16 @@ describe("reconcileWebhooks", () => {
       log,
     );
 
-    expect(result.failed).toEqual(["100"]);
+    // Should be existing — no delete/recreate
+    expect(result.existing).toEqual(["100"]);
     expect(result.recovered).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(mockClient.webhooks.delete).not.toHaveBeenCalled();
     expect(mockClient.raw.POST).not.toHaveBeenCalled();
-    expect(log.error).toHaveBeenCalledWith("webhook_secret_recovery_delete_failed", expect.any(Object));
   });
 
-  it("marks recoveryFailed and stops retrying when create returns no secret", async () => {
+  it("idempotent: pre-existing webhook with empty secret on subsequent calls", async () => {
+    // First call: webhook exists, no registry entry yet
     mockClient.webhooks.list.mockResolvedValue([
       {
         id: 42,
@@ -412,38 +410,22 @@ describe("reconcileWebhooks", () => {
         types: ["Todo", "Comment"],
       },
     ]);
-    mockClient.webhooks.delete.mockResolvedValue(undefined);
-    mockClient.raw.POST.mockResolvedValue({
-      data: {
-        id: 99,
-        active: true,
-        payload_url: "https://example.com/webhooks/basecamp",
-        types: ["Todo", "Comment"],
-        // No secret returned
-      },
-      error: undefined,
-      response: { ok: true, headers: new Headers() },
-    });
 
     const registry = new WebhookSecretRegistry();
     const log = mockLog();
 
-    // First call: recovery attempted, but create returned no secret
     const result1 = await reconcileWebhooks(
       makeConfig({ projects: ["100"] }),
       registry,
       log,
     );
+    expect(result1.existing).toEqual(["100"]);
 
-    expect(result1.failed).toEqual(["100"]);
-    expect(result1.recovered).toEqual([]);
-    expect(registry.get("100")!.recoveryFailed).toBe(true);
-
-    // Second call: should not retry recovery — treat as existing
+    // Second call: same state
     vi.clearAllMocks();
     mockClient.webhooks.list.mockResolvedValue([
       {
-        id: 99,
+        id: 42,
         active: true,
         payload_url: "https://example.com/webhooks/basecamp",
         types: ["Todo", "Comment"],
@@ -457,7 +439,6 @@ describe("reconcileWebhooks", () => {
     );
 
     expect(result2.existing).toEqual(["100"]);
-    expect(result2.recovered).toEqual([]);
     expect(mockClient.webhooks.delete).not.toHaveBeenCalled();
     expect(mockClient.raw.POST).not.toHaveBeenCalled();
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,13 @@ import path from "path";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/types.ts", "src/**/*.d.ts"],
+      reporter: ["text", "json-summary"],
+      thresholds: { lines: 50, functions: 50, branches: 40, statements: 50 },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- **Tier-1 safety net (Q16):** Direct API polling of cards, todos, and check-ins with snapshot diffing — detects appeared, moved, disappeared, assignment changes, and new check-in answers. Deep crawl every 6th cycle for completeness-gated disappeared detection. Multi-account project scoping via `resolveAccountForBucket`.
- **Reconciliation pass (Q12):** Periodic activity feed replay checking `dedup.hasSeen()` to detect delivery gaps. Promotion hysteresis drives safety-net type promotion (2 consecutive gap cycles → promote, 3 clean → demote, max 3, 24h TTL).
- **Webhook auth fix:** Token-first verification (query string `?token=`), HMAC secondary. Removed secret-recovery delete-recreate cycle — BC3 never returns secrets on webhook create, so treat no-secret as success.
- **Test hardening:** 4 new test files (activity, setup, pairing, poller-dispatch) adding 31 tests. Coverage config with `@vitest/coverage-v8`.

## New files

| File | Purpose |
|------|---------|
| `src/inbound/dock-cache.ts` | Project dock tool ID resolution with 1h TTL cache |
| `src/inbound/safety-net.ts` | Safety net direct polling with snapshot diff detection |
| `src/inbound/reconciliation.ts` | Reconciliation pass with promotion logic |

## Modified files

| File | Changes |
|------|---------|
| `src/inbound/poller.ts` | Wire safety net + reconciliation into composite loop |
| `src/inbound/webhooks.ts` | Token-first auth order, auth method metrics |
| `src/inbound/webhook-lifecycle.ts` | Remove secret-recovery cycle, no-secret = success |
| `src/config.ts` | Safety net + reconciliation Zod schemas and resolvers |
| `src/metrics.ts` | Safety net, reconciliation, and webhook auth metrics |
| `src/types.ts` | `"disappeared"` event kind, `meta.delta`, config types |
| `src/inbound/dedup.ts` | `hasSeen()` read-only probe for reconciliation |
| `src/inbound/normalize.ts` | Export `isNormalizableKind`, `recordableTypeForKind` |
| `src/adapters/status.ts` | Safety net lag + reconciliation audit |
| `vitest.config.ts` | Coverage config with thresholds |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 988 passing
- [x] `npx vitest run --coverage` — 77% lines, 87% branches, 78% functions (all above thresholds)
- [ ] DF-011: Register real webhook, trigger real event, verify token auth round-trip
- [ ] DF-022: CB lifecycle: trigger real API block → open→half-open→closed