### PR TITLE
Import CLI credentials during onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       - run: npm run typecheck
       - run: npm run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,86 @@
 
 ## What This Is
 
-An external OpenClaw channel plugin that integrates Basecamp with OpenClaw's agent framework. Campfire chats, card tables, to-do lists, check-ins, pings, message boards — every Basecamp surface becomes a live interaction point for AI agents.
+An external OpenClaw channel plugin that integrates Basecamp with OpenClaw's agent framework. Campfire chats, card tables, to-do lists, check-ins, pings, message boards -- every Basecamp surface becomes a live interaction point for AI agents.
 
 This plugin is developed independently by the 37signals team and can later be nominated for upstream OpenClaw inclusion.
 
 ## Architecture at a Glance
 
-- **Channel type:** `basecamp` — registers via `api.registerChannel()` like any OpenClaw channel
+- **Channel type:** `basecamp` -- registers via `api.registerChannel()` like any OpenClaw channel
 - **Peer model:** All Basecamp places map to OpenClaw's `dm | group` peer kinds using `recording:<id>` / `bucket:<id>` / `ping:<id>` conventions. `parentPeer` enables per-project routing without schema changes.
-- **Event fabric:** Composite ingestion from Activity Feed, Hey! Readings, webhooks, direct polls, and (later) Action Cable. Deduplication via per-account sqlite with 24h TTL.
-- **Multi-persona:** Multiple Basecamp service accounts per deployment, mapped via `channels.basecamp.personas` (agentId → accountId).
-- **Outbound:** Chat lines, comments, card creation via the basecamp CLI (Phase 1), native API later.
+- **Event fabric:** Composite ingestion from five sources -- Activity Feed, Hey! Readings, Assignments, Webhooks, and a Safety-Net reconciliation pass. SQLite-backed dedup with 24h TTL and cross-source secondary keys ensures exactly-once delivery.
+- **Multi-persona:** Multiple Basecamp service accounts per deployment, mapped via `channels.basecamp.personas` (agentId -> accountId).
+- **Outbound:** Chat lines, comments, card creation, and media via `@37signals/basecamp` SDK.
+- **Auth:** OAuth browser-based login with automatic token refresh. Onboarding imports credentials from the Basecamp CLI if available.
+- **Resilience:** Per-source circuit breakers on polling, exponential backoff retry on outbound sends, graceful shutdown with webhook deactivation and state flush.
+- **Agent tools:** 10 channel-specific tools (create/complete/reopen todos, boost, move cards, post messages, answer check-ins, read history, generic API read/write).
+
+## Source Layout
+
+```
+index.ts                    Plugin entry point: registers channel, webhook route, agent prompt hook
+src/channel.ts              ChannelPlugin wiring -- all adapters composed here
+src/config.ts               Zod config schema, account resolution, project scoping
+src/types.ts                Basecamp event types, inbound message shape, peer conventions
+src/basecamp-client.ts      @37signals/basecamp SDK client factory
+src/oauth-credentials.ts    OAuth token management, interactive login, refresh
+src/circuit-breaker.ts      Generic circuit breaker (used by poller sources)
+src/dispatch.ts             Engagement gating, DM policy, agent routing
+src/runtime.ts              OpenClaw runtime handle
+src/metrics.ts              Structured event logging
+src/retry.ts                Exponential backoff retry
+src/util.ts                 Shared utilities (withTimeout, etc.)
+
+src/adapters/               SDK adapter implementations
+  status.ts                 Account health probes and audit
+  directory.ts              People lookup and resolution
+  messaging.ts              Inbound message normalization
+  agent-tools.ts            10 Basecamp-specific agent tools
+  agent-prompt.ts           Prompt context injection
+  actions.ts                Message-level actions (send, react, etc.)
+  outbound.ts               Target resolution and text chunking
+  mentions.ts               @mention resolution
+  groups.ts                 Group/channel metadata
+  heartbeat.ts              Polling liveness
+  security.ts               Sender verification
+  pairing.ts                Account pairing flow
+  setup.ts                  First-run setup
+  onboarding.ts             Interactive onboarding with CLI credential import
+  hatch.ts                  Account creation
+  resolver.ts               Peer/message ID resolution
+
+src/inbound/                Event fabric
+  poller.ts                 Composite poller orchestrator (activity + readings + assignments + safety-net)
+  activity.ts               Activity feed polling
+  readings.ts               Hey! Readings polling
+  assignments.ts            Assignment event polling
+  safety-net.ts             Reconciliation safety net (catches missed events)
+  reconciliation.ts         Webhook reconciliation pass
+  webhooks.ts               Webhook HTTP handler + HMAC verification
+  webhook-lifecycle.ts      Webhook registration/deactivation lifecycle
+  webhook-secrets.ts        Per-project HMAC secret storage
+  normalize.ts              Raw Basecamp events -> BasecampInboundMessage
+  dedup.ts                  In-memory dedup engine with 24h TTL
+  dedup-store.ts            Dedup persistence interface
+  dedup-store-sqlite.ts     SQLite-backed dedup persistence (WAL mode)
+  dedup-registry.ts         Per-account singleton dedup instances
+  cursors.ts                Polling cursor persistence
+  dock-cache.ts             Project dock structure cache
+  state-dir.ts              Plugin state directory resolution
+
+src/outbound/               Message sending
+  send.ts                   Send chat lines, comments, media via Basecamp SDK
+  format.ts                 HTML/Markdown formatting
+
+src/hooks/                  Agent prompt context
+  agent-prompt-context.ts   Surface-aware prompt injection (Campfire vs Cards vs Todos etc.)
+
+src/mentions/               bc-attachment SGID parsing
+  parse.ts                  Extract person IDs from Basecamp HTML @mentions
+
+tests/                      1127+ tests across 65 files
+```
 
 ## For the Dev Agent
 
@@ -21,21 +90,11 @@ Read `PLAN.md` for the full architecture. It is the authoritative source for all
 ### Key Decisions to Know
 
 - **Config schema lives in code** (`ChannelPlugin.configSchema`), not in `openclaw.plugin.json`. The manifest is minimal.
-- **Agent→persona mapping** is in `channels.basecamp.personas`, not in AgentConfig (which external plugins can't extend).
-- **Pings:** 1:1 → `dm`, multi-person → `group`. Determined by Circle membership count.
-- **Webhooks are accelerators only** — correctness comes from polling. The system must work with webhooks disabled.
-- **Phase 1 uses the basecamp CLI** for all Basecamp API access. Native API replaces polling in Phase 2, full native in Phase 3.
-- **All recordable types are ingested from Phase 1.** Outbound actions are phased by risk.
-
-### Where to Start (Phase 1)
-
-1. **Scaffold the repo:** `package.json`, `openclaw.plugin.json`, `tsconfig.json`, `src/index.ts`
-2. **Channel skeleton:** `src/channel.ts` — implement `ChannelPlugin<BasecampAccount>` with meta, capabilities, config adapter
-3. **Config adapter:** `src/config.ts` — parse accounts, virtualAccounts, personas from `channels.basecamp` config
-4. **Types:** `src/types.ts` — Basecamp event types, inbound message shape, peer conventions
-5. **Event fabric:** `src/inbound/` — activity feed polling, Hey! Readings polling, normalization, dedup
-6. **Outbound:** `src/outbound/` — post chat lines and comments via the basecamp CLI
-7. **Mentions:** `src/mentions/parse.ts` — bc-attachment SGID parsing
+- **Agent->persona mapping** is in `channels.basecamp.personas`, not in AgentConfig (which external plugins can't extend).
+- **Pings:** 1:1 -> `dm`, multi-person -> `group`. Determined by Circle membership count.
+- **Webhooks are accelerators only** -- correctness comes from polling. The system must work with webhooks disabled.
+- **All recordable types are ingested.** The composite poller covers activity, readings, assignments, and a safety-net pass for anything missed.
+- **Native API access** via `@37signals/basecamp` SDK (pinned to a specific commit SHA). No CLI dependency at runtime.
 
 ### Reference: OpenClaw Plugin API
 
@@ -57,30 +116,23 @@ Study existing channel plugins (telegram, slack, discord) in `~/Work/openclaw/op
 
 ```
 Bucket (Project/Circle)
-  └── Recording (owns thread tree, events, visibility)
-        └── Recordable (Chat::Transcript, Chat::Line, Kanban::Card, Message, Todo, Question, etc.)
-              └── Child Recordings (comments, lines)
+  +-- Recording (owns thread tree, events, visibility)
+        +-- Recordable (Chat::Transcript, Chat::Line, Kanban::Card, Message, Todo, Question, etc.)
+              +-- Child Recordings (comments, lines)
 ```
 
 - Campfire = `Chat::Transcript` with `Chat::Line` children
-- Pings = Circle bucket → `Chat::Transcript`
+- Pings = Circle bucket -> `Chat::Transcript`
 - Cards = `Kanban::Card` in card tables with columns
 - @mentions = `<bc-attachment sgid="...">` in HTML content
 - Person identity = `personId` + `attachableSgid`
 
 ### Reference: Coworker Context
 
-This plugin powers the Coworker agent system (37signals internal ops). Coworker config lives separately in `~/Work/basecamp/coworker/openclaw-plugin/`. The channel plugin itself is general-purpose — any OpenClaw user could bind agents to Basecamp projects.
+This plugin powers the Coworker agent system (37signals internal ops). Coworker config lives separately in `~/Work/basecamp/coworker/openclaw-plugin/`. The channel plugin itself is general-purpose -- any OpenClaw user could bind agents to Basecamp projects.
 
-Coworker skills (54 SKILL.md files across security, bugs, support, exceptions, performance, audit) inject as system prompts. The channel doesn't know about skills — it just routes events to agents via bindings.
+Coworker skills (54 SKILL.md files across security, bugs, support, exceptions, performance, audit) inject as system prompts. The channel doesn't know about skills -- it just routes events to agents via bindings.
 
 ### Testing
 
-Phase 1 smoke tests (from PLAN.md Part 11):
-1. Plugin installs and appears in `openclaw plugins list`
-2. Config validates without schema errors
-3. Activity feed poll returns events
-4. Outbound post appears in Campfire
-5. parentPeer routing works
-6. Multi-persona @mention routing works
-7. Dedup collapses duplicate events
+Run `npm test` -- 1127+ tests across 65 files with >85% coverage thresholds. Run `npm run typecheck` for zero-error TypeScript checking.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All configuration lives under `channels.basecamp` in your OpenClaw config file.
 |-----|------|-------------|
 | `enabled` | `boolean` | Enable or disable the channel |
 | `accounts` | `object` | Per-account auth config (personId, token/tokenFile, OAuth credentials) |
-| `personas` | `object` | Map agent IDs to Basecamp account IDs for multi-identity support |
+| `personas` | `object` | Map agent IDs to Basecamp account IDs for message routing (agent tools still execute under the default account) |
 | `dmPolicy` | `"pairing" \| "allowlist" \| "open" \| "disabled"` | How the agent handles Basecamp Pings (DMs). Default: `"pairing"` |
 | `allowFrom` | `string[]` | Global allowlist of Basecamp person IDs permitted to interact |
 | `engage` | `string[]` | Engagement types to respond to: `dm`, `mention`, `assignment`, `checkin`, `conversation`, `activity` |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# @37signals/openclaw-basecamp
+
+OpenClaw channel plugin for Basecamp. Connects Campfire chats, card tables, to-do lists, check-ins, pings, and message boards to OpenClaw agents -- every Basecamp surface as a live agent interaction point.
+
+## Prerequisites
+
+- [OpenClaw](https://openclaw.dev) (latest version)
+- Node.js >= 20
+- A Basecamp account with OAuth app credentials (client ID + secret), registered at [launchpad.37signals.com/integrations](https://launchpad.37signals.com/integrations)
+
+## Installation
+
+```sh
+openclaw plugins install @37signals/openclaw-basecamp
+```
+
+## Quick start
+
+```sh
+openclaw channels add
+```
+
+Select **Basecamp** from the list, then follow the onboarding wizard. It handles:
+
+1. OAuth app setup (or importing credentials from an existing Basecamp CLI profile)
+2. Browser-based authentication and token creation
+3. Identity discovery and Basecamp account selection
+4. Writing the channel configuration
+
+## Configuration
+
+All configuration lives under `channels.basecamp` in your OpenClaw config file.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `enabled` | `boolean` | Enable or disable the channel |
+| `accounts` | `object` | Per-account auth config (personId, token/tokenFile, OAuth credentials) |
+| `personas` | `object` | Map agent IDs to Basecamp account IDs for multi-identity support |
+| `dmPolicy` | `"pairing" \| "allowlist" \| "open" \| "disabled"` | How the agent handles Basecamp Pings (DMs). Default: `"pairing"` |
+| `allowFrom` | `string[]` | Global allowlist of Basecamp person IDs permitted to interact |
+| `engage` | `string[]` | Engagement types to respond to: `dm`, `mention`, `assignment`, `checkin`, `conversation`, `activity` |
+| `buckets` | `object` | Per-project overrides (requireMention, tool allow/deny lists, engage types, allowFrom) |
+| `webhooks` | `object` | Webhook subscription config: `payloadUrl`, `projects`, `types`, `autoRegister`, `deactivateOnStop` |
+| `webhookSecret` | `string` | Secret token for webhook URL verification |
+| `oauth` | `object` | Channel-level OAuth credentials (`clientId`, `clientSecret`) shared across accounts |
+| `polling` | `object` | Polling intervals: `activityIntervalMs` (default 120s), `readingsIntervalMs` (60s), `assignmentsIntervalMs` (300s) |
+| `retry` | `object` | Retry behavior: `maxAttempts`, `baseDelayMs`, `maxDelayMs`, `jitter` |
+| `circuitBreaker` | `object` | Circuit breaker: `threshold`, `cooldownMs` |
+| `safetyNet` | `object` | Safety net polling for missed events: `projects`, `intervalMs` |
+| `reconciliation` | `object` | Gap reconciliation: `enabled`, `intervalMs`, `gapThreshold` |
+
+## Agent tools
+
+Agents connected through this channel have access to the following tools:
+
+| Tool | Description |
+|------|-------------|
+| `basecamp_create_todo` | Create a new to-do item in a Basecamp to-do list |
+| `basecamp_complete_todo` | Mark a to-do as complete |
+| `basecamp_reopen_todo` | Reopen a completed to-do (mark as incomplete) |
+| `basecamp_read_history` | Fetch recent messages or comments from a recording (chat transcript or comments) |
+| `basecamp_add_boost` | Add a boost (reaction) to any recording -- emoji or short celebratory text |
+| `basecamp_move_card` | Move a card to a different column in a card table |
+| `basecamp_post_message` | Post a new message to a message board |
+| `basecamp_answer_checkin` | Answer a check-in question |
+| `basecamp_api_read` | GET any Basecamp 3 API resource (projects, people, todos, documents, schedules, etc.) |
+| `basecamp_api_write` | POST/PUT/DELETE any Basecamp 3 API resource |
+
+## Development
+
+```sh
+git clone <repo-url>
+cd basecamp-openclaw-plugin
+npm install
+npm test
+npm run typecheck
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ OpenClaw channel plugin for Basecamp. Connects Campfire chats, card tables, to-d
 
 - [OpenClaw](https://openclaw.dev) (latest version)
 - Node.js >= 22.5 (required for `node:sqlite`)
-- A Basecamp account with OAuth app credentials (client ID + secret), registered at [launchpad.37signals.com/integrations](https://launchpad.37signals.com/integrations)
+- A Basecamp account plus either:
+  - An OAuth app you control (client ID + secret), registered at [launchpad.37signals.com/integrations](https://launchpad.37signals.com/integrations), or
+  - An authenticated Basecamp CLI profile with stored credentials that the onboarding wizard can import
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OpenClaw channel plugin for Basecamp. Connects Campfire chats, card tables, to-d
 ## Prerequisites
 
 - [OpenClaw](https://openclaw.dev) (latest version)
-- Node.js >= 20
+- Node.js >= 22.5 (required for `node:sqlite`)
 - A Basecamp account with OAuth app credentials (client ID + secret), registered at [launchpad.37signals.com/integrations](https://launchpad.37signals.com/integrations)
 
 ## Installation

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
+  "files": {
+    "includes": ["src/**", "tests/**", "index.ts", "vitest.config.ts"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn",
+        "noUnusedFunctionParameters": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noAssignInExpressions": "off",
+        "noImplicitAnyLet": "off"
+      },
+      "complexity": {
+        "noForEach": "off",
+        "noBannedTypes": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "useNodejsImportProtocol": "off",
+        "noParameterAssign": "off",
+        "useDefaultParameterLast": "off",
+        "useTemplate": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,9 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { basecampChannel } from "./src/channel.js";
-import { setBasecampRuntime } from "./src/runtime.js";
-import { handleBasecampWebhook } from "./src/inbound/webhooks.js";
 import { getSurfacePrompt } from "./src/hooks/agent-prompt-context.js";
+import { handleBasecampWebhook } from "./src/inbound/webhooks.js";
+import { setBasecampRuntime } from "./src/runtime.js";
 
 const plugin: {
   id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@37signals/openclaw-basecamp",
       "version": "0.1.0",
       "dependencies": {
-        "@37signals/basecamp": "github:basecamp/basecamp-sdk#63388edfc75e41fdeaf1449013c224330b7b055b",
+        "@37signals/basecamp": "git+https://github.com/basecamp/basecamp-sdk.git#63388edfc75e41fdeaf1449013c224330b7b055b",
         "typescript": "^5.0.0",
         "zod": "^4.3.6"
       },
@@ -19,12 +19,13 @@
         "vitest": "3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.5"
       }
     },
     "node_modules/@37signals/basecamp": {
       "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/basecamp/basecamp-sdk.git#63388edfc75e41fdeaf1449013c224330b7b055b",
+      "resolved": "git+https://github.com/basecamp/basecamp-sdk.git#63388edfc75e41fdeaf1449013c224330b7b055b",
+      "integrity": "sha512-Lvf3S755/adtSeHsuQMq7M3dxyx3evSKJ+sP3oKYXl7riNn3quf3KhQ4SDiw9BG3hj84QQERfnN5RxL9oO+/Fw==",
       "dependencies": {
         "openapi-fetch": "^0.17.0"
       },
@@ -228,51 +229,51 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock": {
-      "version": "3.995.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.995.0.tgz",
-      "integrity": "sha512-ONw5c7pOeHe78kC+jK2j73hP727Kqp7cc9lZqkfshlBD8MWxXmZM9GihIQLrNBCSUKRhc19NH7DUM6B7uN0mMQ==",
+      "version": "3.1002.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1002.0.tgz",
+      "integrity": "sha512-AKSrIoK+J8I0i2byjEQJuj9T1BTgpZ+7/5kaOvdfOIAbY+ZebVhOidGx+Ix8LmdDI82EisMc2MqUjT1ywvUKNQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/credential-provider-node": "^3.972.10",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.11",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/token-providers": "3.995.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.995.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.10",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.23.2",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.16",
-        "@smithy/middleware-retry": "^4.4.33",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.32",
-        "@smithy/util-defaults-mode-node": "^4.2.35",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/credential-provider-node": "^3.972.16",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.17",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/token-providers": "3.1002.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.2",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -280,125 +281,58 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.995.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.995.0.tgz",
-      "integrity": "sha512-nI7tT11L9s34AKr95GHmxs6k2+3ie+rEOew2cXOwsMC9k/5aifrZwh0JjAkBop4FqbmS8n0ZjCKDjBZFY/0YxQ==",
+      "version": "3.1002.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1002.0.tgz",
+      "integrity": "sha512-xUmzgTvTeQFVxBqla8U4nXpZNXLcZ0xszfZ4yxdTUNyChQQb7JLaH4E8pAbl7ulg0RoJ4ChNWtOqMJC/N3+qcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/credential-provider-node": "^3.972.10",
-        "@aws-sdk/eventstream-handler-node": "^3.972.5",
-        "@aws-sdk/middleware-eventstream": "^3.972.3",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.11",
-        "@aws-sdk/middleware-websocket": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/token-providers": "3.995.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.995.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.10",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.23.2",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.8",
-        "@smithy/eventstream-serde-node": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.16",
-        "@smithy/middleware-retry": "^4.4.33",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.32",
-        "@smithy/util-defaults-mode-node": "^4.2.35",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-stream": "^4.5.12",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.993.0.tgz",
-      "integrity": "sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.11",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.993.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.9",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.23.2",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.16",
-        "@smithy/middleware-retry": "^4.4.33",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.32",
-        "@smithy/util-defaults-mode-node": "^4.2.35",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/credential-provider-node": "^3.972.16",
+        "@aws-sdk/eventstream-handler-node": "^3.972.9",
+        "@aws-sdk/middleware-eventstream": "^3.972.6",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.17",
+        "@aws-sdk/middleware-websocket": "^3.972.11",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/token-providers": "3.1002.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.2",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/eventstream-serde-browser": "^4.2.10",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.10",
+        "@smithy/eventstream-serde-node": "^4.2.10",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-stream": "^4.5.16",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -406,24 +340,24 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.11.tgz",
-      "integrity": "sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==",
+      "version": "3.973.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.17.tgz",
+      "integrity": "sha512-VtgGP0TjbCeyp6DQpiBqJKbemTSIaN2bZc3UbeTDCani3lBCyxn75ouJYD6koSSp0bh7rKLEbUpiFsNCI7tr0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/xml-builder": "^3.972.5",
-        "@smithy/core": "^3.23.2",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/xml-builder": "^3.972.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/signature-v4": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -431,16 +365,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.9.tgz",
-      "integrity": "sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.15.tgz",
+      "integrity": "sha512-RhHQG1lhkWHL4tK1C/KDjaOeis+9U0tAMnWDiwiSVQZMC7CsST9Xin+sK89XywJ5g/tyABtb7TvFePJ4Te5XSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -448,21 +382,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.11.tgz",
-      "integrity": "sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.17.tgz",
+      "integrity": "sha512-b/bDL76p51+yQ+0O9ZDH5nw/ioE0sRYkjwjOwFWAWZXo6it2kQZUOXhVpjohx3ldKyUxt/SwAivjUu1Nr/PWlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.12",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.16",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -470,25 +404,25 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.9.tgz",
-      "integrity": "sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.15.tgz",
+      "integrity": "sha512-qWnM+wB8MmU2kKY7f4KowKjOjkwRosaFxrtseEEIefwoXn1SjN+CbHzXBVdTAQxxkbBiqhPgJ/WHiPtES4grRQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/credential-provider-env": "^3.972.9",
-        "@aws-sdk/credential-provider-http": "^3.972.11",
-        "@aws-sdk/credential-provider-login": "^3.972.9",
-        "@aws-sdk/credential-provider-process": "^3.972.9",
-        "@aws-sdk/credential-provider-sso": "^3.972.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.9",
-        "@aws-sdk/nested-clients": "3.993.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/credential-provider-env": "^3.972.15",
+        "@aws-sdk/credential-provider-http": "^3.972.17",
+        "@aws-sdk/credential-provider-login": "^3.972.15",
+        "@aws-sdk/credential-provider-process": "^3.972.15",
+        "@aws-sdk/credential-provider-sso": "^3.972.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.15",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/credential-provider-imds": "^4.2.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -496,19 +430,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.9.tgz",
-      "integrity": "sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.15.tgz",
+      "integrity": "sha512-x92FJy34/95wgu+qOGD8SHcgh1hZ9Qx2uFtQEGn4m9Ljou8ICIv3Ybq5yxdB7A60S8ZGCQB0mIopmjJwiLbh5g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/nested-clients": "3.993.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -516,23 +450,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.10.tgz",
-      "integrity": "sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.16.tgz",
+      "integrity": "sha512-7mlt14Ee4rPFAFUVgpWE7+0CBhetJJyzVFqfIsMp7sgyOSm9Y/+qHZOWAuK5I4JNc+Y5PltvJ9kssTzRo92iXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.9",
-        "@aws-sdk/credential-provider-http": "^3.972.11",
-        "@aws-sdk/credential-provider-ini": "^3.972.9",
-        "@aws-sdk/credential-provider-process": "^3.972.9",
-        "@aws-sdk/credential-provider-sso": "^3.972.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.9",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/credential-provider-env": "^3.972.15",
+        "@aws-sdk/credential-provider-http": "^3.972.17",
+        "@aws-sdk/credential-provider-ini": "^3.972.15",
+        "@aws-sdk/credential-provider-process": "^3.972.15",
+        "@aws-sdk/credential-provider-sso": "^3.972.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.15",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/credential-provider-imds": "^4.2.10",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -540,17 +474,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.9.tgz",
-      "integrity": "sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.15.tgz",
+      "integrity": "sha512-PrH3iTeD18y/8uJvQD2s/T87BTGhsdS/1KZU7ReWHXsplBwvCqi7AbnnNbML1pFlQwRWCE2RdSZFWDVId3CvkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -558,38 +492,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.9.tgz",
-      "integrity": "sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.15.tgz",
+      "integrity": "sha512-M/+LBHTPKZxxXckM6m4dnJeR+jlm9NynH9b2YDswN4Zj2St05SK/crdL3Wy3WfJTZootnnhm3oTh87Usl7PS7w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.993.0",
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/token-providers": "3.993.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.993.0.tgz",
-      "integrity": "sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/nested-clients": "3.993.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/token-providers": "3.1002.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -597,18 +512,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.9.tgz",
-      "integrity": "sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.15.tgz",
+      "integrity": "sha512-QTH6k93v+UOfFam/ado8zc71tH+enTVyuvLy9uEWXX1x894dN5ovtf/MdBDgFwq3g6c9mbtgVJ4B+yBqDtXvdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/nested-clients": "3.993.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -616,15 +531,15 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.5.tgz",
-      "integrity": "sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.9.tgz",
+      "integrity": "sha512-mKPiiVssgFDWkAXdEDh8+wpr2pFSX/fBn2onXXnrfIAYbdZhYb4WilKbZ3SJMUnQi+Y48jZMam5J0RrgARluaA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/eventstream-codec": "^4.2.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -632,15 +547,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.3.tgz",
-      "integrity": "sha512-pbvZ6Ye/Ks6BAZPa3RhsNjHrvxU9li25PMhSdDpbX0jzdpKpAkIR65gXSNKmA/REnSdEMWSD4vKUW+5eMFzB6w==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.6.tgz",
+      "integrity": "sha512-mB2+3G/oxRC+y9WRk0KCdradE2rSfxxJpcOSmAm+vDh3ex3WQHVLZ1catNIe1j5NQ+3FLBsNMRPVGkZ43PRpjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -648,15 +563,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
-      "integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.6.tgz",
+      "integrity": "sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -664,14 +579,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
-      "integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.6.tgz",
+      "integrity": "sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -679,16 +594,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
-      "integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.6.tgz",
+      "integrity": "sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/types": "^3.973.4",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -696,35 +611,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.11.tgz",
-      "integrity": "sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.17.tgz",
+      "integrity": "sha512-HHArkgWzomuwufXwheQqkddu763PWCpoNTq1dGjqXzJT/lojX3VlOqjNSR2Xvb6/T9ISfwYcMOcbFgUp4EWxXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.993.0",
-        "@smithy/core": "^3.23.2",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@smithy/core": "^3.23.7",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -732,23 +630,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.6.tgz",
-      "integrity": "sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.11.tgz",
+      "integrity": "sha512-cWf+8iUUnitgFuUu/ryK2uVfx7f5ezdhGwsjLLEEC1Nk716Ld2Hw4LA8iipyVcQI3EarvK6ExY2dSBET/0PYng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-format-url": "^3.972.3",
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-format-url": "^3.972.6",
+        "@smithy/eventstream-codec": "^4.2.10",
+        "@smithy/eventstream-serde-browser": "^4.2.10",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/signature-v4": "^5.3.10",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-hex-encoding": "^4.2.1",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -756,66 +654,49 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.993.0.tgz",
-      "integrity": "sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.5.tgz",
+      "integrity": "sha512-zn0WApcULn7Rtl6T+KP2CQTZo/7wOa2YV1yHQnbijTQoi4YXQHM8s21JcJzt33/mqPh8AdvWX1f+83KvKuxlZw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.11",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.993.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.9",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.23.2",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.16",
-        "@smithy/middleware-retry": "^4.4.33",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.32",
-        "@smithy/util-defaults-mode-node": "^4.2.35",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.17",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.2",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -823,16 +704,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
-      "integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.6.tgz",
+      "integrity": "sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -840,68 +721,18 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.995.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.995.0.tgz",
-      "integrity": "sha512-lYSadNdZZ513qCKoj/KlJ+PgCycL3n8ZNS37qLVFC0t7TbHzoxvGquu9aD2n9OCERAn43OMhQ7dXjYDYdjAXzA==",
+      "version": "3.1002.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1002.0.tgz",
+      "integrity": "sha512-x972uKOydFn4Rb0PZJzLdNW59rH0KWC78Q2JbQzZpGlGt0DxjYdDRwBG6F42B1MyaEwHGqO/tkGc4r3/PRFfMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/nested-clients": "3.995.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.995.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.995.0.tgz",
-      "integrity": "sha512-7gq9gismVhESiRsSt0eYe1y1b6jS20LqLk+e/YSyPmGi9yHdndHQLIq73RbEJnK/QPpkQGFqq70M1mI46M1HGw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.11",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.11",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.995.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.10",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.23.2",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.16",
-        "@smithy/middleware-retry": "^4.4.33",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.32",
-        "@smithy/util-defaults-mode-node": "^4.2.35",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -909,13 +740,13 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
+      "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -923,16 +754,16 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.995.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.995.0.tgz",
-      "integrity": "sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==",
+      "version": "3.996.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
+      "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-endpoints": "^3.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -940,15 +771,15 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.3.tgz",
-      "integrity": "sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.6.tgz",
+      "integrity": "sha512-0YNVNgFyziCejXJx0rzxPiD2rkxTWco4c9wiMF6n37Tb9aQvIF8+t7GyEyIFCwQHZ0VMQaAl+nCZHOYz5I5EKw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/querystring-builder": "^4.2.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -969,29 +800,29 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
-      "integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.6.tgz",
+      "integrity": "sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/types": "^4.13.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.10.tgz",
-      "integrity": "sha512-LVXzICPlsheET+sE6tkcS47Q5HkSTrANIlqL1iFxGAY/wRQ236DX/PCAK56qMh9QJoXAfXfoRW0B0Og4R+X7Nw==",
+      "version": "3.973.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.2.tgz",
+      "integrity": "sha512-lpaIuekdkpw7VRiik0IZmd6TyvEUcuLgKZ5fKRGpCA3I4PjrD/XH15sSwW+OptxQjNU4DEzSxag70spC9SluvA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.11",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.17",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1007,14 +838,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.5.tgz",
-      "integrity": "sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
+      "integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.3.6",
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1305,16 +1136,16 @@
       ]
     },
     "node_modules/@cacheable/memory": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
-      "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/utils": "^2.3.3",
-        "@keyv/bigmap": "^1.3.0",
-        "hookified": "^1.14.0",
-        "keyv": "^5.5.5"
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@cacheable/node-cache": {
@@ -1333,36 +1164,34 @@
       }
     },
     "node_modules/@cacheable/utils": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
-      "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hashery": "^1.3.0",
-        "keyv": "^5.5.5"
+        "hashery": "^1.5.0",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.1.tgz",
-      "integrity": "sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.1.0.tgz",
+      "integrity": "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.0.1",
-        "picocolors": "^1.0.0",
+        "@clack/core": "1.1.0",
         "sisteransi": "^1.0.5"
       }
     },
@@ -1407,9 +1236,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
       "cpu": [
         "ppc64"
       ],
@@ -1424,9 +1253,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
@@ -1441,9 +1270,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
@@ -1458,9 +1287,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
@@ -1475,9 +1304,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
@@ -1492,9 +1321,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
@@ -1509,9 +1338,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
@@ -1526,9 +1355,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
@@ -1543,9 +1372,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
@@ -1560,9 +1389,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
@@ -1577,9 +1406,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
@@ -1594,9 +1423,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
@@ -1611,9 +1440,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
@@ -1628,9 +1457,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
@@ -1645,9 +1474,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1662,9 +1491,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
@@ -1679,9 +1508,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
@@ -1696,9 +1525,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
       "cpu": [
         "arm64"
       ],
@@ -1713,9 +1542,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
@@ -1730,9 +1559,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
       "cpu": [
         "arm64"
       ],
@@ -1747,9 +1576,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
@@ -1764,9 +1593,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
       "cpu": [
         "arm64"
       ],
@@ -1781,9 +1610,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
@@ -1798,9 +1627,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
@@ -1815,9 +1644,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
@@ -1832,9 +1661,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
@@ -1849,9 +1678,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.42.0.tgz",
-      "integrity": "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.44.0.tgz",
+      "integrity": "sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1905,9 +1734,9 @@
       }
     },
     "node_modules/@grammyjs/types": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.24.0.tgz",
-      "integrity": "sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.25.0.tgz",
+      "integrity": "sha512-iN9i5p+8ZOu9OMxWNcguojQfz4K/PDyMPOnL7PPCON+SoA/F8OKMH3uR7CVUkYfdNe0GCz8QOzAWrnqusQYFOg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1969,9 +1798,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2655,14 +2484,21 @@
       }
     },
     "node_modules/@line/bot-sdk/node_modules/@types/node": {
-      "version": "24.10.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.10.tgz",
-      "integrity": "sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==",
+      "version": "24.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@line/bot-sdk/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@lydell/node-pty": {
       "version": "1.2.0-beta.3",
@@ -3118,9 +2954,9 @@
       }
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.89.tgz",
-      "integrity": "sha512-7GjmkMirJHejeALCqUnZY3QwID7bbumOiLrqq2LKgxrdjdmxWQBTc6rcASa2u8wuWrH7qo4/4n/VNrOwCoKlKg==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.95.tgz",
+      "integrity": "sha512-lkg23ge+rgyhgUwXmlbkPEhuhHq/hUi/gXKH+4I7vO+lJrbNfEYcQdJLIGjKyXLQzgFiiyDAwh5vAe/tITAE+w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3135,23 +2971,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.89",
-        "@napi-rs/canvas-darwin-arm64": "0.1.89",
-        "@napi-rs/canvas-darwin-x64": "0.1.89",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.89",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.89",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.89",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.89",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.89",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.89",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.89",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.89"
+        "@napi-rs/canvas-android-arm64": "0.1.95",
+        "@napi-rs/canvas-darwin-arm64": "0.1.95",
+        "@napi-rs/canvas-darwin-x64": "0.1.95",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.95",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.95",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.95",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.95",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.95"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.89.tgz",
-      "integrity": "sha512-CXxQTXsjtQqKGENS8Ejv9pZOFJhOPIl2goenS+aU8dY4DygvkyagDhy/I07D1YLqrDtPvLEX5zZHt8qUdnuIpQ==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.95.tgz",
+      "integrity": "sha512-SqTh0wsYbetckMXEvHqmR7HKRJujVf1sYv1xdlhkifg6TlCSysz1opa49LlS3+xWuazcQcfRfmhA07HxxxGsAA==",
       "cpu": [
         "arm64"
       ],
@@ -3170,9 +3006,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.89.tgz",
-      "integrity": "sha512-k29cR/Zl20WLYM7M8YePevRu2VQRaKcRedYr1V/8FFHkyIQ8kShEV+MPoPGi+znvmd17Eqjy2Pk2F2kpM2umVg==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.95.tgz",
+      "integrity": "sha512-F7jT0Syu+B9DGBUBcMk3qCRIxAWiDXmvEjamwbYfbZl7asI1pmXZUnCOoIu49Wt0RNooToYfRDxU9omD6t5Xuw==",
       "cpu": [
         "arm64"
       ],
@@ -3191,9 +3027,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.89.tgz",
-      "integrity": "sha512-iUragqhBrA5FqU13pkhYBDbUD1WEAIlT8R2+fj6xHICY2nemzwMUI8OENDhRh7zuL06YDcRwENbjAVxOmaX9jg==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.95.tgz",
+      "integrity": "sha512-54eb2Ho15RDjYGXO/harjRznBrAvu+j5nQ85Z4Qd6Qg3slR8/Ja+Yvvy9G4yo7rdX6NR9GPkZeSTf2UcKXwaXw==",
       "cpu": [
         "x64"
       ],
@@ -3212,9 +3048,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.89.tgz",
-      "integrity": "sha512-y3SM9sfDWasY58ftoaI09YBFm35Ig8tosZqgahLJ2WGqawCusGNPV9P0/4PsrLOCZqGg629WxexQMY25n7zcvA==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.95.tgz",
+      "integrity": "sha512-hYaLCSLx5bmbnclzQc3ado3PgZ66blJWzjXp0wJmdwpr/kH+Mwhj6vuytJIomgksyJoCdIqIa4N6aiqBGJtJ5Q==",
       "cpu": [
         "arm"
       ],
@@ -3233,9 +3069,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.89.tgz",
-      "integrity": "sha512-NEoF9y8xq5fX8HG8aZunBom1ILdTwt7ayBzSBIwrmitk7snj4W6Fz/yN/ZOmlM1iyzHDNX5Xn0n+VgWCF8BEdA==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.95.tgz",
+      "integrity": "sha512-J7VipONahKsmScPZsipHVQBqpbZx4favaD8/enWzzlGcjiwycOoymL7f4tNeqdjK0su19bDOUt6mjp9gsPWYlw==",
       "cpu": [
         "arm64"
       ],
@@ -3254,9 +3090,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.89.tgz",
-      "integrity": "sha512-UQQkIEzV12/l60j1ziMjZ+mtodICNUbrd205uAhbyTw0t60CrC/EsKb5/aJWGq1wM0agvcgZV72JJCKfLS6+4w==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.95.tgz",
+      "integrity": "sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg==",
       "cpu": [
         "arm64"
       ],
@@ -3275,9 +3111,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.89.tgz",
-      "integrity": "sha512-1/VmEoFaIO6ONeeEMGoWF17wOYZOl5hxDC1ios2Bkz/oQjbJJ8DY/X22vWTmvuUKWWhBVlo63pxLGZbjJU/heA==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.95.tgz",
+      "integrity": "sha512-2IzCkW2RHRdcgF9W5/plHvYFpc6uikyjMb5SxjqmNxfyDFz9/HB89yhi8YQo0SNqrGRI7yBVDec7Pt+uMyRWsg==",
       "cpu": [
         "riscv64"
       ],
@@ -3296,9 +3132,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.89.tgz",
-      "integrity": "sha512-ebLuqkCuaPIkKgKH9q4+pqWi1tkPOfiTk5PM1LKR1tB9iO9sFNVSIgwEp+SJreTSbA2DK5rW8lQXiN78SjtcvA==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.95.tgz",
+      "integrity": "sha512-OV/ol/OtcUr4qDhQg8G7SdViZX8XyQeKpPsVv/j3+7U178FGoU4M+yIocdVo1ih/A8GQ63+LjF4jDoEjaVU8Pw==",
       "cpu": [
         "x64"
       ],
@@ -3317,9 +3153,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.89.tgz",
-      "integrity": "sha512-w+5qxHzplvA4BkHhCaizNMLLXiI+CfP84YhpHm/PqMub4u8J0uOAv+aaGv40rYEYra5hHRWr9LUd6cfW32o9/A==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.95.tgz",
+      "integrity": "sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ==",
       "cpu": [
         "x64"
       ],
@@ -3338,9 +3174,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.89.tgz",
-      "integrity": "sha512-DmyXa5lJHcjOsDC78BM3bnEECqbK3xASVMrKfvtT/7S7Z8NGQOugvu+L7b41V6cexCd34mBWgMOsjoEBceeB1Q==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.95.tgz",
+      "integrity": "sha512-aj0YbRpe8qVJ4OzMsK7NfNQePgcf9zkGFzNZ9mSuaxXzhpLHmlF2GivNdCdNOg8WzA/NxV6IU4c5XkXadUMLeA==",
       "cpu": [
         "arm64"
       ],
@@ -3359,9 +3195,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.89",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.89.tgz",
-      "integrity": "sha512-WMej0LZrIqIncQcx0JHaMXlnAG7sncwJh7obs/GBgp0xF9qABjwoRwIooMWCZkSansapKGNUHhamY6qEnFN7gA==",
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.95.tgz",
+      "integrity": "sha512-GA8leTTCfdjuHi8reICTIxU0081PhXvl3lzIniLUjeLACx9GubUiyzkwFb+oyeKLS5IAGZFLKnzAf4wm2epRlA==",
       "cpu": [
         "x64"
       ],
@@ -3738,9 +3574,9 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
-      "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3872,9 +3708,9 @@
       }
     },
     "node_modules/@octokit/plugin-retry": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.3.tgz",
-      "integrity": "sha512-vKGx1i3MC0za53IzYBSBXcrhmd+daQDzuZfYDd52X5S0M2otf3kVZTVP8bLA3EkU0lTvd1WEC2OlNNa4G+dohA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
+      "integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3907,16 +3743,17 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
-      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^11.0.2",
+        "@octokit/endpoint": "^11.0.3",
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
         "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -4221,9 +4058,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -4235,9 +4072,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -4249,9 +4086,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -4263,9 +4100,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -4277,9 +4114,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -4291,9 +4128,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -4305,9 +4142,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -4319,9 +4156,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -4333,9 +4170,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -4347,9 +4184,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -4361,9 +4198,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -4375,9 +4212,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -4389,9 +4226,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
@@ -4403,9 +4240,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -4417,9 +4254,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -4431,9 +4268,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -4445,9 +4282,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -4459,9 +4296,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -4473,9 +4310,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -4487,9 +4324,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -4501,9 +4338,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -4515,9 +4352,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -4529,9 +4366,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -4543,9 +4380,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -4557,9 +4394,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -4698,13 +4535,13 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
-      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4712,17 +4549,17 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
-      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
+      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4730,21 +4567,21 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.2.tgz",
-      "integrity": "sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.8.tgz",
+      "integrity": "sha512-f7uPeBi7ehmLT4YF2u9j3qx6lSnurG1DLXOsTtJrIRNDF7VXio4BGHQ+SQteN/BrUVudbkuL4v7oOsRCzq4BqA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.12",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4752,16 +4589,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
+      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4769,15 +4606,15 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.8.tgz",
-      "integrity": "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.11.tgz",
+      "integrity": "sha512-Sf39Ml0iVX+ba/bgMPxaXWAAFmHqYLTmbjAPfLPLY8CrYkRDEqZdUsKC1OwVMCdJXfAt0v4j49GIJ8DoSYAe6w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4785,14 +4622,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.8.tgz",
-      "integrity": "sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.11.tgz",
+      "integrity": "sha512-3rEpo3G6f/nRS7fQDsZmxw/ius6rnlIpz4UX6FlALEzz8JoSxFmdBt0SZnthis+km7sQo6q5/3e+UJcuQivoXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/eventstream-serde-universal": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4800,13 +4637,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.8.tgz",
-      "integrity": "sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.11.tgz",
+      "integrity": "sha512-XeNIA8tcP/GDWnnKkO7qEm/bg0B/bP9lvIXZBXcGZwZ+VYM8h8k9wuDvUODtdQ2Wcp2RcBkPTCSMmaniVHrMlA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4814,14 +4651,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.8.tgz",
-      "integrity": "sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.11.tgz",
+      "integrity": "sha512-fzbCh18rscBDTQSCrsp1fGcclLNF//nJyhjldsEl/5wCYmgpHblv5JSppQAyQI24lClsFT0wV06N1Porn0IsEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/eventstream-serde-universal": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4829,14 +4666,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.8.tgz",
-      "integrity": "sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.11.tgz",
+      "integrity": "sha512-MJ7HcI+jEkqoWT5vp+uoVaAjBrmxBtKhZTeynDRG/seEjJfqyg3SiqMMqyPnAMzmIfLaeJ/uiuSDP/l9AnMy/Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/eventstream-codec": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4844,16 +4681,16 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
+      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4861,15 +4698,15 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
-      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
+      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4877,13 +4714,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
-      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
+      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4891,9 +4728,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4904,14 +4741,14 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
-      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
+      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4919,19 +4756,19 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.16.tgz",
-      "integrity": "sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==",
+      "version": "4.4.22",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.22.tgz",
+      "integrity": "sha512-sc81w1o4Jy+/MAQlY3sQ8C7CmSpcvIi3TAzXblUv2hjG11BBSJi/Cw8vDx5BxMxapuH2I+Gc+45vWsgU07WZRQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.2",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/core": "^3.23.8",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4939,20 +4776,20 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.33",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.33.tgz",
-      "integrity": "sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==",
+      "version": "4.4.39",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.39.tgz",
+      "integrity": "sha512-MCVCxaCzuZgiHtHGV2Ke44nh6t4+8/tO+rTYOzrr2+G4nMLU/qbzNCWKBX54lyEaVcGQrfOJiG2f8imtiw+nIQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4960,14 +4797,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
-      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
+      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4975,13 +4812,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
-      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
+      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4989,15 +4826,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
-      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
+      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5005,16 +4842,16 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
-      "integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5022,13 +4859,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
-      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
+      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5036,13 +4873,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
-      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5050,14 +4887,14 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
-      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5065,13 +4902,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
-      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
+      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5079,26 +4916,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
-      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
+      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0"
+        "@smithy/types": "^4.13.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
-      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
+      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5106,19 +4943,19 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
+      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5126,18 +4963,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.5.tgz",
-      "integrity": "sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.2.tgz",
+      "integrity": "sha512-HezY3UuG0k4T+4xhFKctLXCA5N2oN+Rtv+mmL8Gt7YmsUY2yhmcLyW75qrSzldfj75IsCW/4UhY3s20KcFnZqA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.2",
-        "@smithy/middleware-endpoint": "^4.4.16",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.12",
+        "@smithy/core": "^3.23.8",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5145,9 +4982,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5158,14 +4995,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
-      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
+      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/querystring-parser": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5173,14 +5010,14 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5188,9 +5025,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5201,9 +5038,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5214,13 +5051,13 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5228,9 +5065,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5241,15 +5078,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.32",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.32.tgz",
-      "integrity": "sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==",
+      "version": "4.3.38",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.38.tgz",
+      "integrity": "sha512-c8P1mFLNxcsdAMabB8/VUQUbWzFmgujWi4bAXSggcqLYPc8V4U5abqFqOyn+dK4YT+q8UyCVkTO8807t4t2syA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5257,18 +5094,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.35",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.35.tgz",
-      "integrity": "sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==",
+      "version": "4.2.41",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.41.tgz",
+      "integrity": "sha512-/UG+9MT3UZAR0fLzOtMJMfWGcjjHvgggq924x/CRy8vRbL+yFf3Z6vETlvq8vDH92+31P/1gSOFoo7303wN8WQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.5",
-        "@smithy/types": "^4.12.0",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5276,14 +5113,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
-      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
+      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5291,9 +5128,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5304,13 +5141,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
-      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5318,14 +5155,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
+      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5333,19 +5170,19 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
-      "integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
+      "version": "4.5.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
+      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.10",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5353,9 +5190,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5366,13 +5203,13 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5380,9 +5217,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5439,9 +5276,9 @@
       "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.160",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.160.tgz",
-      "integrity": "sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==",
+      "version": "8.10.161",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
+      "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5568,13 +5405,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
-      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/qs": {
@@ -6046,9 +5883,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
-      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6056,13 +5893,6 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
       }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -6102,9 +5932,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6114,13 +5944,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/base64-js": {
@@ -6145,9 +5975,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6218,16 +6048,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -6276,16 +6106,16 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
-      "integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
+      "integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/memory": "^2.0.7",
-        "@cacheable/utils": "^2.3.3",
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
         "hookified": "^1.15.0",
-        "keyv": "^5.5.5",
+        "keyv": "^5.6.0",
         "qified": "^0.6.0"
       }
     },
@@ -7186,9 +7016,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7199,32 +7029,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -7466,10 +7296,23 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
       "dev": true,
       "funding": [
         {
@@ -7479,6 +7322,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -7699,9 +7543,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7850,9 +7694,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7945,18 +7789,17 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.1.tgz",
+      "integrity": "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0",
-        "gcp-metadata": "^8.0.0",
-        "google-logging-utils": "^1.0.0",
-        "gtoken": "^8.0.0",
+        "gaxios": "7.1.3",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
@@ -7994,14 +7837,14 @@
       "license": "ISC"
     },
     "node_modules/grammy": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.40.0.tgz",
-      "integrity": "sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.41.1.tgz",
+      "integrity": "sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@grammyjs/types": "3.24.0",
+        "@grammyjs/types": "3.25.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.4.3",
         "node-fetch": "^2.7.0"
@@ -8029,20 +7872,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/gtoken": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/has-flag": {
@@ -8092,9 +7921,9 @@
       "license": "ISC"
     },
     "node_modules/hashery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
-      "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+      "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8127,6 +7956,18 @@
         "node": "*"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hookified": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
@@ -8148,9 +7989,9 @@
       }
     },
     "node_modules/html-escaper": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8326,9 +8167,9 @@
       }
     },
     "node_modules/ipull": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.3.tgz",
-      "integrity": "sha512-ZMkxaopfwKHwmEuGDYx7giNBdLxbHbRCWcQVA1D2eqE4crUguupfxej6s7UqbidYEwT69dkyumYkY8DPHIxF9g==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.5.tgz",
+      "integrity": "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8479,13 +8320,13 @@
       "license": "MIT"
     },
     "node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8542,13 +8383,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-reports/node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -8576,9 +8410,9 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8610,6 +8444,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
+      "integrity": "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8756,7 +8597,7 @@
     "node_modules/libsignal": {
       "name": "@whiskeysockets/libsignal-node",
       "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+      "resolved": "git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
       "dev": true,
       "license": "GPL-3.0",
       "dependencies": {
@@ -8816,9 +8657,9 @@
       }
     },
     "node_modules/lifecycle-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-3.1.0.tgz",
-      "integrity": "sha512-kVvegv+r/icjIo1dkHv1hznVQi4FzEVglJD2IU4w07HzevIyH3BAYsFZzEIbBk/nNZjXHGgclJ5g9rz9QdBCLw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-3.1.1.tgz",
+      "integrity": "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8846,6 +8687,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/linkedom/node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
@@ -8982,9 +8830,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -9147,9 +8995,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9230,9 +9078,9 @@
       "license": "MIT"
     },
     "node_modules/music-metadata": {
-      "version": "11.11.2",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.11.2.tgz",
-      "integrity": "sha512-tJx+lsDg1bGUOxojKKj12BIvccBBUcVa6oWrvOchCF0WAQ9E5t/hK35ILp1z3wWrUSYtgg57LfRbvVMkxGIyzA==",
+      "version": "11.12.1",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.12.1.tgz",
+      "integrity": "sha512-j++ltLxHDb5VCXET9FzQ8bnueiLHwQKgCO7vcbkRH/3F7fRjPkv6qncGEJ47yFhmemcYtgvsOAlcQ1dRBTkDjg==",
       "dev": true,
       "funding": [
         {
@@ -9313,9 +9161,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10067,16 +9915,16 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.4.624",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.624.tgz",
-      "integrity": "sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==",
+      "version": "5.5.207",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.5.207.tgz",
+      "integrity": "sha512-WMqqw06w1vUt9ZfT0gOFhMf3wHsWhaCrxGrckGs5Cci6ybDW87IvPaOd2pnBwT6BJuP/CzXDZxjFgmSULLdsdw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.16.0 || >=22.3.0"
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.88",
+        "@napi-rs/canvas": "^0.1.95",
         "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
@@ -10155,9 +10003,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -10640,13 +10488,13 @@
       "license": "ISC"
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10673,9 +10521,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10689,31 +10537,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -10773,9 +10621,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -11058,9 +10906,9 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.30.0.tgz",
-      "integrity": "sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==",
+      "version": "3.32.3",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.32.3.tgz",
+      "integrity": "sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11146,9 +10994,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11479,13 +11327,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -11541,10 +11389,17 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
       "dev": true,
       "funding": [
         {
@@ -11628,6 +11483,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -11651,13 +11523,13 @@
       }
     },
     "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11961,9 +11833,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -12041,7 +11913,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,18 @@
       "name": "@37signals/openclaw-basecamp",
       "version": "0.1.0",
       "dependencies": {
-        "@37signals/basecamp": "github:basecamp/basecamp-sdk#main",
+        "@37signals/basecamp": "github:basecamp/basecamp-sdk#63388edfc75e41fdeaf1449013c224330b7b055b",
         "typescript": "^5.0.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.5",
         "@vitest/coverage-v8": "^3.2.4",
         "openclaw": "2026.2.19-2",
         "vitest": "3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@37signals/basecamp": {
@@ -1095,6 +1099,169 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.5.tgz",
+      "integrity": "sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.5",
+        "@biomejs/cli-darwin-x64": "2.4.5",
+        "@biomejs/cli-linux-arm64": "2.4.5",
+        "@biomejs/cli-linux-arm64-musl": "2.4.5",
+        "@biomejs/cli-linux-x64": "2.4.5",
+        "@biomejs/cli-linux-x64-musl": "2.4.5",
+        "@biomejs/cli-win32-arm64": "2.4.5",
+        "@biomejs/cli-win32-x64": "2.4.5"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.5.tgz",
+      "integrity": "sha512-lGS4Nd5O3KQJ6TeWv10mElnx1phERhBxqGP/IKq0SvZl78kcWDFMaTtVK+w3v3lusRFxJY78n07PbKplirsU5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.5.tgz",
+      "integrity": "sha512-6MoH4tyISIBNkZ2Q5T1R7dLd5BsITb2yhhhrU9jHZxnNSNMWl+s2Mxu7NBF8Y3a7JJcqq9nsk8i637z4gqkJxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.5.tgz",
+      "integrity": "sha512-U1GAG6FTjhAO04MyH4xn23wRNBkT6H7NentHh+8UxD6ShXKBm5SY4RedKJzkUThANxb9rUKIPc7B8ew9Xo/cWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.5.tgz",
+      "integrity": "sha512-iqLDgpzobG7gpBF0fwEVS/LT8kmN7+S0E2YKFDtqliJfzNLnAiV2Nnyb+ehCDCJgAZBASkYHR2o60VQWikpqIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.5.tgz",
+      "integrity": "sha512-NdODlSugMzTlENPTa4z0xB82dTUlCpsrOxc43///aNkTLblIYH4XpYflBbf5ySlQuP8AA4AZd1qXhV07IdrHdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.5.tgz",
+      "integrity": "sha512-NlKa7GpbQmNhZf9kakQeddqZyT7itN7jjWdakELeXyTU3pg/83fTysRRDPJD0akTfKDl6vZYNT9Zqn4MYZVBOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.5.tgz",
+      "integrity": "sha512-EBfrTqRIWOFSd7CQb/0ttjHMR88zm3hGravnDwUA9wHAaCAYsULKDebWcN5RmrEo1KBtl/gDVJMrFjNR0pdGUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.5.tgz",
+      "integrity": "sha512-Pmhv9zT95YzECfjEHNl3mN9Vhusw9VA5KHY0ZvlGsxsjwS5cb7vpRnHzJIv0vG7jB0JI7xEaMH9ddfZm/RozBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@borewit/text-codec": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw Basecamp channel plugin — Campfire, cards, todos, check-ins, pings",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.5"
   },
   "scripts": {
     "test": "vitest run",
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@37signals/basecamp": "github:basecamp/basecamp-sdk#63388edfc75e41fdeaf1449013c224330b7b055b",
+    "@37signals/basecamp": "git+https://github.com/basecamp/basecamp-sdk.git#63388edfc75e41fdeaf1449013c224330b7b055b",
     "typescript": "^5.0.0",
     "zod": "^4.3.6"
   }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "0.1.0",
   "description": "OpenClaw Basecamp channel plugin — Campfire, cards, todos, check-ins, pings",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",
@@ -30,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@37signals/basecamp": "github:basecamp/basecamp-sdk#main",
+    "@37signals/basecamp": "github:basecamp/basecamp-sdk#63388edfc75e41fdeaf1449013c224330b7b055b",
     "typescript": "^5.0.0",
     "zod": "^4.3.6"
   }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write ."
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.5",
     "@vitest/coverage-v8": "^3.2.4",
     "openclaw": "2026.2.19-2",
     "vitest": "3"

--- a/src/adapters/actions.ts
+++ b/src/adapters/actions.ts
@@ -10,15 +10,15 @@
 
 import type {
   ChannelMessageActionAdapter,
-  ChannelMessageActionName,
   ChannelMessageActionContext,
+  ChannelMessageActionName,
   ChannelToolSend,
 } from "openclaw/plugin-sdk";
 import { jsonResult, readStringParam } from "openclaw/plugin-sdk";
-import { postCampfireLine, postComment } from "../outbound/send.js";
-import { markdownToBasecampHtml } from "../outbound/format.js";
-import { resolveBasecampAccount } from "../config.js";
 import { getClient, numId } from "../basecamp-client.js";
+import { resolveBasecampAccount } from "../config.js";
+import { markdownToBasecampHtml } from "../outbound/format.js";
+import { postCampfireLine, postComment } from "../outbound/send.js";
 
 // ---------------------------------------------------------------------------
 // Supported action set
@@ -174,10 +174,7 @@ async function handleReact(ctx: ChannelMessageActionContext) {
 
   try {
     const client = getClient(account);
-    const result = await client.boosts.createForRecording(
-      numId("recording", recordingId),
-      { content: emoji },
-    );
+    const result = await client.boosts.createForRecording(numId("recording", recordingId), { content: emoji });
     return jsonResult({ ok: true, target: "boost", boostId: (result as any)?.id });
   } catch (err) {
     console.error(`[basecamp:${accountId}] react error: bucket=${bucketId} recording=${recordingId}`, err);

--- a/src/adapters/agent-prompt.ts
+++ b/src/adapters/agent-prompt.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk";
-import type { ResolvedBasecampAccount, BasecampChannelConfig } from "../types.js";
+import type { BasecampChannelConfig, ResolvedBasecampAccount } from "../types.js";
 
 // ChannelAgentPromptAdapter is not exported from the SDK, so extract it from ChannelPlugin.
 type AgentPromptAdapter = NonNullable<ChannelPlugin<ResolvedBasecampAccount>["agentPrompt"]>;
@@ -40,15 +40,14 @@ export const basecampAgentPromptAdapter: AgentPromptAdapter = {
       const va = section.virtualAccounts[accountId];
       hints.push(
         `This account is project-scoped to bucket ${va.bucketId}. ` +
-        `Messages are limited to this specific Basecamp project.`,
+          `Messages are limited to this specific Basecamp project.`,
       );
     }
 
     // Persona mapping context
     if (section.personas && Object.keys(section.personas).length > 0) {
       hints.push(
-        "This channel uses persona mappings — different agents may send " +
-        "as different Basecamp identities.",
+        "This channel uses persona mappings — different agents may send " + "as different Basecamp identities.",
       );
     }
 
@@ -58,9 +57,7 @@ export const basecampAgentPromptAdapter: AgentPromptAdapter = {
         .filter(([, v]) => v?.requireMention === true)
         .map(([k]) => k);
       if (mentionBuckets.length > 0) {
-        hints.push(
-          `Some projects require @mention to trigger the agent: bucket(s) ${mentionBuckets.join(", ")}.`,
-        );
+        hints.push(`Some projects require @mention to trigger the agent: bucket(s) ${mentionBuckets.join(", ")}.`);
       }
     }
 

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -21,9 +21,9 @@
  *   basecamp_api_write    — POST/PUT/DELETE any Basecamp 3 resource
  */
 
-import type { ChannelAgentTool } from "openclaw/plugin-sdk";
-import { Type } from "@sinclair/typebox";
 import type { Static } from "@sinclair/typebox";
+import { Type } from "@sinclair/typebox";
+import type { ChannelAgentTool } from "openclaw/plugin-sdk";
 import type { BasecampClient } from "../basecamp-client.js";
 import { getClient, numId, rawOrThrow } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
@@ -56,21 +56,29 @@ const ReopenTodoParams = Type.Object({
 const ReadHistoryParams = Type.Object({
   bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
   recordingId: Type.String({ description: "Recording ID (chat transcript, todo, card, message, etc.)" }),
-  type: Type.Union([
-    Type.Literal("comments"),
-    Type.Literal("campfire"),
-  ], { description: "Type of history: 'comments' for recording comments, 'campfire' for chat lines" }),
-  limit: Type.Optional(Type.Number({
-    description: "Maximum number of messages to return (default 20, max 50)",
-    minimum: 1,
-    maximum: 50,
-  })),
+  type: Type.Union([Type.Literal("comments"), Type.Literal("campfire")], {
+    description: "Type of history: 'comments' for recording comments, 'campfire' for chat lines",
+  }),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Maximum number of messages to return (default 20, max 50)",
+      minimum: 1,
+      maximum: 50,
+    }),
+  ),
 });
 
 const AddBoostParams = Type.Object({
   bucketId: Type.String({ description: "Basecamp project (bucket) ID" }),
-  recordingId: Type.String({ description: "Recording ID to boost (any recording: comment, todo, campfire line, etc.)" }),
-  content: Type.Optional(Type.String({ description: "Boost content — an emoji or short celebratory text (e.g., '👍', '🎉', 'Congrats!'). Defaults to '👍'." })),
+  recordingId: Type.String({
+    description: "Recording ID to boost (any recording: comment, todo, campfire line, etc.)",
+  }),
+  content: Type.Optional(
+    Type.String({
+      description:
+        "Boost content — an emoji or short celebratory text (e.g., '👍', '🎉', 'Congrats!'). Defaults to '👍'.",
+    }),
+  ),
 });
 
 const MoveCardParams = Type.Object({
@@ -95,15 +103,15 @@ const AnswerCheckinParams = Type.Object({
 
 const ApiReadParams = Type.Object({
   path: Type.String({ description: "Basecamp API path (e.g., /buckets/123/todos/456.json)" }),
-  query: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "URL query parameters (e.g., {completed: 'true'})" })),
+  query: Type.Optional(
+    Type.Record(Type.String(), Type.String(), { description: "URL query parameters (e.g., {completed: 'true'})" }),
+  ),
 });
 
 const ApiWriteParams = Type.Object({
-  method: Type.Union([
-    Type.Literal("POST"),
-    Type.Literal("PUT"),
-    Type.Literal("DELETE"),
-  ], { description: "HTTP method" }),
+  method: Type.Union([Type.Literal("POST"), Type.Literal("PUT"), Type.Literal("DELETE")], {
+    description: "HTTP method",
+  }),
   path: Type.String({ description: "Basecamp API path" }),
   body: Type.Optional(Type.Unknown({ description: "JSON request body" })),
 });
@@ -173,21 +181,19 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
     {
       name: "basecamp_create_todo",
       label: "Create Basecamp To-Do",
-      description: "Create a new to-do item in a Basecamp to-do list. Requires the project (bucket) ID and to-do list ID.",
+      description:
+        "Create a new to-do item in a Basecamp to-do list. Requires the project (bucket) ID and to-do list ID.",
       parameters: CreateTodoParams,
       execute: async (_toolCallId: string, rawParams: unknown) => {
         const params = rawParams as CreateTodoInput;
         try {
-          const result = await client.todos.create(
-            numId("todolist", params.todolistId),
-            {
-              content: params.content,
-              description: params.description,
-              assigneeIds: params.assigneeIds,
-              dueOn: params.dueOn,
-              startsOn: params.startsOn,
-            },
-          );
+          const result = await client.todos.create(numId("todolist", params.todolistId), {
+            content: params.content,
+            description: params.description,
+            assigneeIds: params.assigneeIds,
+            dueOn: params.dueOn,
+            startsOn: params.startsOn,
+          });
           return toolOk({ todoId: (result as any)?.id, title: (result as any)?.title });
         } catch (err) {
           return toolErr(String(err));
@@ -212,7 +218,8 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
     {
       name: "basecamp_reopen_todo",
       label: "Reopen Basecamp To-Do",
-      description: "Reopen a completed Basecamp to-do (mark as incomplete). Requires the project (bucket) ID and to-do ID.",
+      description:
+        "Reopen a completed Basecamp to-do (mark as incomplete). Requires the project (bucket) ID and to-do ID.",
       parameters: ReopenTodoParams,
       execute: async (_toolCallId: string, rawParams: unknown) => {
         const { bucketId, todoId } = rawParams as ReopenTodoInput;
@@ -236,14 +243,13 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         const { bucketId, recordingId, type, limit } = rawParams as ReadHistoryInput;
         const effectiveLimit = Math.min(limit ?? DEFAULT_HISTORY_LIMIT, 50);
 
-        const path = type === "campfire"
-          ? `/buckets/${bucketId}/chats/${recordingId}/lines.json`
-          : `/buckets/${bucketId}/recordings/${recordingId}/comments.json`;
+        const path =
+          type === "campfire"
+            ? `/buckets/${bucketId}/chats/${recordingId}/lines.json`
+            : `/buckets/${bucketId}/recordings/${recordingId}/comments.json`;
 
         try {
-          const entries = await rawOrThrow<BasecampCommentOrLine[]>(
-            await client.raw.GET(path as any, {}),
-          );
+          const entries = await rawOrThrow<BasecampCommentOrLine[]>(await client.raw.GET(path as any, {}));
           const items = Array.isArray(entries) ? entries : [];
           const recent = items.slice(-effectiveLimit);
 
@@ -272,10 +278,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         const params = rawParams as AddBoostInput;
         const content = params.content || "👍";
         try {
-          const result = await client.boosts.createForRecording(
-            numId("recording", params.recordingId),
-            { content },
-          );
+          const result = await client.boosts.createForRecording(numId("recording", params.recordingId), { content });
           return toolOk({ boostId: (result as any)?.id });
         } catch (err) {
           return toolErr(String(err));
@@ -310,10 +313,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
       execute: async (_toolCallId: string, rawParams: unknown) => {
         const { bucketId, messageBoardId, subject, content, categoryId } = rawParams as PostMessageInput;
         try {
-          const result = await client.messages.create(
-            numId("board", messageBoardId),
-            { subject, content, categoryId },
-          );
+          const result = await client.messages.create(numId("board", messageBoardId), { subject, content, categoryId });
           return toolOk({ messageId: (result as any)?.id, subject: (result as any)?.subject });
         } catch (err) {
           return toolErr(String(err));
@@ -324,16 +324,12 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
       name: "basecamp_answer_checkin",
       label: "Answer Basecamp Check-in",
       description:
-        "Answer a Basecamp check-in question. " +
-        "Requires the project (bucket) ID, question ID, and answer content.",
+        "Answer a Basecamp check-in question. " + "Requires the project (bucket) ID, question ID, and answer content.",
       parameters: AnswerCheckinParams,
       execute: async (_toolCallId: string, rawParams: unknown) => {
         const { bucketId, questionId, content } = rawParams as AnswerCheckinInput;
         try {
-          const result = await client.checkins.createAnswer(
-            numId("question", questionId),
-            { content },
-          );
+          const result = await client.checkins.createAnswer(numId("question", questionId), { content });
           return toolOk({ answerId: (result as any)?.id });
         } catch (err) {
           return toolErr(String(err));

--- a/src/adapters/directory.ts
+++ b/src/adapters/directory.ts
@@ -6,9 +6,9 @@
  */
 
 import type { ChannelDirectoryAdapter, ChannelDirectoryEntry, OpenClawConfig } from "openclaw/plugin-sdk";
-import type { ResolvedBasecampAccount, BasecampPerson, BasecampProject, BasecampChannelConfig } from "../types.js";
-import { resolveBasecampAccount } from "../config.js";
 import { getClient, numId } from "../basecamp-client.js";
+import { resolveBasecampAccount } from "../config.js";
+import type { BasecampChannelConfig, BasecampPerson, BasecampProject, ResolvedBasecampAccount } from "../types.js";
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
   return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
@@ -69,7 +69,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
     let people: Array<{ id: number; name: string; email_address: string; avatar_url?: string }>;
     try {
       const client = getClient(account);
-      people = await client.people.list() as any;
+      people = (await client.people.list()) as any;
     } catch {
       return [];
     }
@@ -79,11 +79,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
     let filtered = people;
     if (query) {
       const q = query.toLowerCase();
-      filtered = people.filter(
-        (p) =>
-          p.name.toLowerCase().includes(q) ||
-          p.email_address.toLowerCase().includes(q),
-      );
+      filtered = people.filter((p) => p.name.toLowerCase().includes(q) || p.email_address.toLowerCase().includes(q));
     }
 
     return filtered.map((p) => ({
@@ -120,7 +116,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
     let projects: Array<{ id: number; name: string }>;
     try {
       const client = getClient(account);
-      projects = await client.projects.list() as any;
+      projects = (await client.projects.list()) as any;
     } catch {
       return [];
     }
@@ -150,7 +146,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
     let people: Array<{ id: number; name: string; email_address: string; avatar_url?: string }>;
     try {
       const client = getClient(account);
-      people = await client.people.listForProject(projectId) as any;
+      people = (await client.people.listForProject(projectId)) as any;
     } catch {
       return [];
     }

--- a/src/adapters/groups.ts
+++ b/src/adapters/groups.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ChannelGroupAdapter, ChannelGroupContext } from "openclaw/plugin-sdk";
-import type { BasecampChannelConfig, BasecampBucketConfig } from "../types.js";
+import type { BasecampBucketConfig, BasecampChannelConfig } from "../types.js";
 
 function getBasecampSection(cfg: Record<string, unknown>): BasecampChannelConfig | undefined {
   const channels = cfg.channels as Record<string, unknown> | undefined;

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -13,21 +13,21 @@
  * it's a standalone wizard function called from the onboarding adapter.
  */
 
+import type { AuthorizationInfo } from "@37signals/basecamp";
+import { discoverIdentity } from "@37signals/basecamp/oauth";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { normalizeAccountId } from "openclaw/plugin-sdk";
-import type { AuthorizationInfo } from "@37signals/basecamp";
-import type { BasecampChannelConfig } from "../types.js";
-import type { ResolvedBasecampAccount } from "../types.js";
 import { cliMe, cliProfileList } from "../basecamp-cli.js";
 import { listBasecampAccountIds } from "../config.js";
-import {
-  interactiveLogin,
-  resolveTokenFilePath,
-} from "../oauth-credentials.js";
-import { discoverIdentity } from "@37signals/basecamp/oauth";
+import { interactiveLogin, resolveTokenFilePath } from "../oauth-credentials.js";
+import type { BasecampChannelConfig, ResolvedBasecampAccount } from "../types.js";
 
 type WizardPrompter = {
-  select: (opts: { message: string; options: Array<{ value: string; label: string }>; initialValue?: string }) => Promise<string>;
+  select: (opts: {
+    message: string;
+    options: Array<{ value: string; label: string }>;
+    initialValue?: string;
+  }) => Promise<string>;
   text: (opts: { message: string; validate?: (value: string | undefined) => string | undefined }) => Promise<string>;
   note: (message: string, title?: string) => Promise<void>;
 };
@@ -49,19 +49,16 @@ type AuthMethod = "browser" | "cli";
 // Step 1: Auth method choice
 // ---------------------------------------------------------------------------
 
-async function chooseAuthMethod(
-  prompter: WizardPrompter,
-  cliAvailable: boolean,
-): Promise<AuthMethod> {
+async function chooseAuthMethod(prompter: WizardPrompter, cliAvailable: boolean): Promise<AuthMethod> {
   if (!cliAvailable) return "browser";
 
-  return await prompter.select({
+  return (await prompter.select({
     message: "How do you want to authenticate this identity?",
     options: [
       { value: "browser", label: "Authenticate with browser (recommended)" },
       { value: "cli", label: "Use existing Basecamp CLI profile" },
     ],
-  }) as AuthMethod;
+  })) as AuthMethod;
 }
 
 // ---------------------------------------------------------------------------
@@ -195,10 +192,7 @@ async function selectBasecampAccount(
   if (bc3.length === 0) return undefined;
 
   if (bc3.length === 1) {
-    await prompter.note(
-      `Using account: ${bc3[0]!.name} (${bc3[0]!.id})`,
-      "Basecamp account",
-    );
+    await prompter.note(`Using account: ${bc3[0]!.name} (${bc3[0]!.id})`, "Basecamp account");
     return String(bc3[0]!.id);
   }
 
@@ -227,10 +221,7 @@ async function selectBasecampAccount(
  * 6. Optional persona mapping
  * 7. Apply config (with auth-method conflict cleanup)
  */
-export async function hatchIdentity(
-  cfg: OpenClawConfig,
-  prompter: WizardPrompter,
-): Promise<HatchResult> {
+export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompter): Promise<HatchResult> {
   // Probe CLI availability
   let profileNames: string[] = [];
   try {
@@ -462,13 +453,14 @@ export async function hatchIdentity(
   if (cliProfile) accountEntry.cliProfile = cliProfile;
 
   // Build updated channel-level oauth if credentials were prompted
-  const oauthSection = promptedClientId && oauthClientId
-    ? {
-        ...(section.oauth ?? {}),
-        clientId: oauthClientId,
-        ...(promptedClientSecret && oauthClientSecret ? { clientSecret: oauthClientSecret } : {}),
-      }
-    : section.oauth;
+  const oauthSection =
+    promptedClientId && oauthClientId
+      ? {
+          ...(section.oauth ?? {}),
+          clientId: oauthClientId,
+          ...(promptedClientSecret && oauthClientSecret ? { clientSecret: oauthClientSecret } : {}),
+        }
+      : section.oauth;
 
   const next: OpenClawConfig = {
     ...cfg,

--- a/src/adapters/heartbeat.ts
+++ b/src/adapters/heartbeat.ts
@@ -9,8 +9,8 @@
  */
 
 import type { ChannelHeartbeatAdapter } from "openclaw/plugin-sdk";
-import { resolveBasecampAccount } from "../config.js";
 import { getClient } from "../basecamp-client.js";
+import { resolveBasecampAccount } from "../config.js";
 
 export const basecampHeartbeatAdapter: ChannelHeartbeatAdapter = {
   checkReady: async ({ cfg, accountId }) => {

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -17,7 +17,13 @@ import {
   resolveDefaultBasecampAccountId,
   resolveBasecampAccount,
 } from "../config.js";
-import { cliProfileList, extractCliBootstrapToken } from "../basecamp-cli.js";
+import {
+  cliProfileList,
+  cliProfileListFull,
+  extractCliBootstrapToken,
+  exportCliCredentials,
+  type CliProfile,
+} from "../basecamp-cli.js";
 
 const channel = "basecamp" as const;
 
@@ -120,15 +126,15 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
 
     // Step 2: Auth method choice
     // Probe for CLI availability
-    let cliProfileNames: string[] = [];
+    let cliProfiles: CliProfile[] = [];
     try {
-      const profileResult = await cliProfileList();
-      cliProfileNames = profileResult.data;
+      const profileResult = await cliProfileListFull();
+      cliProfiles = profileResult.data;
     } catch {
       // CLI not installed or profiles unavailable
     }
 
-    const cliAvailable = cliProfileNames.length > 0;
+    const cliAvailable = cliProfiles.length > 0;
 
     type AuthMethod = "oauth" | "cli";
     let authMethod: AuthMethod;
@@ -161,7 +167,11 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
 
       if (!clientId) {
         await prompter.note(
-          "You'll need a Basecamp OAuth app. Register one at:\nhttps://launchpad.37signals.com/integrations",
+          "You'll need a Basecamp OAuth app. Register one at:\n" +
+          "https://launchpad.37signals.com/integrations\n\n" +
+          "When creating the app, set the redirect URI to:\n" +
+          "http://localhost:14923/callback\n\n" +
+          "You can leave the other fields as defaults.",
           "OAuth setup",
         );
         const enteredId = await prompter.text({
@@ -196,18 +206,22 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
 
       // Build a token provider for later use if needed
     } else {
-      // CLI path — discover identity via CLI, then chain into OAuth
-      if (cliProfileNames.length > 1) {
+      // CLI path — import credentials from existing CLI profile
+      let selectedCliProfile: CliProfile | undefined;
+
+      if (cliProfiles.length > 1) {
         const choice = await prompter.select({
           message: "Basecamp CLI profile",
           options: [
-            ...cliProfileNames.map((name) => ({ value: name, label: name })),
+            ...cliProfiles.map((p) => ({ value: p.name, label: p.name })),
             { value: "__none__", label: "Use default (no profile)" },
           ],
         });
-        selectedProfile = choice === "__none__" ? undefined : choice;
-      } else if (cliProfileNames.length === 1) {
-        selectedProfile = cliProfileNames[0];
+        selectedCliProfile = choice === "__none__" ? undefined : cliProfiles.find((p) => p.name === choice);
+        selectedProfile = selectedCliProfile?.name;
+      } else if (cliProfiles.length === 1) {
+        selectedCliProfile = cliProfiles[0];
+        selectedProfile = selectedCliProfile?.name;
       }
 
       // Extract token for identity discovery
@@ -215,6 +229,26 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
         accessToken = await extractCliBootstrapToken(selectedProfile);
       } catch {
         // Token extraction failed — will fall back to manual entry
+      }
+
+      // Import CLI's stored OAuth credentials for persistent use
+      if (selectedCliProfile) {
+        const cliCreds = exportCliCredentials(selectedCliProfile.base_url);
+        if (cliCreds) {
+          const { resolveTokenFilePath } = await import("../oauth-credentials.js");
+          const { FileTokenStore } = await import("@37signals/basecamp/oauth");
+          oauthTokenFile = resolveTokenFilePath(accountId);
+          const store = new FileTokenStore(oauthTokenFile);
+          await store.save({
+            accessToken: cliCreds.accessToken,
+            refreshToken: cliCreds.refreshToken,
+            tokenType: "Bearer",
+            expiresAt: cliCreds.expiresAt ? new Date(cliCreds.expiresAt * 1000) : undefined,
+          });
+          // Store the CLI's client credentials for token refresh
+          promptedClientId = cliCreds.clientId;
+          promptedClientSecret = cliCreds.clientSecret || undefined;
+        }
       }
     }
 
@@ -283,57 +317,13 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
       ...(basecampAccountId ? { basecampAccountId } : {}),
     };
 
-    // CLI path chains into OAuth for persistent token
+    // CLI path: if credential import failed above, fall back to noting the gap
     if (authMethod === "cli" && !oauthTokenFile) {
-      const resolved = resolveBasecampAccount(cfg, accountId);
-      let clientId = resolved.oauthClientId;
-      let clientSecret = resolved.oauthClientSecret;
-
-      if (!clientId) {
-        await prompter.note(
-          "You'll need a Basecamp OAuth app. Register one at:\nhttps://launchpad.37signals.com/integrations",
-          "OAuth setup",
-        );
-        const enteredId = await prompter.text({
-          message: "Enter your Basecamp OAuth app Client ID",
-          validate: (value) => (value?.trim() ? undefined : "Required"),
-        });
-        clientId = String(enteredId).trim();
-        promptedClientId = clientId;
-
-        const enteredSecret = await prompter.text({
-          message: "Client Secret (leave blank to skip)",
-        });
-        const secretVal = String(enteredSecret).trim();
-        if (secretVal) {
-          clientSecret = secretVal;
-          promptedClientSecret = secretVal;
-        }
-      }
-
-      const { interactiveLogin, resolveTokenFilePath } = await import("../oauth-credentials.js");
-      oauthTokenFile = resolveTokenFilePath(accountId);
-      const partialAccount = {
-        ...resolved,
-        accountId,
-        oauthClientId: clientId,
-        oauthClientSecret: clientSecret,
-        config: { ...resolved.config, oauthTokenFile },
-      };
-      const oauthToken = await interactiveLogin(partialAccount, { clientId, clientSecret });
-
-      // Verify OAuth identity matches CLI-discovered identity
-      try {
-        const { discoverIdentity } = await import("@37signals/basecamp/oauth");
-        const oauthInfo = await discoverIdentity(oauthToken.accessToken);
-        const oauthPersonId = String(oauthInfo.identity.id);
-        if (oauthPersonId !== personId) {
-          personId = oauthPersonId;
-          accountPatch.personId = personId;
-        }
-      } catch {
-        // Non-fatal: proceed with CLI-discovered identity
-      }
+      await prompter.note(
+        "Could not import credentials from the CLI.\n" +
+        "Token refresh will not work until you re-run onboarding with OAuth.",
+        "Warning",
+      );
     }
 
     accountPatch.oauthTokenFile = oauthTokenFile;

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -30,6 +30,69 @@ const channel = "basecamp" as const;
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Run the interactive OAuth login flow, prompting for client credentials if
+ * none are available. Used by both the primary OAuth path and the CLI
+ * fallback when credential import fails.
+ */
+async function runOAuthLogin(params: { cfg: OpenClawConfig; accountId: string; prompter: any }): Promise<{
+  accessToken: string;
+  oauthTokenFile: string;
+  promptedClientId?: string;
+  promptedClientSecret?: string;
+}> {
+  const { cfg, accountId, prompter } = params;
+  const resolved = resolveBasecampAccount(cfg, accountId);
+  let clientId = resolved.oauthClientId;
+  let clientSecret = resolved.oauthClientSecret;
+  let promptedClientId: string | undefined;
+  let promptedClientSecret: string | undefined;
+
+  if (!clientId) {
+    await prompter.note(
+      "You'll need a Basecamp OAuth app. Register one at:\n" +
+        "https://launchpad.37signals.com/integrations\n\n" +
+        "When creating the app, set the redirect URI to:\n" +
+        "http://localhost:14923/callback\n\n" +
+        "You can leave the other fields as defaults.",
+      "OAuth setup",
+    );
+    const enteredId = await prompter.text({
+      message: "Enter your Basecamp OAuth app Client ID",
+      validate: (value: string) => (value?.trim() ? undefined : "Required"),
+    });
+    clientId = String(enteredId).trim();
+    promptedClientId = clientId;
+
+    const enteredSecret = await prompter.text({
+      message: "Client Secret (leave blank to skip)",
+    });
+    const secretVal = String(enteredSecret).trim();
+    if (secretVal) {
+      clientSecret = secretVal;
+      promptedClientSecret = secretVal;
+    }
+  }
+
+  const { interactiveLogin, resolveTokenFilePath } = await import("../oauth-credentials.js");
+  const oauthTokenFile = resolveTokenFilePath(accountId);
+  const partialAccount = {
+    ...resolved,
+    accountId,
+    oauthClientId: clientId,
+    oauthClientSecret: clientSecret,
+    config: { ...resolved.config, oauthTokenFile },
+  };
+  const token = await interactiveLogin(partialAccount, { clientId, clientSecret });
+
+  return {
+    accessToken: token.accessToken,
+    oauthTokenFile,
+    promptedClientId,
+    promptedClientSecret,
+  };
+}
+
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
   return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
 }
@@ -156,51 +219,11 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
     let cliImportedClientSecret: string | undefined;
 
     if (authMethod === "oauth") {
-      // Resolve clientId: check resolved account's oauthClientId (falls through to channel-level)
-      const resolved = resolveBasecampAccount(cfg, accountId);
-      let clientId = resolved.oauthClientId;
-      let clientSecret = resolved.oauthClientSecret;
-
-      if (!clientId) {
-        await prompter.note(
-          "You'll need a Basecamp OAuth app. Register one at:\n" +
-            "https://launchpad.37signals.com/integrations\n\n" +
-            "When creating the app, set the redirect URI to:\n" +
-            "http://localhost:14923/callback\n\n" +
-            "You can leave the other fields as defaults.",
-          "OAuth setup",
-        );
-        const enteredId = await prompter.text({
-          message: "Enter your Basecamp OAuth app Client ID",
-          validate: (value) => (value?.trim() ? undefined : "Required"),
-        });
-        clientId = String(enteredId).trim();
-        promptedClientId = clientId;
-
-        const enteredSecret = await prompter.text({
-          message: "Client Secret (leave blank to skip)",
-        });
-        const secretVal = String(enteredSecret).trim();
-        if (secretVal) {
-          clientSecret = secretVal;
-          promptedClientSecret = secretVal;
-        }
-      }
-
-      // Run interactive login
-      const { interactiveLogin, resolveTokenFilePath } = await import("../oauth-credentials.js");
-      oauthTokenFile = resolveTokenFilePath(accountId);
-      const partialAccount = {
-        ...resolved,
-        accountId,
-        oauthClientId: clientId,
-        oauthClientSecret: clientSecret,
-        config: { ...resolved.config, oauthTokenFile },
-      };
-      const token = await interactiveLogin(partialAccount, { clientId, clientSecret });
-      accessToken = token.accessToken;
-
-      // Build a token provider for later use if needed
+      const oauthResult = await runOAuthLogin({ cfg, accountId, prompter });
+      accessToken = oauthResult.accessToken;
+      oauthTokenFile = oauthResult.oauthTokenFile;
+      promptedClientId = oauthResult.promptedClientId;
+      promptedClientSecret = oauthResult.promptedClientSecret;
     } else {
       // CLI path — import credentials from existing CLI profile
       let selectedCliProfile: CliProfile | undefined;
@@ -251,6 +274,17 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
           cliImportedClientSecret = cliCreds.clientSecret || undefined;
         }
       }
+    }
+
+    // CLI path: if credential import failed, fall back to browser OAuth.
+    // Must run before identity discovery so the OAuth token is available.
+    if (authMethod === "cli" && !oauthTokenFile) {
+      await prompter.note("Could not import CLI credentials. Falling back to browser OAuth.", "Note");
+      const oauthResult = await runOAuthLogin({ cfg, accountId, prompter });
+      accessToken = oauthResult.accessToken;
+      oauthTokenFile = oauthResult.oauthTokenFile;
+      promptedClientId = oauthResult.promptedClientId;
+      promptedClientSecret = oauthResult.promptedClientSecret;
     }
 
     // Step 4: Discover identity
@@ -314,15 +348,6 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
       enabled: true,
       ...(basecampAccountId ? { basecampAccountId } : {}),
     };
-
-    // CLI path: if credential import failed above, fall back to noting the gap
-    if (authMethod === "cli" && !oauthTokenFile) {
-      await prompter.note(
-        "Could not import credentials from the CLI.\n" +
-          "Token refresh will not work until you re-run onboarding with OAuth.",
-        "Warning",
-      );
-    }
 
     if (oauthTokenFile) accountPatch.oauthTokenFile = oauthTokenFile;
     if (selectedProfile) accountPatch.cliProfile = selectedProfile;

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -3,7 +3,7 @@
  *
  * Supports two authentication paths:
  * - Browser-based OAuth (recommended) — uses @37signals/basecamp interactive login
- * - Basecamp CLI profile — discovers identity via CLI, then chains into OAuth for persistent token
+ * - Basecamp CLI profile — imports CLI's stored credentials for persistent token
  *
  * Both paths converge on discoverIdentity() for account/person resolution.
  */
@@ -18,7 +18,6 @@ import {
   resolveBasecampAccount,
 } from "../config.js";
 import {
-  cliProfileList,
   cliProfileListFull,
   extractCliBootstrapToken,
   exportCliCredentials,
@@ -158,6 +157,10 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
     let oauthTokenFile: string | undefined;
     let promptedClientId: string | undefined;
     let promptedClientSecret: string | undefined;
+    // CLI-imported client creds go per-account (not channel-level) to avoid
+    // overwriting existing channel OAuth config that other accounts rely on.
+    let cliImportedClientId: string | undefined;
+    let cliImportedClientSecret: string | undefined;
 
     if (authMethod === "oauth") {
       // Resolve clientId: check resolved account's oauthClientId (falls through to channel-level)
@@ -217,8 +220,13 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
             { value: "__none__", label: "Use default (no profile)" },
           ],
         });
-        selectedCliProfile = choice === "__none__" ? undefined : cliProfiles.find((p) => p.name === choice);
-        selectedProfile = selectedCliProfile?.name;
+        if (choice === "__none__") {
+          // No explicit profile flag, but resolve active/default profile for credential import
+          selectedCliProfile = cliProfiles.find((p) => p.active || p.default) ?? cliProfiles[0];
+        } else {
+          selectedCliProfile = cliProfiles.find((p) => p.name === choice);
+          selectedProfile = selectedCliProfile?.name;
+        }
       } else if (cliProfiles.length === 1) {
         selectedCliProfile = cliProfiles[0];
         selectedProfile = selectedCliProfile?.name;
@@ -245,9 +253,9 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
             tokenType: "Bearer",
             expiresAt: cliCreds.expiresAt ? new Date(cliCreds.expiresAt * 1000) : undefined,
           });
-          // Store the CLI's client credentials for token refresh
-          promptedClientId = cliCreds.clientId;
-          promptedClientSecret = cliCreds.clientSecret || undefined;
+          // Store per-account so we don't overwrite channel-level OAuth
+          cliImportedClientId = cliCreds.clientId;
+          cliImportedClientSecret = cliCreds.clientSecret || undefined;
         }
       }
     }
@@ -326,15 +334,20 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
       );
     }
 
-    accountPatch.oauthTokenFile = oauthTokenFile;
+    if (oauthTokenFile) accountPatch.oauthTokenFile = oauthTokenFile;
     if (selectedProfile) accountPatch.cliProfile = selectedProfile;
-    // When credentials were freshly prompted and written to channel-level oauth,
-    // remove per-account overrides so the account inherits from channel-level.
-    // Otherwise preserve per-account oauthClientId/oauthClientSecret — the
-    // TokenManager reads these for token refresh.
+    // When credentials were freshly prompted (OAuth path) and written to
+    // channel-level oauth, remove per-account overrides so the account
+    // inherits from channel-level.
     if (promptedClientId) {
       delete accountPatch.oauthClientId;
       delete accountPatch.oauthClientSecret;
+    }
+    // CLI-imported client creds go per-account to avoid overwriting
+    // channel-level OAuth that other accounts depend on.
+    if (cliImportedClientId) {
+      accountPatch.oauthClientId = cliImportedClientId;
+      accountPatch.oauthClientSecret = cliImportedClientSecret;
     }
 
     // Build channel-level OAuth config when credentials were prompted

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -8,21 +8,21 @@
  * Both paths converge on discoverIdentity() for account/person resolution.
  */
 
-import type { OpenClawConfig, ChannelOnboardingAdapter, ChannelOnboardingDmPolicy } from "openclaw/plugin-sdk";
-import type { DmPolicy } from "openclaw/plugin-sdk";
+import type {
+  ChannelOnboardingAdapter,
+  ChannelOnboardingDmPolicy,
+  DmPolicy,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
-import type { BasecampChannelConfig } from "../types.js";
 import {
-  listBasecampAccountIds,
-  resolveDefaultBasecampAccountId,
-  resolveBasecampAccount,
-} from "../config.js";
-import {
-  cliProfileListFull,
-  extractCliBootstrapToken,
-  exportCliCredentials,
   type CliProfile,
+  cliProfileListFull,
+  exportCliCredentials,
+  extractCliBootstrapToken,
 } from "../basecamp-cli.js";
+import { listBasecampAccountIds, resolveBasecampAccount, resolveDefaultBasecampAccountId } from "../config.js";
+import type { BasecampChannelConfig } from "../types.js";
 
 const channel = "basecamp" as const;
 
@@ -83,20 +83,13 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
     };
   },
 
-  configure: async ({
-    cfg,
-    prompter,
-    accountOverrides,
-    shouldPromptAccountIds,
-  }) => {
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
     let next = cfg;
 
     // Step 1: Resolve OpenClaw account ID
     const basecampOverride = accountOverrides.basecamp?.trim();
     const defaultAccountId = resolveDefaultBasecampAccountId(cfg);
-    let accountId = basecampOverride
-      ? normalizeAccountId(basecampOverride)
-      : defaultAccountId;
+    let accountId = basecampOverride ? normalizeAccountId(basecampOverride) : defaultAccountId;
 
     if (shouldPromptAccountIds && !basecampOverride) {
       const existingIds = listBasecampAccountIds(cfg);
@@ -171,10 +164,10 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
       if (!clientId) {
         await prompter.note(
           "You'll need a Basecamp OAuth app. Register one at:\n" +
-          "https://launchpad.37signals.com/integrations\n\n" +
-          "When creating the app, set the redirect URI to:\n" +
-          "http://localhost:14923/callback\n\n" +
-          "You can leave the other fields as defaults.",
+            "https://launchpad.37signals.com/integrations\n\n" +
+            "When creating the app, set the redirect URI to:\n" +
+            "http://localhost:14923/callback\n\n" +
+            "You can leave the other fields as defaults.",
           "OAuth setup",
         );
         const enteredId = await prompter.text({
@@ -291,10 +284,7 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
       basecampAccountId = choice;
     } else if (discoveredAccounts.length === 1) {
       basecampAccountId = String(discoveredAccounts[0]!.id);
-      await prompter.note(
-        `Using account: ${discoveredAccounts[0]!.name} (${basecampAccountId})`,
-        "Basecamp account",
-      );
+      await prompter.note(`Using account: ${discoveredAccounts[0]!.name} (${basecampAccountId})`, "Basecamp account");
     }
 
     // Step 6: Resolve personId
@@ -329,7 +319,7 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
     if (authMethod === "cli" && !oauthTokenFile) {
       await prompter.note(
         "Could not import credentials from the CLI.\n" +
-        "Token refresh will not work until you re-run onboarding with OAuth.",
+          "Token refresh will not work until you re-run onboarding with OAuth.",
         "Warning",
       );
     }

--- a/src/adapters/outbound.ts
+++ b/src/adapters/outbound.ts
@@ -14,9 +14,7 @@
 /** Basecamp's per-message character limit. Shared by channel config and dispatch. */
 export const BASECAMP_TEXT_CHUNK_LIMIT = 10_000;
 
-export type ResolveTargetResult =
-  | { ok: true; to: string }
-  | { ok: false; error: string };
+export type ResolveTargetResult = { ok: true; to: string } | { ok: false; error: string };
 
 /**
  * Validate an outbound target for direct sendText delivery.
@@ -36,7 +34,8 @@ export function resolveOutboundTarget(to: string): ResolveTargetResult {
   if (/^(recording|ping):\d+$/.test(to)) {
     return {
       ok: false,
-      error: `Basecamp target "${to}" requires bucket context for delivery. ` +
+      error:
+        `Basecamp target "${to}" requires bucket context for delivery. ` +
         `Direct sendText is not supported — agent replies use the dispatch bridge`,
     };
   }

--- a/src/adapters/pairing.ts
+++ b/src/adapters/pairing.ts
@@ -8,8 +8,8 @@
 
 import type { ChannelPairingAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
 import { PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk";
-import { resolveBasecampAccount } from "../config.js";
 import { getClient, rawOrThrow } from "../basecamp-client.js";
+import { resolveBasecampAccount } from "../config.js";
 
 export const basecampPairingAdapter: ChannelPairingAdapter = {
   idLabel: "basecampPersonId",
@@ -28,10 +28,11 @@ export const basecampPairingAdapter: ChannelPairingAdapter = {
     // This is NOT in the OpenAPI spec — use raw client.
     try {
       const client = getClient(account);
-      await rawOrThrow(await client.raw.POST(
-        `/circles/people/${id}/lines.json` as any,
-        { body: { content: `<p>${PAIRING_APPROVED_MESSAGE}</p>` } as any },
-      ));
+      await rawOrThrow(
+        await client.raw.POST(`/circles/people/${id}/lines.json` as any, {
+          body: { content: `<p>${PAIRING_APPROVED_MESSAGE}</p>` } as any,
+        }),
+      );
     } catch {
       // Ping delivery is best-effort; the person can check their status
       // via `openclaw pairing status` if they don't receive the message.

--- a/src/adapters/resolver.ts
+++ b/src/adapters/resolver.ts
@@ -6,10 +6,10 @@
  * exact name (case-insensitive), partial name, or email prefix.
  */
 
-import type { ChannelResolverAdapter, ChannelResolveResult } from "openclaw/plugin-sdk";
-import type { BasecampPerson, BasecampProject } from "../types.js";
-import { resolveBasecampAccount } from "../config.js";
+import type { ChannelResolveResult, ChannelResolverAdapter } from "openclaw/plugin-sdk";
 import { getClient } from "../basecamp-client.js";
+import { resolveBasecampAccount } from "../config.js";
+import type { BasecampPerson, BasecampProject } from "../types.js";
 
 function matchPerson(input: string, people: BasecampPerson[]): BasecampPerson | undefined {
   const lower = input.toLowerCase();
@@ -60,7 +60,7 @@ export const basecampResolverAdapter: ChannelResolverAdapter = {
       let people: BasecampPerson[];
       try {
         const client = getClient(account);
-        people = await client.people.list() as any;
+        people = (await client.people.list()) as any;
       } catch {
         return inputs.map((input) => ({
           input,
@@ -91,7 +91,7 @@ export const basecampResolverAdapter: ChannelResolverAdapter = {
       let projects: BasecampProject[];
       try {
         const client = getClient(account);
-        projects = await client.projects.list() as any;
+        projects = (await client.projects.list()) as any;
       } catch {
         return inputs.map((input) => ({
           input,

--- a/src/adapters/security.ts
+++ b/src/adapters/security.ts
@@ -14,7 +14,15 @@ function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefi
 }
 
 export const basecampSecurityAdapter = {
-  resolveDmPolicy: ({ cfg, accountId: _accountId, account: _account }: { cfg: OpenClawConfig; accountId?: string | null; account: ResolvedBasecampAccount }) => {
+  resolveDmPolicy: ({
+    cfg,
+    accountId: _accountId,
+    account: _account,
+  }: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+    account: ResolvedBasecampAccount;
+  }) => {
     const section = getBasecampSection(cfg);
     const dmPolicy = section?.dmPolicy ?? "pairing";
     const allowFrom = section?.allowFrom ?? [];
@@ -29,7 +37,14 @@ export const basecampSecurityAdapter = {
     };
   },
 
-  collectWarnings: async ({ cfg, account: _account }: { cfg: OpenClawConfig; accountId?: string | null; account: ResolvedBasecampAccount }): Promise<string[]> => {
+  collectWarnings: async ({
+    cfg,
+    account: _account,
+  }: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+    account: ResolvedBasecampAccount;
+  }): Promise<string[]> => {
     const section = getBasecampSection(cfg);
     if (!section) return [];
 
@@ -37,9 +52,7 @@ export const basecampSecurityAdapter = {
 
     // 1. Open DM policy with no allowFrom entries
     if (section.dmPolicy === "open" && (!section.allowFrom || section.allowFrom.length === 0)) {
-      warnings.push(
-        "dmPolicy is \"open\" with no allowFrom entries — any Basecamp user can DM agents",
-      );
+      warnings.push('dmPolicy is "open" with no allowFrom entries — any Basecamp user can DM agents');
     }
 
     // 2. Persona mapping references non-existent account
@@ -47,9 +60,7 @@ export const basecampSecurityAdapter = {
     const accounts = section.accounts ?? {};
     for (const [agentId, targetAccountId] of Object.entries(personas)) {
       if (!accounts[targetAccountId]) {
-        warnings.push(
-          `Persona "${agentId}" maps to account "${targetAccountId}" which does not exist`,
-        );
+        warnings.push(`Persona "${agentId}" maps to account "${targetAccountId}" which does not exist`);
       }
     }
 
@@ -57,9 +68,7 @@ export const basecampSecurityAdapter = {
     const virtualAccounts = section.virtualAccounts ?? {};
     for (const [scopeId, va] of Object.entries(virtualAccounts)) {
       if (!accounts[va.accountId]) {
-        warnings.push(
-          `Virtual account "${scopeId}" references backing account "${va.accountId}" which does not exist`,
-        );
+        warnings.push(`Virtual account "${scopeId}" references backing account "${va.accountId}" which does not exist`);
       }
     }
 
@@ -75,18 +84,14 @@ export const basecampSecurityAdapter = {
     }
     for (const [pid, ids] of personIdMap) {
       if (ids.length > 1) {
-        warnings.push(
-          `Person ID ${pid} is used by multiple accounts: ${ids.join(", ")}`,
-        );
+        warnings.push(`Person ID ${pid} is used by multiple accounts: ${ids.join(", ")}`);
       }
     }
 
     // 5. Account has no auth configured
     for (const [id, acct] of Object.entries(accounts)) {
       if (!acct.token && !acct.tokenFile && !acct.oauthTokenFile) {
-        warnings.push(
-          `Account "${id}" has no token, tokenFile, or oauthTokenFile configured`,
-        );
+        warnings.push(`Account "${id}" has no token, tokenFile, or oauthTokenFile configured`);
       }
     }
 
@@ -95,9 +100,7 @@ export const basecampSecurityAdapter = {
     for (const entry of allowFrom) {
       const str = String(entry);
       if (!/^\d+$/.test(str)) {
-        warnings.push(
-          `allowFrom entry "${str}" does not look like a numeric person ID`,
-        );
+        warnings.push(`allowFrom entry "${str}" does not look like a numeric person ID`);
       }
     }
 

--- a/src/adapters/setup.ts
+++ b/src/adapters/setup.ts
@@ -5,8 +5,8 @@
  * and config application for Basecamp accounts.
  */
 
-import type { OpenClawConfig, ChannelSetupAdapter, ChannelSetupInput } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId, applyAccountNameToChannelSection } from "openclaw/plugin-sdk";
+import type { ChannelSetupAdapter, ChannelSetupInput, OpenClawConfig } from "openclaw/plugin-sdk";
+import { applyAccountNameToChannelSection, DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
 import type { BasecampChannelConfig } from "../types.js";
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
@@ -42,11 +42,7 @@ export const basecampSetupAdapter: ChannelSetupAdapter = {
     const accounts = (section.accounts ?? {}) as Record<string, Record<string, unknown>>;
     const existingAccount = accounts[accountId] ?? {};
 
-    const tokenConfig = input.tokenFile
-      ? { tokenFile: input.tokenFile }
-      : input.token
-        ? { token: input.token }
-        : {};
+    const tokenConfig = input.tokenFile ? { tokenFile: input.tokenFile } : input.token ? { token: input.token } : {};
 
     return {
       ...namedConfig,

--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -10,13 +10,13 @@
  * and status issue collection.
  */
 
-import type { ChannelStatusAdapter, ChannelAccountSnapshot, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ChannelAccountSnapshot, ChannelStatusAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
-import type { ResolvedBasecampAccount, BasecampChannelConfig, BasecampProject } from "../types.js";
 import { getClient, numId } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
-import { getAccountMetrics } from "../metrics.js";
 import type { AccountMetrics, PollerSourceMetrics } from "../metrics.js";
+import { getAccountMetrics } from "../metrics.js";
+import type { BasecampChannelConfig, BasecampProject, ResolvedBasecampAccount } from "../types.js";
 
 export type BasecampProbe = {
   ok: boolean;
@@ -156,16 +156,28 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
         if (resolved.tokenSource !== "none") {
           personasValid++;
         } else {
-          errors.push({ kind: "config", message: `Persona "${agentId}" → account "${targetAccountId}": no auth configured` });
+          errors.push({
+            kind: "config",
+            message: `Persona "${agentId}" → account "${targetAccountId}": no auth configured`,
+          });
         }
       } else {
-        errors.push({ kind: "config", message: `Persona "${agentId}" → account "${targetAccountId}": account does not exist` });
+        errors.push({
+          kind: "config",
+          message: `Persona "${agentId}" → account "${targetAccountId}": account does not exist`,
+        });
       }
     }
 
     // Enrich with operational metrics
     const metrics = getAccountMetrics(account.accountId);
-    const result: BasecampAudit = { projectsAccessible, personasMapped, personasValid, errors, personIdSet: !!account.personId };
+    const result: BasecampAudit = {
+      projectsAccessible,
+      personasMapped,
+      personasValid,
+      errors,
+      personIdSet: !!account.personId,
+    };
 
     if (metrics) {
       result.pollerLag = {
@@ -217,9 +229,7 @@ export const basecampStatusAdapter: ChannelStatusAdapter<ResolvedBasecampAccount
   },
 
   buildAccountSnapshot: ({ account, runtime, probe, audit }): BasecampAccountSnapshot => {
-    const configured = Boolean(
-      account.token?.trim() || account.config.tokenFile || account.config.oauthTokenFile,
-    );
+    const configured = Boolean(account.token?.trim() || account.config.tokenFile || account.config.oauthTokenFile);
     return {
       accountId: account.accountId,
       name: account.displayName,

--- a/src/basecamp-cli.ts
+++ b/src/basecamp-cli.ts
@@ -203,8 +203,12 @@ export async function cliAuthStatus(
  */
 export async function cliProfileList(opts: CliOptions = {}): Promise<CliResult<string[]>> {
   try {
-    const result = await execCli<string[]>(["profile", "list"], opts);
-    const profiles = Array.isArray(result.data) ? result.data : [];
+    const result = await execCli<unknown[]>(["profile", "list"], opts);
+    const raw = Array.isArray(result.data) ? result.data : [];
+    // CLI returns objects like { name, account_id, ... } — extract names
+    const profiles = raw.map((entry) =>
+      typeof entry === "string" ? entry : (entry as Record<string, unknown>)?.name as string,
+    ).filter((n): n is string => typeof n === "string" && n.length > 0);
     return { data: profiles, raw: result.raw };
   } catch (err) {
     if (err instanceof CliError) {

--- a/src/basecamp-cli.ts
+++ b/src/basecamp-cli.ts
@@ -7,8 +7,8 @@
 
 import { execFile, spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { homedir } from "node:os";
+import { join } from "node:path";
 
 // Re-export from extracted module for backwards compatibility
 export { CircuitBreaker, type CircuitBreakerOptions } from "./circuit-breaker.js";
@@ -105,15 +105,17 @@ function execCli<T = unknown>(args: string[], opts: CliOptions = {}): Promise<Cl
             meaningfulMsg ||
             `exit code ${(error as any).code ?? "unknown"}`;
           const exitCode =
-            typeof (error as any).code === "number" ? (error as any).code :
-            typeof (error as any).status === "number" ? (error as any).status :
-            null;
-          reject(new CliError(
-            `Basecamp CLI failed (${cmdStr}): ${detail}`,
-            exitCode,
-            stderrTrimmed || stdoutTrimmed,
-            [binary, ...fullArgs],
-          ));
+            typeof (error as any).code === "number"
+              ? (error as any).code
+              : typeof (error as any).status === "number"
+                ? (error as any).status
+                : null;
+          reject(
+            new CliError(`Basecamp CLI failed (${cmdStr}): ${detail}`, exitCode, stderrTrimmed || stdoutTrimmed, [
+              binary,
+              ...fullArgs,
+            ]),
+          );
           return;
         }
 
@@ -127,12 +129,12 @@ function execCli<T = unknown>(args: string[], opts: CliOptions = {}): Promise<Cl
           const data = JSON.parse(raw) as T;
           resolve({ data, raw });
         } catch (parseErr) {
-          reject(new CliError(
-            `Basecamp CLI output is not valid JSON: ${String(parseErr)}`,
-            null,
-            raw,
-            [binary, ...fullArgs],
-          ));
+          reject(
+            new CliError(`Basecamp CLI output is not valid JSON: ${String(parseErr)}`, null, raw, [
+              binary,
+              ...fullArgs,
+            ]),
+          );
         }
       },
     );
@@ -149,9 +151,7 @@ function execCli<T = unknown>(args: string[], opts: CliOptions = {}): Promise<Cl
  */
 export async function cliMe(
   opts: CliOptions = {},
-): Promise<
-  CliResult<{ id: number; name: string; email_address: string; attachable_sgid?: string }>
-> {
+): Promise<CliResult<{ id: number; name: string; email_address: string; attachable_sgid?: string }>> {
   return execCli<{ id: number; name: string; email_address: string; attachable_sgid?: string }>(["me"], opts);
 }
 
@@ -182,15 +182,10 @@ export async function cliWhich(): Promise<CliResult<{ path: string }>> {
  * Check the authentication status of a CLI profile.
  * Runs `basecamp auth status` to verify the profile's credentials are valid.
  */
-export async function cliAuthStatus(
-  opts: CliOptions = {},
-): Promise<CliResult<{ authenticated: boolean }>> {
+export async function cliAuthStatus(opts: CliOptions = {}): Promise<CliResult<{ authenticated: boolean }>> {
   try {
     const result = await execCli<{ authenticated?: boolean }>(["auth", "status"], opts);
-    const authenticated =
-      typeof result.data === "object" &&
-      result.data !== null &&
-      result.data.authenticated === true;
+    const authenticated = typeof result.data === "object" && result.data !== null && result.data.authenticated === true;
     return { data: { authenticated }, raw: result.raw };
   } catch (err) {
     if (err instanceof CliError) {
@@ -209,9 +204,9 @@ export async function cliProfileList(opts: CliOptions = {}): Promise<CliResult<s
     const result = await execCli<unknown[]>(["profile", "list"], opts);
     const raw = Array.isArray(result.data) ? result.data : [];
     // CLI returns objects like { name, account_id, ... } — extract names
-    const profiles = raw.map((entry) =>
-      typeof entry === "string" ? entry : (entry as Record<string, unknown>)?.name as string,
-    ).filter((n): n is string => typeof n === "string" && n.length > 0);
+    const profiles = raw
+      .map((entry) => (typeof entry === "string" ? entry : ((entry as Record<string, unknown>)?.name as string)))
+      .filter((n): n is string => typeof n === "string" && n.length > 0);
     return { data: profiles, raw: result.raw };
   } catch (err) {
     if (err instanceof CliError) {
@@ -225,9 +220,7 @@ export async function cliProfileList(opts: CliOptions = {}): Promise<CliResult<s
  * Launch `basecamp auth login` as an interactive subprocess.
  * This opens the browser for Basecamp OAuth and waits for completion.
  */
-export async function execCliAuthLogin(
-  opts: { profile?: string } = {},
-): Promise<void> {
+export async function execCliAuthLogin(opts: { profile?: string } = {}): Promise<void> {
   const binary = resolveCliBinaryPath();
   const args = ["auth", "login"];
   if (opts.profile) {
@@ -241,28 +234,14 @@ export async function execCliAuthLogin(
     });
 
     proc.on("error", (err: Error) => {
-      reject(
-        new CliError(
-          `Basecamp CLI auth login failed to start: ${err.message}`,
-          null,
-          "",
-          [binary, ...args],
-        ),
-      );
+      reject(new CliError(`Basecamp CLI auth login failed to start: ${err.message}`, null, "", [binary, ...args]));
     });
 
     proc.on("close", (code: number | null) => {
       if (code === 0) {
         resolve();
       } else {
-        reject(
-          new CliError(
-            `Basecamp CLI auth login exited with code ${code}`,
-            code,
-            "",
-            [binary, ...args],
-          ),
-        );
+        reject(new CliError(`Basecamp CLI auth login exited with code ${code}`, code, "", [binary, ...args]));
       }
     });
   });
@@ -302,7 +281,8 @@ export async function cliProfileListFull(opts: CliOptions = {}): Promise<CliResu
     const raw = Array.isArray(result.data) ? result.data : [];
     const profiles = raw.filter(
       (e): e is CliProfile =>
-        typeof e === "object" && e !== null &&
+        typeof e === "object" &&
+        e !== null &&
         typeof (e as Record<string, unknown>).name === "string" &&
         typeof (e as Record<string, unknown>).base_url === "string",
     );
@@ -360,12 +340,14 @@ export function extractCliBootstrapToken(profile?: string): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile(binary, args, { timeout: 10_000, encoding: "utf-8" }, (error, stdout, stderr) => {
       if (error) {
-        reject(new CliError(
-          `CLI token extraction failed: ${(stderr as string).trim() || error.message}`,
-          null,
-          (stderr as string).trim(),
-          [binary, ...args],
-        ));
+        reject(
+          new CliError(
+            `CLI token extraction failed: ${(stderr as string).trim() || error.message}`,
+            null,
+            (stderr as string).trim(),
+            [binary, ...args],
+          ),
+        );
         return;
       }
       const token = (stdout as string).trim();

--- a/src/basecamp-cli.ts
+++ b/src/basecamp-cli.ts
@@ -6,6 +6,9 @@
  */
 
 import { execFile, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 
 // Re-export from extracted module for backwards compatibility
 export { CircuitBreaker, type CircuitBreakerOptions } from "./circuit-breaker.js";
@@ -263,6 +266,85 @@ export async function execCliAuthLogin(
       }
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// CLI credential export (for onboarding — imports CLI's token into plugin)
+// ---------------------------------------------------------------------------
+
+/** Shape returned by `basecamp --agent profile list`. */
+export interface CliProfile {
+  name: string;
+  base_url: string;
+  account_id?: string;
+  authenticated?: boolean;
+  active?: boolean;
+  default?: boolean;
+}
+
+/** Parsed result from CLI credential files. */
+export interface CliCredentials {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  clientId: string;
+  clientSecret: string;
+  tokenEndpoint?: string;
+}
+
+const CLI_CONFIG_DIR = join(homedir(), ".config", "basecamp");
+
+/**
+ * List CLI profiles as full objects (name, base_url, account_id, etc.).
+ */
+export async function cliProfileListFull(opts: CliOptions = {}): Promise<CliResult<CliProfile[]>> {
+  try {
+    const result = await execCli<unknown[]>(["profile", "list"], opts);
+    const raw = Array.isArray(result.data) ? result.data : [];
+    const profiles = raw.filter(
+      (e): e is CliProfile =>
+        typeof e === "object" && e !== null &&
+        typeof (e as Record<string, unknown>).name === "string" &&
+        typeof (e as Record<string, unknown>).base_url === "string",
+    );
+    return { data: profiles, raw: result.raw };
+  } catch (err) {
+    if (err instanceof CliError) {
+      return { data: [], raw: err.stderr };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Export the CLI's stored OAuth credentials for a given base URL.
+ *
+ * Reads `~/.config/basecamp/credentials.json` (tokens keyed by base_url)
+ * and `~/.config/basecamp/client.json` (CLI's OAuth client ID/secret).
+ * Returns null if credentials are missing or unparseable.
+ */
+export function exportCliCredentials(baseUrl: string): CliCredentials | null {
+  try {
+    const credsRaw = readFileSync(join(CLI_CONFIG_DIR, "credentials.json"), "utf-8");
+    const creds = JSON.parse(credsRaw) as Record<string, Record<string, unknown>>;
+    const entry = creds[baseUrl];
+    if (!entry?.access_token || !entry?.refresh_token) return null;
+
+    const clientRaw = readFileSync(join(CLI_CONFIG_DIR, "client.json"), "utf-8");
+    const client = JSON.parse(clientRaw) as Record<string, unknown>;
+    if (!client.client_id) return null;
+
+    return {
+      accessToken: String(entry.access_token),
+      refreshToken: String(entry.refresh_token),
+      expiresAt: typeof entry.expires_at === "number" ? entry.expires_at : 0,
+      clientId: String(client.client_id),
+      clientSecret: String(client.client_secret ?? ""),
+      tokenEndpoint: typeof entry.token_endpoint === "string" ? entry.token_endpoint : undefined,
+    };
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/basecamp-cli.ts
+++ b/src/basecamp-cli.ts
@@ -289,7 +289,6 @@ export interface CliCredentials {
   expiresAt: number;
   clientId: string;
   clientSecret: string;
-  tokenEndpoint?: string;
 }
 
 const CLI_CONFIG_DIR = join(homedir(), ".config", "basecamp");
@@ -340,7 +339,6 @@ export function exportCliCredentials(baseUrl: string): CliCredentials | null {
       expiresAt: typeof entry.expires_at === "number" ? entry.expires_at : 0,
       clientId: String(client.client_id),
       clientSecret: String(client.client_secret ?? ""),
-      tokenEndpoint: typeof entry.token_endpoint === "string" ? entry.token_endpoint : undefined,
     };
   } catch {
     return null;

--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -5,10 +5,10 @@
  * Handles token resolution from multiple sources (config, tokenFile, oauth).
  */
 
-import { createBasecampClient, type BasecampClient, BasecampError, errorFromResponse } from "@37signals/basecamp";
-import type { ResolvedBasecampAccount } from "./types.js";
 import { homedir } from "node:os";
 import { resolve as pathResolve } from "node:path";
+import { type BasecampClient, BasecampError, createBasecampClient, errorFromResponse } from "@37signals/basecamp";
+import type { ResolvedBasecampAccount } from "./types.js";
 
 export { BasecampError };
 export type { BasecampClient };
@@ -52,12 +52,11 @@ export function clearClients(): void {
 // ---------------------------------------------------------------------------
 
 function resolveNumericAccountId(account: ResolvedBasecampAccount): string {
-  const id = account.config.basecampAccountId
-    ?? (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
+  const id = account.config.basecampAccountId ?? (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
   if (!id) {
     throw new Error(
       `Cannot resolve numeric Basecamp account ID for "${account.accountId}". ` +
-      `Set channels.basecamp.accounts.${account.accountId}.basecampAccountId`,
+        `Set channels.basecamp.accounts.${account.accountId}.basecampAccountId`,
     );
   }
   return id;
@@ -67,9 +66,7 @@ function resolveNumericAccountId(account: ResolvedBasecampAccount): string {
 // Token resolution
 // ---------------------------------------------------------------------------
 
-function resolveTokenProvider(
-  account: ResolvedBasecampAccount,
-): string | (() => Promise<string>) {
+function resolveTokenProvider(account: ResolvedBasecampAccount): string | (() => Promise<string>) {
   switch (account.tokenSource) {
     case "config":
       return account.token;
@@ -91,9 +88,7 @@ function resolveTokenProvider(
       let tmPromise: Promise<{ getToken(): Promise<string> }> | null = null;
       return async () => {
         if (!tmPromise) {
-          tmPromise = import("./oauth-credentials.js").then(({ createTokenManager }) =>
-            createTokenManager(account),
-          );
+          tmPromise = import("./oauth-credentials.js").then(({ createTokenManager }) => createTokenManager(account));
         }
         const tm = await tmPromise;
         return tm.getToken();
@@ -103,7 +98,7 @@ function resolveTokenProvider(
     case "none":
       throw new Error(
         `No authentication configured for account "${account.accountId}". ` +
-        `Set token, tokenFile, or oauthTokenFile.`,
+          `Set token, tokenFile, or oauthTokenFile.`,
       );
   }
 }
@@ -146,14 +141,9 @@ export function numId(label: string, value: string | number): number {
  * Use for client.raw.GET/POST/PUT/DELETE calls that return { data, error, response }
  * instead of auto-throwing.
  */
-export async function rawOrThrow<T>(
-  result: { data?: T; error?: unknown; response: Response },
-): Promise<T> {
+export async function rawOrThrow<T>(result: { data?: T; error?: unknown; response: Response }): Promise<T> {
   if (!result.response.ok || result.error) {
-    throw await errorFromResponse(
-      result.response,
-      result.response.headers.get("X-Request-Id") ?? undefined,
-    );
+    throw await errorFromResponse(result.response, result.response.headers.get("X-Request-Id") ?? undefined);
   }
   return result.data as T;
 }

--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -47,6 +47,11 @@ export function clearClients(): void {
   clientCache.clear();
 }
 
+/** Clear the cached client for a single account. */
+export function clearClient(accountId: string): void {
+  clientCache.delete(accountId);
+}
+
 // ---------------------------------------------------------------------------
 // Account ID resolution
 // ---------------------------------------------------------------------------

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2,46 +2,45 @@ import type { ChannelPlugin } from "openclaw/plugin-sdk";
 import {
   buildChannelConfigSchema,
   DEFAULT_ACCOUNT_ID,
-  setAccountEnabledInConfigSection,
   deleteAccountFromConfigSection,
+  setAccountEnabledInConfigSection,
 } from "openclaw/plugin-sdk";
-import type { ResolvedBasecampAccount, BasecampInboundMessage } from "./types.js";
-import type { BasecampProbe, BasecampAudit } from "./adapters/status.js";
-import type { BasecampChannelConfig } from "./types.js";
+import { basecampActionsAdapter } from "./adapters/actions.js";
+import { basecampAgentPromptAdapter } from "./adapters/agent-prompt.js";
+import { basecampAgentTools } from "./adapters/agent-tools.js";
+import { basecampDirectoryAdapter } from "./adapters/directory.js";
+import { basecampGroupAdapter } from "./adapters/groups.js";
+import { basecampHeartbeatAdapter } from "./adapters/heartbeat.js";
+import { basecampMentionAdapter } from "./adapters/mentions.js";
+import { basecampMessagingAdapter } from "./adapters/messaging.js";
+import { basecampOnboardingAdapter } from "./adapters/onboarding.js";
+import { BASECAMP_TEXT_CHUNK_LIMIT, chunkMarkdownText, resolveOutboundTarget } from "./adapters/outbound.js";
+import { basecampPairingAdapter } from "./adapters/pairing.js";
+import { basecampResolverAdapter } from "./adapters/resolver.js";
+import { basecampSecurityAdapter } from "./adapters/security.js";
+import { basecampSetupAdapter } from "./adapters/setup.js";
+import type { BasecampAudit, BasecampProbe } from "./adapters/status.js";
+import { basecampStatusAdapter } from "./adapters/status.js";
+import { clearClients } from "./basecamp-client.js";
 import {
   BasecampConfigSchema,
   listBasecampAccountIds,
+  resolveAccountForBucket,
   resolveBasecampAccount,
   resolveBasecampAccountAsync,
-  resolveDefaultBasecampAccountId,
   resolveBasecampAllowFrom,
+  resolveDefaultBasecampAccountId,
   resolveWebhooksConfig,
-  resolveAccountForBucket,
   scopeWebhookProjects,
 } from "./config.js";
-import { getBasecampRuntime } from "./runtime.js";
-import { sendBasecampText, sendBasecampMedia } from "./outbound/send.js";
 import { dispatchBasecampEvent } from "./dispatch.js";
-import { basecampOnboardingAdapter } from "./adapters/onboarding.js";
-import { basecampSetupAdapter } from "./adapters/setup.js";
-import { basecampStatusAdapter } from "./adapters/status.js";
-import { basecampPairingAdapter } from "./adapters/pairing.js";
-import { basecampDirectoryAdapter } from "./adapters/directory.js";
-import { basecampMessagingAdapter } from "./adapters/messaging.js";
-import { basecampResolverAdapter } from "./adapters/resolver.js";
-import { basecampHeartbeatAdapter } from "./adapters/heartbeat.js";
-import { basecampGroupAdapter } from "./adapters/groups.js";
-import { basecampAgentPromptAdapter } from "./adapters/agent-prompt.js";
-import { basecampSecurityAdapter } from "./adapters/security.js";
-import { resolveOutboundTarget, chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
-import { basecampMentionAdapter } from "./adapters/mentions.js";
-import { basecampActionsAdapter } from "./adapters/actions.js";
-import { basecampAgentTools } from "./adapters/agent-tools.js";
-import { clearClients } from "./basecamp-client.js";
-import { flushWebhookSecrets, getWebhookSecretRegistry } from "./inbound/webhooks.js";
 import { closeAccountDedup } from "./inbound/dedup-registry.js";
 import { resolvePluginStateDir } from "./inbound/state-dir.js";
-import { reconcileWebhooks, deactivateWebhooks } from "./inbound/webhook-lifecycle.js";
+import { deactivateWebhooks, reconcileWebhooks } from "./inbound/webhook-lifecycle.js";
+import { flushWebhookSecrets, getWebhookSecretRegistry } from "./inbound/webhooks.js";
+import { sendBasecampMedia, sendBasecampText } from "./outbound/send.js";
+import { getBasecampRuntime } from "./runtime.js";
+import type { BasecampChannelConfig, BasecampInboundMessage, ResolvedBasecampAccount } from "./types.js";
 import { withTimeout } from "./util.js";
 
 /** JSON snapshot of config sections relevant to persona/virtualAccount validation.
@@ -62,7 +61,8 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
     selectionLabel: "Basecamp (Campfire, Cards, Todos, Check-ins, Pings)",
     docsPath: "/channels/basecamp",
     docsLabel: "basecamp",
-    blurb: "Campfire chats, card tables, to-do lists, check-ins, pings — every Basecamp surface as a live agent interaction point.",
+    blurb:
+      "Campfire chats, card tables, to-do lists, check-ins, pings — every Basecamp surface as a live agent interaction point.",
     systemImage: "building.2",
   },
 
@@ -116,11 +116,13 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         case "config":
           throw new Error("Account uses an inline token — no login needed. Update the token in config directly.");
         case "tokenFile":
-          throw new Error(`Account uses a token file (${account.config.tokenFile}). Update the file contents directly.`);
+          throw new Error(
+            `Account uses a token file (${account.config.tokenFile}). Update the file contents directly.`,
+          );
         case "none":
           throw new Error(
             "No authentication configured for this account. " +
-            "Run `openclaw channels add` and select Basecamp to set up credentials.",
+              "Run `openclaw channels add` and select Basecamp to set up credentials.",
           );
       }
     },
@@ -137,22 +139,63 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
   configSchema: {
     ...buildChannelConfigSchema(BasecampConfigSchema),
     uiHints: {
-      "accounts.*.tokenFile": { label: "Token file path", help: "Path to file containing OAuth token", sensitive: true },
-      "accounts.*.token": { label: "Token", help: "Inline OAuth token (prefer tokenFile)", sensitive: true, advanced: true },
-      "accounts.*.cliProfile": { label: "Basecamp CLI profile", help: "CLI profile for identity discovery during setup (not used at runtime)" },
+      "accounts.*.tokenFile": {
+        label: "Token file path",
+        help: "Path to file containing OAuth token",
+        sensitive: true,
+      },
+      "accounts.*.token": {
+        label: "Token",
+        help: "Inline OAuth token (prefer tokenFile)",
+        sensitive: true,
+        advanced: true,
+      },
+      "accounts.*.cliProfile": {
+        label: "Basecamp CLI profile",
+        help: "CLI profile for identity discovery during setup (not used at runtime)",
+      },
       "accounts.*.personId": { label: "Person ID", help: "Your Basecamp person ID (numeric)" },
-      "accounts.*.basecampAccountId": { label: "Basecamp Account ID", help: "Numeric Basecamp account ID (auto-set during onboarding)" },
-      "accounts.*.oauthTokenFile": { label: "OAuth token file", help: "Path to OAuth token JSON (auto-managed)", sensitive: true },
-      "accounts.*.oauthClientId": { label: "OAuth Client ID (override)", help: "Override channel-level OAuth client ID for this account" },
-      "accounts.*.oauthClientSecret": { label: "OAuth Client Secret (override)", help: "Override channel-level OAuth secret", sensitive: true },
+      "accounts.*.basecampAccountId": {
+        label: "Basecamp Account ID",
+        help: "Numeric Basecamp account ID (auto-set during onboarding)",
+      },
+      "accounts.*.oauthTokenFile": {
+        label: "OAuth token file",
+        help: "Path to OAuth token JSON (auto-managed)",
+        sensitive: true,
+      },
+      "accounts.*.oauthClientId": {
+        label: "OAuth Client ID (override)",
+        help: "Override channel-level OAuth client ID for this account",
+      },
+      "accounts.*.oauthClientSecret": {
+        label: "OAuth Client Secret (override)",
+        help: "Override channel-level OAuth secret",
+        sensitive: true,
+      },
       "oauth.clientId": { label: "OAuth Client ID", help: "Basecamp OAuth app client ID for browser-based login" },
       "oauth.clientSecret": { label: "OAuth Client Secret", help: "Basecamp OAuth app secret", sensitive: true },
-      "personas": { label: "Agent personas", help: "Maps agent IDs to Basecamp account IDs for multi-identity outbound", advanced: true },
-      "virtualAccounts": { label: "Project scopes", help: "Maps synthetic account IDs to specific projects", advanced: true },
-      "dmPolicy": { label: "DM policy", help: "Controls who can DM agents: pairing, allowlist, open, disabled" },
-      "allowFrom": { label: "Allowed senders", help: "Basecamp person IDs allowed to message agents" },
-      "engage": { label: "Engagement policy", help: "Event types that trigger agent response: dm, mention, assignment, checkin, conversation, activity" },
-      "buckets": { label: "Per-project settings", help: "Override engage, requireMention, and tool policies per bucket", advanced: true },
+      personas: {
+        label: "Agent personas",
+        help: "Maps agent IDs to Basecamp account IDs for multi-identity outbound",
+        advanced: true,
+      },
+      virtualAccounts: {
+        label: "Project scopes",
+        help: "Maps synthetic account IDs to specific projects",
+        advanced: true,
+      },
+      dmPolicy: { label: "DM policy", help: "Controls who can DM agents: pairing, allowlist, open, disabled" },
+      allowFrom: { label: "Allowed senders", help: "Basecamp person IDs allowed to message agents" },
+      engage: {
+        label: "Engagement policy",
+        help: "Event types that trigger agent response: dm, mention, assignment, checkin, conversation, activity",
+      },
+      buckets: {
+        label: "Per-project settings",
+        help: "Override engage, requireMention, and tool policies per bucket",
+        advanced: true,
+      },
     },
   },
 
@@ -160,7 +203,8 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
     listAccountIds: (cfg) => listBasecampAccountIds(cfg),
     resolveAccount: (cfg, accountId) => resolveBasecampAccount(cfg, accountId),
     defaultAccountId: (cfg) => resolveDefaultBasecampAccountId(cfg),
-    isConfigured: (account) => Boolean(account.token?.trim() || account.config.tokenFile || account.config.oauthTokenFile),
+    isConfigured: (account) =>
+      Boolean(account.token?.trim() || account.config.tokenFile || account.config.oauthTokenFile),
     isEnabled: (account) => account.enabled,
     disabledReason: () => "Manually disabled",
     unconfiguredReason: () => "No token or OAuth token file configured",
@@ -192,8 +236,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       return updated;
     },
     resolveAllowFrom: ({ cfg }) => resolveBasecampAllowFrom(cfg),
-    formatAllowFrom: ({ allowFrom }) =>
-      allowFrom.map((entry) => `Person ${entry}`),
+    formatAllowFrom: ({ allowFrom }) => allowFrom.map((entry) => `Person ${entry}`),
   },
 
   security: basecampSecurityAdapter,
@@ -225,9 +268,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       // ----- Startup validation -----
       // Verify critical config is valid. Log warnings but don't block startup.
       if (!account.personId) {
-        ctx.log?.warn(
-          `[${account.accountId}] validation: personId is not set — self-message filtering will not work`,
-        );
+        ctx.log?.warn(`[${account.accountId}] validation: personId is not set — self-message filtering will not work`);
       }
 
       // Validate persona and virtualAccounts mappings when config changes.
@@ -248,15 +289,13 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           if (Object.keys(startupSection.personas).length > 0) {
             ctx.log?.warn(
               "Agent tools execute under the default account; " +
-              "persona-mapped accounts are not yet supported for tool calls",
+                "persona-mapped accounts are not yet supported for tool calls",
             );
           }
           for (const [agentId, targetAccountId] of Object.entries(startupSection.personas)) {
             const targetAccounts = startupSection.accounts ?? {};
             if (!targetAccounts[targetAccountId]) {
-              ctx.log?.warn(
-                `validation: persona "${agentId}" references non-existent account "${targetAccountId}"`,
-              );
+              ctx.log?.warn(`validation: persona "${agentId}" references non-existent account "${targetAccountId}"`);
             }
           }
         }
@@ -264,9 +303,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           for (const [key, va] of Object.entries(startupSection.virtualAccounts)) {
             const targetAccounts = startupSection.accounts ?? {};
             if (!targetAccounts[va.accountId]) {
-              ctx.log?.warn(
-                `validation: virtualAccount "${key}" references non-existent account "${va.accountId}"`,
-              );
+              ctx.log?.warn(`validation: virtualAccount "${key}" references non-existent account "${va.accountId}"`);
             }
           }
         }
@@ -279,17 +316,13 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
           const tm = createTokenManager(account);
           await tm.getToken(); // validates + refreshes if needed
         } catch (err) {
-          ctx.log?.error(
-            `[${account.accountId}] cannot start: OAuth token invalid: ${String(err)}`,
-          );
+          ctx.log?.error(`[${account.accountId}] cannot start: OAuth token invalid: ${String(err)}`);
           return;
         }
       }
 
       if (account.tokenSource === "none") {
-        ctx.log?.error(
-          `[${account.accountId}] cannot start: no authentication configured`,
-        );
+        ctx.log?.error(`[${account.accountId}] cannot start: no authentication configured`);
         return;
       }
 
@@ -303,20 +336,17 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       // Resolve the numeric Basecamp account ID for API calls.
       // Prefers explicit basecampAccountId, then falls back to accountId if numeric.
       const basecampAccountId =
-        account.config.basecampAccountId ??
-        (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
+        account.config.basecampAccountId ?? (/^\d+$/.test(account.accountId) ? account.accountId : undefined);
 
       if (!basecampAccountId) {
         ctx.log?.warn(
           `[${account.accountId}] validation: Basecamp account ID could not be resolved — ` +
-          `outbound dispatch and API tools will fail. ` +
-          `Set channels.basecamp.accounts.${account.accountId}.basecampAccountId`,
+            `outbound dispatch and API tools will fail. ` +
+            `Set channels.basecamp.accounts.${account.accountId}.basecampAccountId`,
         );
       }
 
-      ctx.log?.info(
-        `[${account.accountId}] starting Basecamp channel (person: ${account.personId})`,
-      );
+      ctx.log?.info(`[${account.accountId}] starting Basecamp channel (person: ${account.personId})`);
 
       // Import poller dynamically to avoid circular deps and allow
       // the inbound worker to complete their module independently.
@@ -325,9 +355,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         const pollerMod = await import("./inbound/poller.js");
         startCompositePoller = pollerMod.startCompositePoller;
       } catch (err) {
-        ctx.log?.error(
-          `[${account.accountId}] failed to load poller module: ${String(err)}`,
-        );
+        ctx.log?.error(`[${account.accountId}] failed to load poller module: ${String(err)}`);
         return;
       }
 
@@ -361,17 +389,19 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
               account,
             },
             registry,
-            ctx.log ? {
-              info: (e, d) => ctx.log?.info?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
-              warn: (e, d) => ctx.log?.warn?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
-              error: (e, d) => ctx.log?.error?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
-              debug: (e, d) => ctx.log?.debug?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
-            } : undefined,
+            ctx.log
+              ? {
+                  info: (e, d) => ctx.log?.info?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                  warn: (e, d) => ctx.log?.warn?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                  error: (e, d) => ctx.log?.error?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                  debug: (e, d) => ctx.log?.debug?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                }
+              : undefined,
           );
           ctx.log?.info(
             `[${account.accountId}] webhook reconciliation: ` +
-            `${result.created.length} created, ${result.existing.length} existing, ` +
-            `${result.recovered.length} recovered, ${result.failed.length} failed`,
+              `${result.created.length} created, ${result.existing.length} existing, ` +
+              `${result.recovered.length} recovered, ${result.failed.length} failed`,
           );
           // Projects with active webhooks (created, already existing, or recovered)
           const active = [...result.created, ...result.existing, ...result.recovered];
@@ -379,9 +409,7 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
             webhookActiveProjects = new Set(active);
           }
         } catch (err) {
-          ctx.log?.error(
-            `[${account.accountId}] webhook reconciliation failed: ${String(err)}`,
-          );
+          ctx.log?.error(`[${account.accountId}] webhook reconciliation failed: ${String(err)}`);
         }
       }
 
@@ -440,16 +468,16 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
                 account,
               },
               registry,
-              ctx.log ? {
-                info: (e, d) => ctx.log?.info?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
-                warn: (e, d) => ctx.log?.warn?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
-                error: (e, d) => ctx.log?.error?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
-                debug: (e, d) => ctx.log?.debug?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
-              } : undefined,
+              ctx.log
+                ? {
+                    info: (e, d) => ctx.log?.info?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                    warn: (e, d) => ctx.log?.warn?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                    error: (e, d) => ctx.log?.error?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                    debug: (e, d) => ctx.log?.debug?.(`[${account.accountId}] ${e} ${d ? JSON.stringify(d) : ""}`),
+                  }
+                : undefined,
             ).catch((err) => {
-              ctx.log?.error(
-                `[${account.accountId}] webhook deactivation failed: ${String(err)}`,
-              );
+              ctx.log?.error(`[${account.accountId}] webhook deactivation failed: ${String(err)}`);
             }),
             5000,
             `${account.accountId} webhook deactivation`,
@@ -505,4 +533,3 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
     },
   },
 };
-

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -37,6 +37,7 @@ import { resolveOutboundTarget, chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } f
 import { basecampMentionAdapter } from "./adapters/mentions.js";
 import { basecampActionsAdapter } from "./adapters/actions.js";
 import { basecampAgentTools } from "./adapters/agent-tools.js";
+import { clearClients } from "./basecamp-client.js";
 import { flushWebhookSecrets, getWebhookSecretRegistry } from "./inbound/webhooks.js";
 import { closeAccountDedup } from "./inbound/dedup-registry.js";
 import { resolvePluginStateDir } from "./inbound/state-dir.js";
@@ -243,6 +244,13 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       if (configJson !== lastValidatedConfigJson) {
         lastValidatedConfigJson = configJson;
         if (startupSection?.personas) {
+          // Warn about persona limitation with agent tools
+          if (Object.keys(startupSection.personas).length > 0) {
+            ctx.log?.warn(
+              "Agent tools execute under the default account; " +
+              "persona-mapped accounts are not yet supported for tool calls",
+            );
+          }
           for (const [agentId, targetAccountId] of Object.entries(startupSection.personas)) {
             const targetAccounts = startupSection.accounts ?? {};
             if (!targetAccounts[targetAccountId]) {
@@ -468,7 +476,32 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
       }
     },
     logoutAccount: async ({ accountId, cfg }) => {
-      return { cleared: false, loggedOut: false };
+      const account = resolveBasecampAccount(cfg, accountId);
+
+      // Delete OAuth token file if it exists
+      let cleared = false;
+      const tokenFilePath = account.config.oauthTokenFile;
+      if (tokenFilePath) {
+        try {
+          const { unlink } = await import("node:fs/promises");
+          await unlink(tokenFilePath);
+          cleared = true;
+        } catch (err: any) {
+          if (err?.code !== "ENOENT") throw err;
+          // File already gone — still counts as cleared
+          cleared = true;
+        }
+      }
+
+      // Evict cached TokenManagers and SDK clients
+      const { clearTokenManagers } = await import("./oauth-credentials.js");
+      clearTokenManagers();
+      clearClients();
+
+      // Close account dedup DB
+      closeAccountDedup(accountId);
+
+      return { cleared, loggedOut: cleared };
     },
   },
 };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -21,7 +21,7 @@ import { basecampSecurityAdapter } from "./adapters/security.js";
 import { basecampSetupAdapter } from "./adapters/setup.js";
 import type { BasecampAudit, BasecampProbe } from "./adapters/status.js";
 import { basecampStatusAdapter } from "./adapters/status.js";
-import { clearClients } from "./basecamp-client.js";
+import { clearClient } from "./basecamp-client.js";
 import {
   BasecampConfigSchema,
   listBasecampAccountIds,
@@ -521,10 +521,10 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         }
       }
 
-      // Evict cached TokenManagers and SDK clients
-      const { clearTokenManagers } = await import("./oauth-credentials.js");
-      clearTokenManagers();
-      clearClients();
+      // Evict cached TokenManager and SDK client for this account only
+      const { clearTokenManager } = await import("./oauth-credentials.js");
+      clearTokenManager(accountId);
+      clearClient(accountId);
 
       // Close account dedup DB
       closeAccountDedup(accountId);

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,8 +98,6 @@ export const BasecampConfigSchema = z.object({
     .object({
       projects: z.array(z.string()).optional(),
       intervalMs: z.number().positive().optional(),
-      /** @deprecated tier2 is accepted but ignored. Frequency escalation deferred. */
-      tier2: z.any().optional(),
     })
     .optional(),
   reconciliation: z
@@ -416,22 +414,15 @@ export function resolveAccountForBucket(
   return undefined;
 }
 
-let _tier2Warned = false;
-
 /** Resolve safety net config with defaults. */
 export function resolveSafetyNetConfig(cfg: OpenClawConfig): {
   projects: string[];
   intervalMs: number;
 } {
   const section = getBasecampSection(cfg);
-  const sn = section?.safetyNet as { projects?: string[]; intervalMs?: number; tier2?: unknown } | undefined;
-  if (sn?.tier2 != null && !_tier2Warned) {
-    _tier2Warned = true;
-    console.warn("[basecamp] safetyNet.tier2 is deprecated and ignored — frequency escalation is deferred");
-  }
   return {
-    projects: sn?.projects ?? [],
-    intervalMs: sn?.intervalMs ?? 600_000,
+    projects: section?.safetyNet?.projects ?? [],
+    intervalMs: section?.safetyNet?.intervalMs ?? 600_000,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import { z } from "zod";
 import type {
   BasecampAccountConfig,
   BasecampChannelConfig,
@@ -31,16 +31,16 @@ const BasecampVirtualAccountSchema = z.object({
   bucketId: z.string(),
 });
 
-const EngagementTypeSchema = z.enum([
-  "dm", "mention", "assignment", "checkin", "conversation", "activity",
-]);
+const EngagementTypeSchema = z.enum(["dm", "mention", "assignment", "checkin", "conversation", "activity"]);
 
 const BasecampBucketConfigSchema = z.object({
   requireMention: z.boolean().optional(),
-  tools: z.object({
-    allow: z.array(z.string()).optional(),
-    deny: z.array(z.string()).optional(),
-  }).optional(),
+  tools: z
+    .object({
+      allow: z.array(z.string()).optional(),
+      deny: z.array(z.string()).optional(),
+    })
+    .optional(),
   enabled: z.boolean().optional(),
   engage: z.array(EngagementTypeSchema).optional(),
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
@@ -306,10 +306,7 @@ export async function resolveBasecampAccountAsync(
  * Resolve the persona (Basecamp account) for a given agent ID.
  * Returns undefined if no persona mapping exists.
  */
-export function resolvePersonaAccountId(
-  cfg: OpenClawConfig,
-  agentId: string,
-): string | undefined {
+export function resolvePersonaAccountId(cfg: OpenClawConfig, agentId: string): string | undefined {
   const section = getBasecampSection(cfg);
   return section?.personas?.[agentId];
 }
@@ -325,7 +322,12 @@ export function resolvePollingIntervals(cfg: unknown) {
 }
 
 /** Resolve retry options from config, with defaults. */
-export function resolveRetryConfig(cfg: OpenClawConfig): { maxAttempts: number; baseDelayMs: number; maxDelayMs: number; jitter: boolean } {
+export function resolveRetryConfig(cfg: OpenClawConfig): {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  jitter: boolean;
+} {
   const section = getBasecampSection(cfg);
   return {
     maxAttempts: section?.retry?.maxAttempts ?? 3,
@@ -357,10 +359,7 @@ export function resolveBasecampAllowFrom(cfg: OpenClawConfig): string[] {
 }
 
 /** Get the allow-from list for a specific bucket. Returns undefined if unset (all senders allowed). */
-export function resolveBasecampBucketAllowFrom(
-  cfg: OpenClawConfig,
-  bucketId: string,
-): string[] | undefined {
+export function resolveBasecampBucketAllowFrom(cfg: OpenClawConfig, bucketId: string): string[] | undefined {
   const section = getBasecampSection(cfg);
   const bucketConfig = section?.buckets?.[bucketId] ?? section?.buckets?.["*"];
   if (!bucketConfig?.allowFrom) return undefined;
@@ -397,10 +396,7 @@ export function resolveWebhooksConfig(cfg: OpenClawConfig): {
  * Checks virtualAccounts for a scope mapping and returns the concrete
  * accountId (not the virtual alias key). Returns undefined if no mapping found.
  */
-export function resolveAccountForBucket(
-  cfg: OpenClawConfig,
-  bucketId: string,
-): string | undefined {
+export function resolveAccountForBucket(cfg: OpenClawConfig, bucketId: string): string | undefined {
   const section = getBasecampSection(cfg);
   // Check virtualAccounts for a scope mapping to this bucket.
   // Return the concrete account ID — not the alias key — so callers can
@@ -464,7 +460,7 @@ export function scopeWebhookProjects(opts: {
     if (isSingleAccount) return true;
     log?.warn(
       `[${accountId}] skipping unmapped webhook project ${projectId} — ` +
-      `add a virtualAccounts entry to assign it to an account`,
+        `add a virtualAccounts entry to assign it to an account`,
     );
     return false;
   });

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -11,18 +11,30 @@
  *    to send the agent's response back to the correct Basecamp surface
  */
 
-import type { BasecampInboundMessage, BasecampChannelConfig, BasecampEngagementType, ResolvedBasecampAccount } from "./types.js";
-import { DEFAULT_ENGAGE } from "./types.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { getBasecampRuntime } from "./runtime.js";
-import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom, resolveBasecampBucketAllowFrom, resolveCircuitBreakerConfig } from "./config.js";
-import { postReplyToEvent } from "./outbound/send.js";
-import { markdownToBasecampHtml } from "./outbound/format.js";
-import { chunkMarkdownText, BASECAMP_TEXT_CHUNK_LIMIT } from "./adapters/outbound.js";
-import { createStructuredLog } from "./logging.js";
-import { CircuitBreaker } from "./circuit-breaker.js";
+import { BASECAMP_TEXT_CHUNK_LIMIT, chunkMarkdownText } from "./adapters/outbound.js";
 import { BasecampError } from "./basecamp-client.js";
+import { CircuitBreaker } from "./circuit-breaker.js";
+import {
+  resolveBasecampAccount,
+  resolveBasecampAllowFrom,
+  resolveBasecampBucketAllowFrom,
+  resolveBasecampDmPolicy,
+  resolveCircuitBreakerConfig,
+  resolvePersonaAccountId,
+} from "./config.js";
+import { createStructuredLog } from "./logging.js";
 import { recordCircuitBreakerState, recordDispatchFailure } from "./metrics.js";
+import { markdownToBasecampHtml } from "./outbound/format.js";
+import { postReplyToEvent } from "./outbound/send.js";
+import { getBasecampRuntime } from "./runtime.js";
+import type {
+  BasecampChannelConfig,
+  BasecampEngagementType,
+  BasecampInboundMessage,
+  ResolvedBasecampAccount,
+} from "./types.js";
+import { DEFAULT_ENGAGE } from "./types.js";
 
 /** Per-account outbound circuit breakers. Separate from poller CBs. */
 const outboundCircuitBreakers = new Map<string, CircuitBreaker>();
@@ -41,7 +53,12 @@ export type DispatchOptions = {
   /** The resolved account that received this event. */
   account: ResolvedBasecampAccount;
   /** Optional logger. */
-  log?: { info: (msg: string) => void; warn: (msg: string) => void; debug?: (msg: string) => void; error: (msg: string) => void };
+  log?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    debug?: (msg: string) => void;
+    error: (msg: string) => void;
+  };
 };
 
 /**
@@ -50,10 +67,7 @@ export type DispatchOptions = {
  * Returns true if the message was dispatched, false if it was dropped
  * (e.g., no matching agent route, self-message, etc.).
  */
-export async function dispatchBasecampEvent(
-  msg: BasecampInboundMessage,
-  options: DispatchOptions,
-): Promise<boolean> {
+export async function dispatchBasecampEvent(msg: BasecampInboundMessage, options: DispatchOptions): Promise<boolean> {
   const runtime = getBasecampRuntime();
   const cfg = runtime.config.loadConfig();
   const { account, log } = options;
@@ -159,9 +173,7 @@ export async function dispatchBasecampEvent(
   // ----- Resolve persona for outbound -----
   // The agent may have a dedicated Basecamp persona (service account).
   const personaAccountId = resolvePersonaAccountId(cfg, route.agentId);
-  const outboundAccount = personaAccountId
-    ? resolveBasecampAccount(cfg, personaAccountId)
-    : account;
+  const outboundAccount = personaAccountId ? resolveBasecampAccount(cfg, personaAccountId) : account;
   // Resolve the numeric account ID for circuit breaker keying and logging.
   const outboundBasecampAccountId =
     outboundAccount.config.basecampAccountId ??
@@ -311,10 +323,7 @@ function classifyEngagement(msg: BasecampInboundMessage): BasecampEngagementType
   if (msg.meta.assignedToAgent) return "assignment";
 
   // Check-in reminders: Question in Hey! inbox = you're a respondent
-  if (
-    msg.meta.recordableType === "Question" &&
-    msg.meta.sources.includes("readings")
-  ) {
+  if (msg.meta.recordableType === "Question" && msg.meta.sources.includes("readings")) {
     return "checkin";
   }
 
@@ -334,10 +343,7 @@ function classifyEngagement(msg: BasecampInboundMessage): BasecampEngagementType
  * Resolve the engagement policy for a given bucket.
  * Per-bucket `engage` overrides channel-level; falls back to DEFAULT_ENGAGE.
  */
-function resolveEngagePolicy(
-  cfg: OpenClawConfig,
-  bucketId: string,
-): BasecampEngagementType[] {
+function resolveEngagePolicy(cfg: OpenClawConfig, bucketId: string): BasecampEngagementType[] {
   const section = cfg.channels?.basecamp as BasecampChannelConfig | undefined;
 
   // Per-bucket override (exact match → wildcard fallback)
@@ -394,7 +400,8 @@ function classifyDispatchError(err: unknown): string {
     lowerMessage.includes("econnreset") ||
     lowerMessage.includes("timeout") ||
     lowerMessage.includes("fetch")
-  ) return "network";
+  )
+    return "network";
 
   if (/\bno route\b/.test(lowerMessage)) return "routing";
 
@@ -405,10 +412,7 @@ function classifyDispatchError(err: unknown): string {
  * Check if an inbound message's bucketId matches a virtualAccounts entry.
  * Returns the virtual account key (scope alias) if matched, undefined otherwise.
  */
-function resolveProjectScopeAccountId(
-  cfg: OpenClawConfig,
-  msg: BasecampInboundMessage,
-): string | undefined {
+function resolveProjectScopeAccountId(cfg: OpenClawConfig, msg: BasecampInboundMessage): string | undefined {
   const section = cfg.channels?.basecamp as BasecampChannelConfig | undefined;
   const virtualAccounts = section?.virtualAccounts;
   if (!virtualAccounts) return undefined;
@@ -486,4 +490,3 @@ function syncOutboundCircuitBreakerMetrics(
     trippedAt: state.trippedAt,
   });
 }
-

--- a/src/hooks/agent-prompt-context.ts
+++ b/src/hooks/agent-prompt-context.ts
@@ -18,7 +18,7 @@ const SURFACE_PROMPTS: Record<string, string> = {
     "Use short paragraphs. Match the casual chat tone.",
   ].join(" "),
 
-  "Todo": [
+  Todo: [
     "You are commenting on a Basecamp to-do.",
     "Be detailed and actionable. Reference specific tasks and steps.",
     "Structure your response clearly — use lists for action items.",
@@ -31,25 +31,25 @@ const SURFACE_PROMPTS: Record<string, string> = {
     "Be concise but thorough. Structure feedback clearly.",
   ].join(" "),
 
-  "Question": [
+  Question: [
     "You are answering a Basecamp check-in question.",
     "Be direct and structured. Match the question format.",
     "Keep your answer focused on what was asked.",
   ].join(" "),
 
-  "Message": [
+  Message: [
     "You are commenting on a Basecamp Message Board post.",
     "Be thorough and well-structured. Use headings and lists where appropriate.",
     "This is a longer-form discussion context.",
   ].join(" "),
 
-  "Circle": [
+  Circle: [
     "You are in a direct Basecamp Ping conversation.",
     "Be helpful and personal. This is a private conversation.",
     "You can be more detailed since it's a focused 1:1 or small group chat.",
   ].join(" "),
 
-  "Comment": [
+  Comment: [
     "You are responding to a comment on a Basecamp recording.",
     "Be concise and relevant to the discussion thread.",
     "Reference the parent context when appropriate.",

--- a/src/hooks/agent-prompt-context.ts
+++ b/src/hooks/agent-prompt-context.ts
@@ -31,12 +31,6 @@ const SURFACE_PROMPTS: Record<string, string> = {
     "Be concise but thorough. Structure feedback clearly.",
   ].join(" "),
 
-  "Kanban::Triage": [
-    "You are commenting on a Basecamp Card Table card.",
-    "Focus on the card's context and triage status.",
-    "Be concise but thorough.",
-  ].join(" "),
-
   "Question": [
     "You are answering a Basecamp check-in question.",
     "Be direct and structured. Match the question format.",

--- a/src/inbound/activity.ts
+++ b/src/inbound/activity.ts
@@ -7,14 +7,10 @@
  * timestamp.
  */
 
-import type {
-  BasecampActivityEvent,
-  BasecampInboundMessage,
-  ResolvedBasecampAccount,
-} from "../types.js";
-import type { CircuitBreaker } from "../circuit-breaker.js";
 import { getClient, rawOrThrow } from "../basecamp-client.js";
+import type { CircuitBreaker } from "../circuit-breaker.js";
 import { withCircuitBreaker } from "../retry.js";
+import type { BasecampActivityEvent, BasecampInboundMessage, ResolvedBasecampAccount } from "../types.js";
 import { normalizeActivityEvent } from "./normalize.js";
 
 export interface ActivityPollResult {
@@ -40,9 +36,7 @@ export interface ActivityPollerOptions {
 /**
  * Poll the activity feed for new events via the Basecamp API.
  */
-export async function pollActivityFeed(
-  opts: ActivityPollerOptions,
-): Promise<ActivityPollResult> {
+export async function pollActivityFeed(opts: ActivityPollerOptions): Promise<ActivityPollResult> {
   const { account, since, log } = opts;
 
   log?.debug?.(`[${account.accountId}] polling activity feed via SDK`);
@@ -80,9 +74,7 @@ export async function pollActivityFeed(
         newestAt = raw.created_at;
       }
     } catch (err) {
-      log?.warn?.(
-        `[${account.accountId}] failed to normalize activity event id=${raw.id}: ${String(err)}`,
-      );
+      log?.warn?.(`[${account.accountId}] failed to normalize activity event id=${raw.id}: ${String(err)}`);
     }
   }
 

--- a/src/inbound/assignments.ts
+++ b/src/inbound/assignments.ts
@@ -12,14 +12,10 @@
  * Subsequent polls: diff current vs stored — new IDs emit assignment events.
  */
 
-import type {
-  BasecampAssignmentTodo,
-  BasecampInboundMessage,
-  ResolvedBasecampAccount,
-} from "../types.js";
-import type { CircuitBreaker } from "../circuit-breaker.js";
 import { getClient, rawOrThrow } from "../basecamp-client.js";
+import type { CircuitBreaker } from "../circuit-breaker.js";
 import { withCircuitBreaker } from "../retry.js";
+import type { BasecampAssignmentTodo, BasecampInboundMessage, ResolvedBasecampAccount } from "../types.js";
 import { normalizeAssignmentTodo } from "./normalize.js";
 
 export interface AssignmentsPollResult {
@@ -89,9 +85,7 @@ function extractTodos(data: unknown): BasecampAssignmentTodo[] {
 /**
  * Poll assignments for newly-assigned todos.
  */
-export async function pollAssignments(
-  opts: AssignmentsPollerOptions,
-): Promise<AssignmentsPollResult> {
+export async function pollAssignments(opts: AssignmentsPollerOptions): Promise<AssignmentsPollResult> {
   const { account, knownIds, isBootstrap, log } = opts;
 
   log?.debug?.(`[${account.accountId}] polling assignments via SDK`);
@@ -108,15 +102,11 @@ export async function pollAssignments(
   const todos = extractTodos(data);
   const currentIds = new Set(todos.map((t) => String(t.id)));
 
-  log?.debug?.(
-    `[${account.accountId}] assignments: ${currentIds.size} current, ${knownIds.size} known`,
-  );
+  log?.debug?.(`[${account.accountId}] assignments: ${currentIds.size} current, ${knownIds.size} known`);
 
   // Bootstrap: record all current IDs without emitting events.
   if (isBootstrap) {
-    log?.info?.(
-      `[${account.accountId}] assignments bootstrap: recording ${currentIds.size} existing assignments`,
-    );
+    log?.info?.(`[${account.accountId}] assignments bootstrap: recording ${currentIds.size} existing assignments`);
     return { events: [], knownIds: currentIds };
   }
 
@@ -137,9 +127,7 @@ export async function pollAssignments(
       const normalized = normalizeAssignmentTodo(todo, account);
       events.push(normalized);
     } catch (err) {
-      log?.warn?.(
-        `[${account.accountId}] failed to normalize assignment todo id=${todo.id}: ${String(err)}`,
-      );
+      log?.warn?.(`[${account.accountId}] failed to normalize assignment todo id=${todo.id}: ${String(err)}`);
     }
   }
 

--- a/src/inbound/cursors.ts
+++ b/src/inbound/cursors.ts
@@ -8,7 +8,7 @@
  * File format: cursors-<accountId>.json
  */
 
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 export interface PollCursors {

--- a/src/inbound/dedup-registry.ts
+++ b/src/inbound/dedup-registry.ts
@@ -12,8 +12,8 @@
 
 import { join } from "node:path";
 import { EventDedup } from "./dedup.js";
-import { openDedupDb } from "./dedup-store-sqlite.js";
 import type { DedupDb } from "./dedup-store-sqlite.js";
+import { openDedupDb } from "./dedup-store-sqlite.js";
 import { resolvePluginStateDir } from "./state-dir.js";
 
 const registry = new Map<string, { dedup: EventDedup; db?: DedupDb; stateDir: string }>();

--- a/src/inbound/dedup-store-sqlite.ts
+++ b/src/inbound/dedup-store-sqlite.ts
@@ -9,10 +9,10 @@
  * with a clear error — this is intentional (platform prerequisite).
  */
 
-import { DatabaseSync } from "node:sqlite";
-import { readFileSync, renameSync, mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync } from "node:fs";
 import { dirname } from "node:path";
-import type { DedupStore, DedupSnapshot, DedupStoreEntry } from "./dedup-store.js";
+import { DatabaseSync } from "node:sqlite";
+import type { DedupSnapshot, DedupStore, DedupStoreEntry } from "./dedup-store.js";
 
 export class DedupDb {
   private readonly db: DatabaseSync;
@@ -60,15 +60,13 @@ export class DedupDb {
    */
   migrateFromJson(legacyPaths: string[]): void {
     // Gate 1: already migrated?
-    const flagRow = this.db.prepare(
-      "SELECT value FROM dedup_meta WHERE key = 'migrated_json'",
-    ).get() as { value: string } | undefined;
+    const flagRow = this.db.prepare("SELECT value FROM dedup_meta WHERE key = 'migrated_json'").get() as
+      | { value: string }
+      | undefined;
     if (flagRow) return;
 
     // Gate 2: DB already populated by normal save()?
-    const countRow = this.db.prepare(
-      "SELECT COUNT(*) AS cnt FROM dedup_primary",
-    ).get() as { cnt: number };
+    const countRow = this.db.prepare("SELECT COUNT(*) AS cnt FROM dedup_primary").get() as { cnt: number };
     if (countRow.cnt > 0) {
       this.db.exec("INSERT OR REPLACE INTO dedup_meta VALUES ('migrated_json', '1')");
       return;
@@ -85,8 +83,12 @@ export class DedupDb {
         if (
           data &&
           typeof data === "object" &&
-          data.primary !== null && typeof data.primary === "object" && !Array.isArray(data.primary) &&
-          data.secondary !== null && typeof data.secondary === "object" && !Array.isArray(data.secondary)
+          data.primary !== null &&
+          typeof data.primary === "object" &&
+          !Array.isArray(data.primary) &&
+          data.secondary !== null &&
+          typeof data.secondary === "object" &&
+          !Array.isArray(data.secondary)
         ) {
           // Merge — INSERT OR IGNORE semantics: first file wins on conflict
           for (const [k, v] of Object.entries(data.primary as Record<string, DedupStoreEntry>)) {
@@ -106,9 +108,7 @@ export class DedupDb {
       }
     }
 
-    const hasCombinedData =
-      Object.keys(combined.primary).length > 0 ||
-      Object.keys(combined.secondary).length > 0;
+    const hasCombinedData = Object.keys(combined.primary).length > 0 || Object.keys(combined.secondary).length > 0;
 
     if (!hasCombinedData && validPaths.length === 0) {
       // No JSON files found or all empty — just set the flag
@@ -123,7 +123,11 @@ export class DedupDb {
       this.db.exec("INSERT OR REPLACE INTO dedup_meta VALUES ('migrated_json', '1')");
       this.db.exec("COMMIT");
     } catch (err) {
-      try { this.db.exec("ROLLBACK"); } catch { /* ignore rollback failure */ }
+      try {
+        this.db.exec("ROLLBACK");
+      } catch {
+        /* ignore rollback failure */
+      }
       console.warn("[dedup-store-sqlite] JSON migration transaction failed:", err);
       return; // Leave JSON files intact for retry
     }
@@ -143,16 +147,12 @@ export class DedupDb {
     this.db.exec("DELETE FROM dedup_primary");
     this.db.exec("DELETE FROM dedup_secondary");
 
-    const insertPrimary = this.db.prepare(
-      "INSERT INTO dedup_primary (key, seen_at, source) VALUES (?, ?, ?)",
-    );
+    const insertPrimary = this.db.prepare("INSERT INTO dedup_primary (key, seen_at, source) VALUES (?, ?, ?)");
     for (const [key, entry] of Object.entries(snapshot.primary)) {
       insertPrimary.run(key, entry.seenAt, entry.source);
     }
 
-    const insertSecondary = this.db.prepare(
-      "INSERT INTO dedup_secondary (key, primary_key) VALUES (?, ?)",
-    );
+    const insertSecondary = this.db.prepare("INSERT INTO dedup_secondary (key, primary_key) VALUES (?, ?)");
     for (const [key, primaryKey] of Object.entries(snapshot.secondary)) {
       insertSecondary.run(key, primaryKey);
     }
@@ -181,16 +181,19 @@ export class SqliteDedupStore implements DedupStore {
       const primary: Record<string, DedupStoreEntry> = {};
       const secondary: Record<string, string> = {};
 
-      const pRows = this.db.prepare(
-        "SELECT key, seen_at, source FROM dedup_primary",
-      ).all() as Array<{ key: string; seen_at: number; source: string }>;
+      const pRows = this.db.prepare("SELECT key, seen_at, source FROM dedup_primary").all() as Array<{
+        key: string;
+        seen_at: number;
+        source: string;
+      }>;
       for (const row of pRows) {
         primary[row.key] = { seenAt: row.seen_at, source: row.source };
       }
 
-      const sRows = this.db.prepare(
-        "SELECT key, primary_key FROM dedup_secondary",
-      ).all() as Array<{ key: string; primary_key: string }>;
+      const sRows = this.db.prepare("SELECT key, primary_key FROM dedup_secondary").all() as Array<{
+        key: string;
+        primary_key: string;
+      }>;
       for (const row of sRows) {
         secondary[row.key] = row.primary_key;
       }
@@ -215,7 +218,11 @@ export class SqliteDedupStore implements DedupStore {
       this._insertSnapshot(snapshot);
       this.db.exec("COMMIT");
     } catch (err) {
-      try { this.db.exec("ROLLBACK"); } catch { /* ignore */ }
+      try {
+        this.db.exec("ROLLBACK");
+      } catch {
+        /* ignore */
+      }
       throw err;
     }
   }
@@ -225,16 +232,12 @@ export class SqliteDedupStore implements DedupStore {
     this.db.exec("DELETE FROM dedup_primary");
     this.db.exec("DELETE FROM dedup_secondary");
 
-    const insertPrimary = this.db.prepare(
-      "INSERT INTO dedup_primary (key, seen_at, source) VALUES (?, ?, ?)",
-    );
+    const insertPrimary = this.db.prepare("INSERT INTO dedup_primary (key, seen_at, source) VALUES (?, ?, ?)");
     for (const [key, entry] of Object.entries(snapshot.primary)) {
       insertPrimary.run(key, entry.seenAt, entry.source);
     }
 
-    const insertSecondary = this.db.prepare(
-      "INSERT INTO dedup_secondary (key, primary_key) VALUES (?, ?)",
-    );
+    const insertSecondary = this.db.prepare("INSERT INTO dedup_secondary (key, primary_key) VALUES (?, ?)");
     for (const [key, primaryKey] of Object.entries(snapshot.secondary)) {
       insertSecondary.run(key, primaryKey);
     }

--- a/src/inbound/dedup-store.ts
+++ b/src/inbound/dedup-store.ts
@@ -9,7 +9,7 @@
  *   { primary: { [key]: { seenAt, source } }, secondary: { [key]: primaryKey } }
  */
 
-import { readFileSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 export interface DedupStoreEntry {
@@ -47,8 +47,12 @@ export class JsonFileDedupStore implements DedupStore {
       if (
         data &&
         typeof data === "object" &&
-        data.primary !== null && typeof data.primary === "object" && !Array.isArray(data.primary) &&
-        data.secondary !== null && typeof data.secondary === "object" && !Array.isArray(data.secondary)
+        data.primary !== null &&
+        typeof data.primary === "object" &&
+        !Array.isArray(data.primary) &&
+        data.secondary !== null &&
+        typeof data.secondary === "object" &&
+        !Array.isArray(data.secondary)
       ) {
         return data as DedupSnapshot;
       }

--- a/src/inbound/dedup.ts
+++ b/src/inbound/dedup.ts
@@ -83,11 +83,7 @@ export class EventDedup {
    *
    * @example secondaryKey("456", "created", "2025-01-15T10:00:00Z") → "456:created:2025-01-15T10:00:00Z"
    */
-  static secondaryKey(
-    recordingId: string | number,
-    action: string,
-    createdAt: string,
-  ): string {
+  static secondaryKey(recordingId: string | number, action: string, createdAt: string): string {
     return `${recordingId}:${action}:${createdAt}`;
   }
 
@@ -97,10 +93,7 @@ export class EventDedup {
    * Checks both the primary key and optional secondary key.
    * If not a duplicate, records the event and returns false.
    */
-  isDuplicate(
-    primaryKey: string,
-    secondaryKey?: string,
-  ): boolean {
+  isDuplicate(primaryKey: string, secondaryKey?: string): boolean {
     const now = Date.now();
 
     // Check primary key

--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -10,6 +10,9 @@
  */
 
 import crypto from "node:crypto";
+import { extractAttachmentSgids, htmlToPlainText, mentionsAgent } from "../mentions/parse.js";
+import { recordUnknownKind } from "../metrics.js";
+import { resolveCircleInfoCached } from "../outbound/send.js";
 import type {
   BasecampActivityEvent,
   BasecampAssignmentTodo,
@@ -20,13 +23,10 @@ import type {
   BasecampRecordableType,
   BasecampSender,
   BasecampWebhookPayload,
-  WebhookEventDetails,
   ResolvedBasecampAccount,
+  WebhookEventDetails,
 } from "../types.js";
-import { mentionsAgent, extractAttachmentSgids, htmlToPlainText } from "../mentions/parse.js";
 import { EventDedup } from "./dedup.js";
-import { recordUnknownKind } from "../metrics.js";
-import { resolveCircleInfoCached } from "../outbound/send.js";
 
 // ---------------------------------------------------------------------------
 // event.kind → recordableType mapping (expanded from TimelinesApiHelper)
@@ -121,10 +121,7 @@ export function resolveEventKind(kind: string): string {
 }
 
 /** Resolve recordable type from event kind, falling back to recording.type. */
-function resolveRecordableType(
-  kind: string,
-  recordingType?: string,
-): BasecampRecordableType | undefined {
+function resolveRecordableType(kind: string, recordingType?: string): BasecampRecordableType | undefined {
   const mapped = KIND_TO_RECORDABLE_TYPE[kind];
   if (mapped) return mapped;
 
@@ -161,9 +158,20 @@ function normalizeRecordingType(type: string): BasecampRecordableType | undefine
 
   if (type.includes("::")) {
     const known: string[] = [
-      "Chat::Transcript", "Chat::Line", "Kanban::Card", "Kanban::Column",
-      "Comment", "Message", "Todo", "Todolist", "Question", "Question::Answer",
-      "Document", "Upload", "Vault", "Schedule::Entry",
+      "Chat::Transcript",
+      "Chat::Line",
+      "Kanban::Card",
+      "Kanban::Column",
+      "Comment",
+      "Message",
+      "Todo",
+      "Todolist",
+      "Question",
+      "Question::Answer",
+      "Document",
+      "Upload",
+      "Vault",
+      "Schedule::Entry",
     ];
     if (known.includes(type)) return type as BasecampRecordableType;
   }
@@ -193,7 +201,10 @@ export function parseBucketIdFromUrl(url: string): string | undefined {
  */
 export function parseRecordingIdFromUrl(url: string): string | undefined {
   // Match the last /<resource-type>/<numeric-id> in the URL
-  const match = /\/(?:messages|todos|todolists|cards|chats|recordings|comments|documents|uploads|vaults|questions|question_answers|schedule_entries|lines|forwards|replies)\/(\d+)/.exec(url);
+  const match =
+    /\/(?:messages|todos|todolists|cards|chats|recordings|comments|documents|uploads|vaults|questions|question_answers|schedule_entries|lines|forwards|replies)\/(\d+)/.exec(
+      url,
+    );
   return match ? match[1] : undefined;
 }
 
@@ -223,17 +234,14 @@ export function resolveBasecampPeer(params: {
   isPing?: boolean;
   participantCount?: number;
 }): BasecampPeer {
-  const { recordableType, recordingId, parentRecordingId, bucketId, isPing, participantCount } =
-    params;
+  const { recordableType, recordingId, parentRecordingId, bucketId, isPing, participantCount } = params;
 
   if (isPing) {
     // Fail closed: when participant count is unknown (Circle API failure),
     // default to "dm" so DM policy applies. This prevents API outages from
     // relaxing DM gating on actual 1:1 Pings by misclassifying them as group.
     // When count is known: ≤2 = dm, >2 = group.
-    const kind = participantCount != null && participantCount > 2
-      ? "group"
-      : "dm";
+    const kind = participantCount != null && participantCount > 2 ? "group" : "dm";
     return { kind, id: `ping:${bucketId}` };
   }
 
@@ -256,10 +264,7 @@ export function resolveBasecampPeer(params: {
  * Resolve parent peer for project-level routing.
  * bucket:<bucketId> for non-Pings, undefined for Pings.
  */
-export function resolveParentPeer(
-  bucketId: string,
-  isPing: boolean,
-): BasecampPeer | undefined {
+export function resolveParentPeer(bucketId: string, isPing: boolean): BasecampPeer | undefined {
   if (isPing) return undefined;
   return { kind: "group", id: `bucket:${bucketId}` };
 }
@@ -268,10 +273,7 @@ export function resolveParentPeer(
 // Self-message detection
 // ---------------------------------------------------------------------------
 
-export function isSelfMessage(
-  creatorId: string | number,
-  account: ResolvedBasecampAccount,
-): boolean {
+export function isSelfMessage(creatorId: string | number, account: ResolvedBasecampAccount): boolean {
   return String(creatorId) === String(account.personId);
 }
 
@@ -317,10 +319,7 @@ export async function normalizeActivityEvent(
   raw: BasecampActivityEvent,
   account: ResolvedBasecampAccount,
 ): Promise<BasecampInboundMessage | null> {
-  const recordableType = resolveRecordableType(
-    raw.kind,
-    raw.recording?.recordable_type ?? raw.recording?.type,
-  );
+  const recordableType = resolveRecordableType(raw.kind, raw.recording?.recordable_type ?? raw.recording?.type);
 
   // Unknown kind → drop with metric rather than misclassifying as Document
   if (!recordableType) {
@@ -348,9 +347,7 @@ export async function normalizeActivityEvent(
     recordingId = String(raw.id);
   }
 
-  const parentRecordingId = raw.parent_recording_id
-    ? String(raw.parent_recording_id)
-    : undefined;
+  const parentRecordingId = raw.parent_recording_id ? String(raw.parent_recording_id) : undefined;
 
   const content = raw.recording?.content ?? raw.summary_excerpt ?? raw.title ?? "";
   const text = content ? htmlToPlainText(content) : (raw.title ?? "");
@@ -477,9 +474,7 @@ export function normalizeReadingsEvent(
   const html = raw.content_excerpt ?? "";
 
   const sgids = extractAttachmentSgids(html);
-  const isAgentMentioned =
-    mentionsAgent(html, account.attachableSgid, account.personId) ||
-    raw.section === "mentions";
+  const isAgentMentioned = mentionsAgent(html, account.attachableSgid, account.personId) || raw.section === "mentions";
 
   const sender: BasecampSender = raw.creator
     ? {
@@ -563,8 +558,7 @@ export function normalizeAssignmentTodo(
 
   // Use the actual type from the API response when available (e.g. "Todo",
   // "Schedule"). Fall back to "Todo" for legacy/untyped payloads.
-  const recordableType: BasecampRecordableType =
-    (raw.type && normalizeRecordingType(raw.type)) || "Todo";
+  const recordableType: BasecampRecordableType = (raw.type && normalizeRecordingType(raw.type)) || "Todo";
 
   const peer = resolveBasecampPeer({
     recordableType,
@@ -625,9 +619,7 @@ export async function normalizeWebhookPayload(
   }
 
   const recordingId = String(raw.recording.id);
-  const parentRecordingId = raw.recording.parent
-    ? String(raw.recording.parent.id)
-    : undefined;
+  const parentRecordingId = raw.recording.parent ? String(raw.recording.parent.id) : undefined;
   const bucketId = String(raw.recording.bucket.id);
 
   const content = raw.recording.content ?? raw.recording.title ?? "";

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -17,27 +17,47 @@
  * backoff on errors (max 5 minutes).
  */
 
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { getClient, rawOrThrow } from "../basecamp-client.js";
+import { CircuitBreaker } from "../circuit-breaker.js";
+import {
+  listBasecampAccountIds,
+  resolveAccountForBucket,
+  resolveCircuitBreakerConfig,
+  resolvePollingIntervals,
+  resolveReconciliationConfig,
+  resolveSafetyNetConfig,
+} from "../config.js";
+import { createStructuredLog } from "../logging.js";
+import {
+  recordCircuitBreakerState,
+  recordDedupSize,
+  recordPollAttempt,
+  recordPollError,
+  recordPollSuccess,
+  recordReconciliationRun,
+} from "../metrics.js";
+import { withCircuitBreaker } from "../retry.js";
 import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../types.js";
-import { resolvePollingIntervals, resolveCircuitBreakerConfig, resolveSafetyNetConfig, resolveReconciliationConfig, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
+import { withTimeout } from "../util.js";
+import { pollActivityFeed } from "./activity.js";
+import { pollAssignments } from "./assignments.js";
+import { CursorStore } from "./cursors.js";
 import { EventDedup } from "./dedup.js";
 import { getAccountDedup } from "./dedup-registry.js";
-import { resolvePluginStateDir } from "./state-dir.js";
-import { CursorStore } from "./cursors.js";
-import { pollActivityFeed } from "./activity.js";
-import { pollReadings } from "./readings.js";
-import { pollAssignments } from "./assignments.js";
-import { pollSafetyNet, deserializeSnapshot, serializeSnapshot, deserializePending, serializePending } from "./safety-net.js";
-import type { SafetyNetSnapshot, DisappearedPending } from "./safety-net.js";
-import { runReconciliation, deserializePromotionState, serializePromotionState } from "./reconciliation.js";
-import type { PromotionState } from "./reconciliation.js";
-import { CircuitBreaker } from "../circuit-breaker.js";
-import { getClient, rawOrThrow } from "../basecamp-client.js";
-import { withCircuitBreaker } from "../retry.js";
 import { isSelfMessage } from "./normalize.js";
-import { createStructuredLog } from "../logging.js";
-import { recordPollAttempt, recordPollSuccess, recordPollError, recordDedupSize, recordCircuitBreakerState, recordReconciliationRun } from "../metrics.js";
-import { withTimeout } from "../util.js";
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { pollReadings } from "./readings.js";
+import type { PromotionState } from "./reconciliation.js";
+import { deserializePromotionState, runReconciliation, serializePromotionState } from "./reconciliation.js";
+import type { DisappearedPending, SafetyNetSnapshot } from "./safety-net.js";
+import {
+  deserializePending,
+  deserializeSnapshot,
+  pollSafetyNet,
+  serializePending,
+  serializeSnapshot,
+} from "./safety-net.js";
+import { resolvePluginStateDir } from "./state-dir.js";
 
 export interface CompositePollerOptions {
   account: ResolvedBasecampAccount;
@@ -64,7 +84,14 @@ function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
       return;
     }
     const timer = setTimeout(resolve, ms);
-    signal?.addEventListener("abort", () => { clearTimeout(timer); resolve(); }, { once: true });
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
   });
 }
 
@@ -73,10 +100,7 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 /** Save cursors with one retry after 1s delay on failure. */
-async function saveCursorsWithRetry(
-  cursors: CursorStore,
-  slog: ReturnType<typeof createStructuredLog>,
-): Promise<void> {
+async function saveCursorsWithRetry(cursors: CursorStore, slog: ReturnType<typeof createStructuredLog>): Promise<void> {
   try {
     await cursors.save();
   } catch (err) {
@@ -93,9 +117,7 @@ async function saveCursorsWithRetry(
 /**
  * Start the composite poller. Long-running; resolves when abort fires.
  */
-export async function startCompositePoller(
-  opts: CompositePollerOptions,
-): Promise<void> {
+export async function startCompositePoller(opts: CompositePollerOptions): Promise<void> {
   const { account, cfg, abortSignal, onEvent, log } = opts;
   const slog = createStructuredLog(log, { accountId: account.accountId, source: "poller" });
 
@@ -189,7 +211,7 @@ export async function startCompositePoller(
 
   // Resolve safety-net projects scoped to this account
   const allSnProjects = snConfig.projects;
-  let accountSnProjects: number[] = [];
+  const accountSnProjects: number[] = [];
   if (allSnProjects.length > 0) {
     const concreteAccountIds = listBasecampAccountIds(cfg as OpenClawConfig);
     const isSingleAccount = concreteAccountIds.length <= 1;
@@ -230,7 +252,9 @@ export async function startCompositePoller(
     activityMs: activityIntervalMs,
     readingsMs: readingsIntervalMs,
     assignmentsMs: assignmentsIntervalMs,
-    ...(webhookActive ? { mode: "reconciliation", webhookProjects: opts.webhookActiveProjects!.size } : { mode: "primary" }),
+    ...(webhookActive
+      ? { mode: "reconciliation", webhookProjects: opts.webhookActiveProjects!.size }
+      : { mode: "primary" }),
   });
 
   while (!abortSignal?.aborted) {
@@ -336,9 +360,11 @@ export async function startCompositePoller(
           try {
             const markRead = async () => {
               const client = getClient(account);
-              await rawOrThrow(await client.raw.PUT("/my/unreads.json" as any, {
-                body: { readables: result.processedSgids } as any,
-              }));
+              await rawOrThrow(
+                await client.raw.PUT("/my/unreads.json" as any, {
+                  body: { readables: result.processedSgids } as any,
+                }),
+              );
             };
             await withCircuitBreaker(cb, "readings:mark-read", markRead);
             slog.debug("readings_marked_read", { count: result.processedSgids.length });
@@ -522,10 +548,7 @@ export async function startCompositePoller(
             promotions: result.promotions,
             previousGaps: result.gapsByType,
           };
-          cursors.setCustom(
-            "reconciliation:promotions",
-            serializePromotionState(result.promotions, result.gapsByType),
-          );
+          cursors.setCustom("reconciliation:promotions", serializePromotionState(result.promotions, result.gapsByType));
           await saveCursorsWithRetry(cursors, slog);
 
           recordReconciliationRun(account.accountId, {

--- a/src/inbound/readings.ts
+++ b/src/inbound/readings.ts
@@ -6,14 +6,10 @@
  * account hasn't "read" yet.
  */
 
-import type {
-  BasecampInboundMessage,
-  BasecampReadingsEntry,
-  ResolvedBasecampAccount,
-} from "../types.js";
-import type { CircuitBreaker } from "../circuit-breaker.js";
 import { getClient, rawOrThrow } from "../basecamp-client.js";
+import type { CircuitBreaker } from "../circuit-breaker.js";
 import { withCircuitBreaker } from "../retry.js";
+import type { BasecampInboundMessage, BasecampReadingsEntry, ResolvedBasecampAccount } from "../types.js";
 import { normalizeReadingsEvent } from "./normalize.js";
 
 export interface ReadingsPollResult {
@@ -41,9 +37,7 @@ export interface ReadingsPollerOptions {
 /**
  * Poll Hey! Readings for unread items.
  */
-export async function pollReadings(
-  opts: ReadingsPollerOptions,
-): Promise<ReadingsPollResult> {
+export async function pollReadings(opts: ReadingsPollerOptions): Promise<ReadingsPollResult> {
   const { account, since, log } = opts;
 
   log?.debug?.(`[${account.accountId}] polling readings via SDK`);
@@ -98,9 +92,7 @@ export async function pollReadings(
       if (!normalized) continue;
       events.push(normalized);
     } catch (err) {
-      log?.warn?.(
-        `[${account.accountId}] failed to normalize reading id=${raw.id}: ${String(err)}`,
-      );
+      log?.warn?.(`[${account.accountId}] failed to normalize reading id=${raw.id}: ${String(err)}`);
     }
   }
 

--- a/src/inbound/reconciliation.ts
+++ b/src/inbound/reconciliation.ts
@@ -19,7 +19,7 @@ import { isNormalizableKind, recordableTypeForKind, resolveEventKind } from "./n
 // Which recordable types can be promoted to safety-net direct polling
 const PROMOTABLE_TYPES: Partial<Record<BasecampRecordableType, string>> = {
   "Kanban::Card": "cards",
-  "Todo": "todos",
+  Todo: "todos",
   "Question::Answer": "checkins",
 };
 
@@ -80,25 +80,15 @@ export interface ReconciliationOptions {
   };
 }
 
-export async function runReconciliation(
-  opts: ReconciliationOptions,
-): Promise<ReconciliationResult> {
-  const {
-    account,
-    client,
-    dedup,
-    log,
-    maxItems = 250,
-    windowMs = 24 * 60 * 60 * 1000,
-    gapThreshold = 3,
-  } = opts;
+export async function runReconciliation(opts: ReconciliationOptions): Promise<ReconciliationResult> {
+  const { account, client, dedup, log, maxItems = 250, windowMs = 24 * 60 * 60 * 1000, gapThreshold = 3 } = opts;
 
   const cutoff = new Date(Date.now() - windowMs).toISOString();
 
   // Fetch recent activity
   let rawEvents: BasecampActivityEvent[];
   try {
-    rawEvents = await client.reports.progress({ maxItems }) as BasecampActivityEvent[];
+    rawEvents = (await client.reports.progress({ maxItems })) as BasecampActivityEvent[];
     if (!Array.isArray(rawEvents)) rawEvents = [];
   } catch (err) {
     log?.error?.(`[${account.accountId}] reconciliation: fetch failed: ${String(err)}`);
@@ -163,9 +153,7 @@ function applyPromotionLogic(opts: {
   const { gapsByType, gapThreshold, previousState } = opts;
   const now = Date.now();
   const previousGaps = previousState?.previousGaps ?? {};
-  const existing = (previousState?.promotions ?? []).filter(
-    (p) => now - p.promotedAt < PROMOTION_TTL_MS,
-  );
+  const existing = (previousState?.promotions ?? []).filter((p) => now - p.promotedAt < PROMOTION_TTL_MS);
 
   const result: PromotionEntry[] = [];
 

--- a/src/inbound/safety-net.ts
+++ b/src/inbound/safety-net.ts
@@ -14,24 +14,20 @@
  */
 
 import crypto from "node:crypto";
+import { BasecampError } from "../basecamp-client.js";
 import type {
+  BasecampEventKind,
   BasecampInboundMessage,
   BasecampInboundMeta,
-  BasecampEventKind,
   BasecampRecordableType,
   ResolvedBasecampAccount,
 } from "../types.js";
 import { EventDedup } from "./dedup.js";
-import { resolveDockToolIds, invalidateDockCache } from "./dock-cache.js";
-import { BasecampError } from "../basecamp-client.js";
+import { invalidateDockCache, resolveDockToolIds } from "./dock-cache.js";
 
 function isStaleResourceError(err: unknown): boolean {
   if (err instanceof BasecampError) {
-    return (
-      err.httpStatus === 404 ||
-      err.httpStatus === 410 ||
-      err.code === "not_found"
-    );
+    return err.httpStatus === 404 || err.httpStatus === 410 || err.code === "not_found";
   }
   return false;
 }
@@ -152,9 +148,7 @@ export interface SafetyNetPollOptions {
   };
 }
 
-export async function pollSafetyNet(
-  opts: SafetyNetPollOptions,
-): Promise<SafetyNetPollResult> {
+export async function pollSafetyNet(opts: SafetyNetPollOptions): Promise<SafetyNetPollResult> {
   const { account, client, projectIds, previousSnapshot, isDeepCrawl, log } = opts;
   const maxItems = isDeepCrawl ? undefined : (opts.maxItems ?? 50);
   const events: BasecampInboundMessage[] = [];
@@ -198,32 +192,36 @@ export async function pollSafetyNet(
             if (!prev) {
               // Appeared
               const hash = changeHash(`appeared:${cardId}`);
-              events.push(buildDeltaMessage({
-                accountId: account.accountId,
-                projectId,
-                recordingId: cardId,
-                recordableType: "Kanban::Card",
-                eventKind: "created",
-                text: `Card ${cardId} appeared in ${card.columnName}`,
-                dedupKey: `direct:card:${cardId}:${hash}`,
-                createdAt: card.updatedAt,
-                extraMeta: { column: card.columnName, assignees: card.assignees },
-              }));
-            } else {
-              if (prev.columnId !== card.columnId) {
-                // Moved
-                const hash = changeHash(`moved:${cardId}:${prev.columnId}:${card.columnId}`);
-                events.push(buildDeltaMessage({
+              events.push(
+                buildDeltaMessage({
                   accountId: account.accountId,
                   projectId,
                   recordingId: cardId,
                   recordableType: "Kanban::Card",
-                  eventKind: "moved",
-                  text: `Card ${cardId} moved from ${prev.columnName} to ${card.columnName}`,
+                  eventKind: "created",
+                  text: `Card ${cardId} appeared in ${card.columnName}`,
                   dedupKey: `direct:card:${cardId}:${hash}`,
                   createdAt: card.updatedAt,
-                  extraMeta: { column: card.columnName, columnPrevious: prev.columnName },
-                }));
+                  extraMeta: { column: card.columnName, assignees: card.assignees },
+                }),
+              );
+            } else {
+              if (prev.columnId !== card.columnId) {
+                // Moved
+                const hash = changeHash(`moved:${cardId}:${prev.columnId}:${card.columnId}`);
+                events.push(
+                  buildDeltaMessage({
+                    accountId: account.accountId,
+                    projectId,
+                    recordingId: cardId,
+                    recordableType: "Kanban::Card",
+                    eventKind: "moved",
+                    text: `Card ${cardId} moved from ${prev.columnName} to ${card.columnName}`,
+                    dedupKey: `direct:card:${cardId}:${hash}`,
+                    createdAt: card.updatedAt,
+                    extraMeta: { column: card.columnName, columnPrevious: prev.columnName },
+                  }),
+                );
               }
               // Assignment diff
               const added = card.assignees.filter((a) => !prev.assignees.includes(a));
@@ -231,20 +229,22 @@ export async function pollSafetyNet(
               if (added.length > 0 || removed.length > 0) {
                 const hash = changeHash(`assign:${cardId}:${card.assignees.sort().join(",")}`);
                 const agentAssigned = account.personId ? added.includes(account.personId) : false;
-                events.push(buildDeltaMessage({
-                  accountId: account.accountId,
-                  projectId,
-                  recordingId: cardId,
-                  recordableType: "Kanban::Card",
-                  eventKind: "assigned",
-                  text: `Card ${cardId} assignees changed: +${added.length} -${removed.length}`,
-                  dedupKey: `direct:card:${cardId}:${hash}`,
-                  createdAt: card.updatedAt,
-                  extraMeta: {
-                    assignees: card.assignees,
-                    assignedToAgent: agentAssigned || undefined,
-                  },
-                }));
+                events.push(
+                  buildDeltaMessage({
+                    accountId: account.accountId,
+                    projectId,
+                    recordingId: cardId,
+                    recordableType: "Kanban::Card",
+                    eventKind: "assigned",
+                    text: `Card ${cardId} assignees changed: +${added.length} -${removed.length}`,
+                    dedupKey: `direct:card:${cardId}:${hash}`,
+                    createdAt: card.updatedAt,
+                    extraMeta: {
+                      assignees: card.assignees,
+                      assignedToAgent: agentAssigned || undefined,
+                    },
+                  }),
+                );
               }
             }
           }
@@ -257,16 +257,18 @@ export async function pollSafetyNet(
                 pending.entries[pendingKey] = (pending.entries[pendingKey] ?? 0) + 1;
                 if (pending.entries[pendingKey] >= 2) {
                   const hash = changeHash(`disappeared:${cardId}`);
-                  events.push(buildDeltaMessage({
-                    accountId: account.accountId,
-                    projectId,
-                    recordingId: cardId,
-                    recordableType: "Kanban::Card",
-                    eventKind: "disappeared",
-                    text: `Card ${cardId} disappeared`,
-                    dedupKey: `direct:card:${cardId}:${hash}`,
-                    createdAt: new Date().toISOString(),
-                  }));
+                  events.push(
+                    buildDeltaMessage({
+                      accountId: account.accountId,
+                      projectId,
+                      recordingId: cardId,
+                      recordableType: "Kanban::Card",
+                      eventKind: "disappeared",
+                      text: `Card ${cardId} disappeared`,
+                      dedupKey: `direct:card:${cardId}:${hash}`,
+                      createdAt: new Date().toISOString(),
+                    }),
+                  );
                   delete pending.entries[pendingKey];
                 }
               } else {
@@ -295,17 +297,19 @@ export async function pollSafetyNet(
             const prev = prevProject.todos[todoId];
             if (!prev) {
               const hash = changeHash(`appeared:${todoId}`);
-              events.push(buildDeltaMessage({
-                accountId: account.accountId,
-                projectId,
-                recordingId: todoId,
-                recordableType: "Todo",
-                eventKind: "created",
-                text: `Todo ${todoId} appeared`,
-                dedupKey: `direct:todo:${todoId}:${hash}`,
-                createdAt: todo.updatedAt,
-                extraMeta: { assignees: todo.assignees },
-              }));
+              events.push(
+                buildDeltaMessage({
+                  accountId: account.accountId,
+                  projectId,
+                  recordingId: todoId,
+                  recordableType: "Todo",
+                  eventKind: "created",
+                  text: `Todo ${todoId} appeared`,
+                  dedupKey: `direct:todo:${todoId}:${hash}`,
+                  createdAt: todo.updatedAt,
+                  extraMeta: { assignees: todo.assignees },
+                }),
+              );
             } else {
               // Assignment diff
               const added = todo.assignees.filter((a) => !prev.assignees.includes(a));
@@ -313,20 +317,22 @@ export async function pollSafetyNet(
               if (added.length > 0 || removed.length > 0) {
                 const hash = changeHash(`assign:${todoId}:${todo.assignees.sort().join(",")}`);
                 const agentAssigned = account.personId ? added.includes(account.personId) : false;
-                events.push(buildDeltaMessage({
-                  accountId: account.accountId,
-                  projectId,
-                  recordingId: todoId,
-                  recordableType: "Todo",
-                  eventKind: "assigned",
-                  text: `Todo ${todoId} assignees changed: +${added.length} -${removed.length}`,
-                  dedupKey: `direct:todo:${todoId}:${hash}`,
-                  createdAt: todo.updatedAt,
-                  extraMeta: {
-                    assignees: todo.assignees,
-                    assignedToAgent: agentAssigned || undefined,
-                  },
-                }));
+                events.push(
+                  buildDeltaMessage({
+                    accountId: account.accountId,
+                    projectId,
+                    recordingId: todoId,
+                    recordableType: "Todo",
+                    eventKind: "assigned",
+                    text: `Todo ${todoId} assignees changed: +${added.length} -${removed.length}`,
+                    dedupKey: `direct:todo:${todoId}:${hash}`,
+                    createdAt: todo.updatedAt,
+                    extraMeta: {
+                      assignees: todo.assignees,
+                      assignedToAgent: agentAssigned || undefined,
+                    },
+                  }),
+                );
               }
             }
           }
@@ -338,16 +344,18 @@ export async function pollSafetyNet(
                 pending.entries[pendingKey] = (pending.entries[pendingKey] ?? 0) + 1;
                 if (pending.entries[pendingKey] >= 2) {
                   const hash = changeHash(`disappeared:${todoId}`);
-                  events.push(buildDeltaMessage({
-                    accountId: account.accountId,
-                    projectId,
-                    recordingId: todoId,
-                    recordableType: "Todo",
-                    eventKind: "disappeared",
-                    text: `Todo ${todoId} disappeared`,
-                    dedupKey: `direct:todo:${todoId}:${hash}`,
-                    createdAt: new Date().toISOString(),
-                  }));
+                  events.push(
+                    buildDeltaMessage({
+                      accountId: account.accountId,
+                      projectId,
+                      recordingId: todoId,
+                      recordableType: "Todo",
+                      eventKind: "disappeared",
+                      text: `Todo ${todoId} disappeared`,
+                      dedupKey: `direct:todo:${todoId}:${hash}`,
+                      createdAt: new Date().toISOString(),
+                    }),
+                  );
                   delete pending.entries[pendingKey];
                 }
               } else {
@@ -376,16 +384,18 @@ export async function pollSafetyNet(
               const prevSet = new Set(prev.answerIds);
               const newAnswerIds = q.answerIds.filter((id) => !prevSet.has(id));
               for (const answerId of newAnswerIds) {
-                events.push(buildDeltaMessage({
-                  accountId: account.accountId,
-                  projectId,
-                  recordingId: answerId,
-                  recordableType: "Question::Answer",
-                  eventKind: "checkin_answered",
-                  text: `New answer ${answerId} to check-in question ${questionId}`,
-                  dedupKey: `direct:answer:${answerId}`,
-                  createdAt: new Date().toISOString(),
-                }));
+                events.push(
+                  buildDeltaMessage({
+                    accountId: account.accountId,
+                    projectId,
+                    recordingId: answerId,
+                    recordableType: "Question::Answer",
+                    eventKind: "checkin_answered",
+                    text: `New answer ${answerId} to check-in question ${questionId}`,
+                    dedupKey: `direct:answer:${answerId}`,
+                    createdAt: new Date().toISOString(),
+                  }),
+                );
               }
             }
           }
@@ -393,7 +403,9 @@ export async function pollSafetyNet(
       } catch (err) {
         if (isStaleResourceError(err)) invalidateDockCache(projectId);
         if (prevProject) projectSnap.checkins = prevProject.checkins;
-        log?.warn?.(`[${account.accountId}] safety_net: checkins crawl failed for project ${projectId}: ${String(err)}`);
+        log?.warn?.(
+          `[${account.accountId}] safety_net: checkins crawl failed for project ${projectId}: ${String(err)}`,
+        );
       }
     }
 
@@ -434,9 +446,7 @@ async function crawlCards(
     if (result?.meta?.truncated) truncated = true;
 
     for (const card of items) {
-      const assignees: string[] = Array.isArray(card.assignees)
-        ? card.assignees.map((a: any) => String(a.id))
-        : [];
+      const assignees: string[] = Array.isArray(card.assignees) ? card.assignees.map((a: any) => String(a.id)) : [];
       cards[String(card.id)] = {
         columnId: col.id,
         columnName: col.title,
@@ -454,11 +464,7 @@ interface TodoCrawlResult {
   truncated: boolean;
 }
 
-async function crawlTodos(
-  client: any,
-  projectId: number,
-  maxItems?: number,
-): Promise<TodoCrawlResult> {
+async function crawlTodos(client: any, projectId: number, maxItems?: number): Promise<TodoCrawlResult> {
   const todos: Record<string, TodoSnapshot> = {};
   let truncated = false;
 
@@ -471,9 +477,7 @@ async function crawlTodos(
   if (result?.meta?.truncated) truncated = true;
 
   for (const todo of items) {
-    const assignees: string[] = Array.isArray(todo.assignees)
-      ? todo.assignees.map((a: any) => String(a.id))
-      : [];
+    const assignees: string[] = Array.isArray(todo.assignees) ? todo.assignees.map((a: any) => String(a.id)) : [];
     todos[String(todo.id)] = {
       updatedAt: todo.updated_at ?? new Date().toISOString(),
       assignees,
@@ -487,11 +491,7 @@ interface CheckinCrawlResult {
   checkins: Record<string, CheckinSnapshot>;
 }
 
-async function crawlCheckins(
-  client: any,
-  projectId: number,
-  questionnaireId: number,
-): Promise<CheckinCrawlResult> {
+async function crawlCheckins(client: any, projectId: number, questionnaireId: number): Promise<CheckinCrawlResult> {
   const checkins: Record<string, CheckinSnapshot> = {};
 
   const questions = await client.checkins.listQuestions(projectId, questionnaireId);

--- a/src/inbound/state-dir.ts
+++ b/src/inbound/state-dir.ts
@@ -21,7 +21,7 @@ export function resolvePluginStateDir(): string {
       fallbackWarned = true;
       console.warn(
         `[basecamp:state-dir] runtime unavailable, using fallback ${FALLBACK_STATE_DIR} — ` +
-        "secrets and dedup state will persist here until runtime is available",
+          "secrets and dedup state will persist here until runtime is available",
       );
     }
     // Create with restrictive permissions — may contain webhook secrets and dedup DBs

--- a/src/inbound/webhook-lifecycle.ts
+++ b/src/inbound/webhook-lifecycle.ts
@@ -9,10 +9,10 @@
  * so HMAC verification survives restarts.
  */
 
-import type { ResolvedBasecampAccount } from "../types.js";
 import { getClient, numId, rawOrThrow } from "../basecamp-client.js";
-import type { WebhookSecretRegistry } from "./webhook-secrets.js";
 import type { StructuredLog } from "../logging.js";
+import type { ResolvedBasecampAccount } from "../types.js";
+import type { WebhookSecretRegistry } from "./webhook-secrets.js";
 
 export interface WebhookLifecycleConfig {
   /** HTTPS URL where Basecamp sends webhook payloads. */
@@ -79,16 +79,14 @@ export async function reconcileWebhooks(
       let existing: WebhookRecord[] = [];
       try {
         const listResult = await client.webhooks.list(numId("project", projectId));
-        existing = Array.isArray(listResult) ? listResult as any : [];
+        existing = Array.isArray(listResult) ? (listResult as any) : [];
       } catch {
         // List failed — treat as empty (will attempt create)
         existing = [];
       }
 
       // Check if a webhook with our payloadUrl already exists
-      const urlMatch = existing.find(
-        (wh) => wh.payload_url === config.payloadUrl && wh.active,
-      );
+      const urlMatch = existing.find((wh) => wh.payload_url === config.payloadUrl && wh.active);
 
       if (urlMatch && typesMatch(urlMatch.types, config.types)) {
         log?.debug("webhook_exists", {
@@ -145,10 +143,7 @@ export async function reconcileWebhooks(
       }
 
       const webhook = await rawOrThrow<WebhookRecord>(
-        await client.raw.POST(
-          `/buckets/${projectId}/webhooks.json` as any,
-          { body: createBody as any },
-        ),
+        await client.raw.POST(`/buckets/${projectId}/webhooks.json` as any, { body: createBody as any }),
       );
 
       if (!webhook?.id) {

--- a/src/inbound/webhook-secrets.ts
+++ b/src/inbound/webhook-secrets.ts
@@ -8,7 +8,7 @@
  * Format: { [projectId]: { webhookId, secret, payloadUrl, types } }
  */
 
-import { readFileSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 export interface WebhookSecretEntry {

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -10,20 +10,34 @@
  * (recording:id:kind:ts) which both sources generate for the same event.
  */
 
-import type { IncomingMessage, ServerResponse } from "node:http";
 import crypto from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { join } from "node:path";
+import {
+  listBasecampAccountIds,
+  resolveAccountForBucket,
+  resolveBasecampAccount,
+  resolveDefaultBasecampAccountId,
+  resolveWebhookSecret,
+} from "../config.js";
+import { dispatchBasecampEvent } from "../dispatch.js";
+import { createConsoleStructuredLog } from "../logging.js";
+import {
+  recordQueueFullDrop,
+  recordWebhookAuthMethod,
+  recordWebhookDedupSize,
+  recordWebhookDispatched,
+  recordWebhookDropped,
+  recordWebhookError,
+  recordWebhookReceived,
+} from "../metrics.js";
+import { getBasecampRuntime } from "../runtime.js";
 import type { BasecampWebhookPayload, ResolvedBasecampAccount } from "../types.js";
-import { normalizeWebhookPayload, isSelfMessage } from "./normalize.js";
 import { EventDedup } from "./dedup.js";
 import { getAccountDedup } from "./dedup-registry.js";
+import { isSelfMessage, normalizeWebhookPayload } from "./normalize.js";
 import { resolvePluginStateDir } from "./state-dir.js";
-import { WebhookSecretRegistry, JsonFileWebhookSecretStore } from "./webhook-secrets.js";
-import { dispatchBasecampEvent } from "../dispatch.js";
-import { getBasecampRuntime } from "../runtime.js";
-import { resolveBasecampAccount, resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../config.js";
-import { createConsoleStructuredLog } from "../logging.js";
-import { recordWebhookReceived, recordWebhookDispatched, recordWebhookDropped, recordWebhookError, recordWebhookDedupSize, recordQueueFullDrop, recordWebhookAuthMethod } from "../metrics.js";
+import { JsonFileWebhookSecretStore, WebhookSecretRegistry } from "./webhook-secrets.js";
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter
@@ -135,10 +149,7 @@ export function verifyWebhookSignature(params: {
   const signedPayload = `${timestamp}.${rawBody}`;
 
   for (const secret of secrets) {
-    const expected = "sha256=" + crypto
-      .createHmac("sha256", secret)
-      .update(signedPayload)
-      .digest("hex");
+    const expected = "sha256=" + crypto.createHmac("sha256", secret).update(signedPayload).digest("hex");
 
     // Timing-safe comparison
     if (expected.length === signature.length) {
@@ -205,10 +216,7 @@ function readBody(req: IncomingMessage): Promise<string> {
  * Returns 200 immediately to acknowledge receipt, then processes
  * the event asynchronously to avoid webhook timeout.
  */
-export async function handleBasecampWebhook(
-  req: IncomingMessage,
-  res: ServerResponse,
-): Promise<void> {
+export async function handleBasecampWebhook(req: IncomingMessage, res: ServerResponse): Promise<void> {
   // Only accept POST
   if (req.method !== "POST") {
     res.writeHead(405, { "Content-Type": "application/json" });
@@ -274,7 +282,7 @@ export async function handleBasecampWebhook(
           if (bucketAccountId) {
             bucketResolved = true;
             const registry = getWebhookSecretRegistry(bucketAccountId);
-            candidateSecrets = registry.getAllSecrets().filter(s => s.length > 0);
+            candidateSecrets = registry.getAllSecrets().filter((s) => s.length > 0);
           }
         }
       } catch {
@@ -284,7 +292,7 @@ export async function handleBasecampWebhook(
       if (!bucketResolved && candidateSecrets.length === 0) {
         for (const accountId of listBasecampAccountIds(cfg)) {
           const registry = getWebhookSecretRegistry(accountId);
-          candidateSecrets.push(...registry.getAllSecrets().filter(s => s.length > 0));
+          candidateSecrets.push(...registry.getAllSecrets().filter((s) => s.length > 0));
         }
       }
 
@@ -304,12 +312,14 @@ export async function handleBasecampWebhook(
     // No valid authentication — check if webhooks are configured at all.
     // Eagerly load registries for all configured accounts to avoid false
     // negatives when secrets exist on disk but weren't loaded yet.
-    const hasAnySecrets = listBasecampAccountIds(cfg).some(
-      (id) => getWebhookSecretRegistry(id).size > 0,
-    );
+    const hasAnySecrets = listBasecampAccountIds(cfg).some((id) => getWebhookSecretRegistry(id).size > 0);
     if (!webhookSecret && !hasAnySecrets) {
       res.writeHead(403, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Webhooks not configured (set channels.basecamp.webhookSecret or configure webhooks.payloadUrl)" }));
+      res.end(
+        JSON.stringify({
+          error: "Webhooks not configured (set channels.basecamp.webhookSecret or configure webhooks.payloadUrl)",
+        }),
+      );
     } else {
       res.writeHead(403, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Invalid webhook signature or token" }));
@@ -368,7 +378,10 @@ export async function handleBasecampWebhook(
     }
   } catch (err) {
     const errlog = createConsoleStructuredLog({ accountId: "unknown", source: "webhook" });
-    errlog.error("account_resolution_failed", { error: String(err), stack: err instanceof Error ? err.stack : undefined });
+    errlog.error("account_resolution_failed", {
+      error: String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     return;
   }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -19,14 +19,8 @@ export type SdkLog = {
   debug?: (msg: string) => void;
 };
 
-function formatMessage(
-  prefix: string,
-  event: string,
-  detail?: Record<string, unknown>,
-): string {
-  return detail
-    ? `${prefix} ${event} ${JSON.stringify(detail)}`
-    : `${prefix} ${event}`;
+function formatMessage(prefix: string, event: string, detail?: Record<string, unknown>): string {
+  return detail ? `${prefix} ${event} ${JSON.stringify(detail)}` : `${prefix} ${event}`;
 }
 
 /**
@@ -58,9 +52,7 @@ export function createStructuredLog(
  * Create a structured logger that delegates to console methods.
  * Useful in contexts where the SDK log object is not available (e.g. webhook handlers).
  */
-export function createConsoleStructuredLog(
-  context: { accountId: string; source: string },
-): StructuredLog {
+export function createConsoleStructuredLog(context: { accountId: string; source: string }): StructuredLog {
   const prefix = `[basecamp:${context.source}:${context.accountId}]`;
   return {
     info(event, detail) {

--- a/src/mentions/parse.ts
+++ b/src/mentions/parse.ts
@@ -8,8 +8,7 @@
  */
 
 /** Matches <bc-attachment sgid="..." ...> tags with mention content-type. */
-const BC_ATTACHMENT_RE =
-  /<bc-attachment\s[^>]*sgid="([^"]+)"[^>]*>/gi;
+const BC_ATTACHMENT_RE = /<bc-attachment\s[^>]*sgid="([^"]+)"[^>]*>/gi;
 
 /** Matches specifically mention-typed attachments. */
 const BC_MENTION_RE =
@@ -90,11 +89,7 @@ export function parseMentions(html: string): ParsedMention[] {
  * Check whether any of the given SGIDs match the agent's identity.
  * Compares against both the agent's attachableSgid and personId.
  */
-export function mentionsAgent(
-  html: string,
-  agentSgid: string | undefined,
-  agentPersonId: string | undefined,
-): boolean {
+export function mentionsAgent(html: string, agentSgid: string | undefined, agentPersonId: string | undefined): boolean {
   const mentions = parseMentions(html);
   if (mentions.length === 0) return false;
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -170,11 +170,7 @@ export function recordWebhookDedupSize(accountId: string, size: number): void {
   m.webhookDedupSize = size;
 }
 
-export function recordCircuitBreakerState(
-  accountId: string,
-  key: string,
-  state: CircuitBreakerMetrics,
-): void {
+export function recordCircuitBreakerState(accountId: string, key: string, state: CircuitBreakerMetrics): void {
   const m = getOrCreate(accountId);
   m.circuitBreaker[key] = state;
 }
@@ -194,7 +190,10 @@ export function recordWebhookAuthMethod(accountId: string, method: "token" | "hm
   m.webhook.authMethods[method] = (m.webhook.authMethods[method] ?? 0) + 1;
 }
 
-export function recordReconciliationRun(accountId: string, result: { replayed: number; unseen: number; promotedTypes: string[] }): void {
+export function recordReconciliationRun(
+  accountId: string,
+  result: { replayed: number; unseen: number; promotedTypes: string[] },
+): void {
   const m = getOrCreate(accountId);
   m.reconciliation.lastRunAt = Date.now();
   m.reconciliation.replayed = result.replayed;

--- a/src/oauth-credentials.ts
+++ b/src/oauth-credentials.ts
@@ -78,6 +78,11 @@ export function clearTokenManagers(): void {
   managerCache.clear();
 }
 
+/** Clear the cached TokenManager for a single account. */
+export function clearTokenManager(accountId: string): void {
+  managerCache.delete(accountId);
+}
+
 // ---------------------------------------------------------------------------
 // Interactive login
 // ---------------------------------------------------------------------------

--- a/src/oauth-credentials.ts
+++ b/src/oauth-credentials.ts
@@ -10,16 +10,16 @@
  * that PR lands.
  */
 
-import {
-  TokenManager,
-  FileTokenStore,
-  performInteractiveLogin,
-  refreshToken as sdkRefreshToken,
-  type OAuthToken,
-} from "@37signals/basecamp/oauth";
-import type { ResolvedBasecampAccount } from "./types.js";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+  FileTokenStore,
+  type OAuthToken,
+  performInteractiveLogin,
+  refreshToken as sdkRefreshToken,
+  TokenManager,
+} from "@37signals/basecamp/oauth";
+import type { ResolvedBasecampAccount } from "./types.js";
 
 const LAUNCHPAD_TOKEN_ENDPOINT = "https://launchpad.37signals.com/authorization/token";
 
@@ -27,14 +27,7 @@ const LAUNCHPAD_TOKEN_ENDPOINT = "https://launchpad.37signals.com/authorization/
 // Token file path resolution
 // ---------------------------------------------------------------------------
 
-const DEFAULT_TOKEN_DIR = join(
-  homedir(),
-  ".local",
-  "share",
-  "openclaw",
-  "basecamp",
-  "tokens",
-);
+const DEFAULT_TOKEN_DIR = join(homedir(), ".local", "share", "openclaw", "basecamp", "tokens");
 
 /**
  * Resolve the path for an OAuth token file.
@@ -42,10 +35,7 @@ const DEFAULT_TOKEN_DIR = join(
  * When `stateDir` is provided: `{stateDir}/tokens/{accountId}.json`
  * Otherwise: `~/.local/share/openclaw/basecamp/tokens/{accountId}.json`
  */
-export function resolveTokenFilePath(
-  accountId: string,
-  stateDir?: string,
-): string {
+export function resolveTokenFilePath(accountId: string, stateDir?: string): string {
   const dir = stateDir ? join(stateDir, "tokens") : DEFAULT_TOKEN_DIR;
   return join(dir, `${accountId}.json`);
 }
@@ -62,15 +52,11 @@ const managerCache = new Map<string, TokenManager>();
  * Managers are cached per accountId so that repeated `getToken()` calls
  * share a single refresh mutex and file store.
  */
-export function createTokenManager(
-  account: ResolvedBasecampAccount,
-): TokenManager {
+export function createTokenManager(account: ResolvedBasecampAccount): TokenManager {
   const existing = managerCache.get(account.accountId);
   if (existing) return existing;
 
-  const tokenFilePath =
-    account.config.oauthTokenFile ??
-    resolveTokenFilePath(account.accountId);
+  const tokenFilePath = account.config.oauthTokenFile ?? resolveTokenFilePath(account.accountId);
 
   const store = new FileTokenStore(tokenFilePath);
 
@@ -112,14 +98,12 @@ export async function interactiveLogin(
   if (!clientId) {
     throw new Error(
       `No OAuth clientId available for account "${account.accountId}". ` +
-      `Set oauthClientId on the account or oauth.clientId at the channel level.`,
+        `Set oauthClientId on the account or oauth.clientId at the channel level.`,
     );
   }
   const clientSecret = overrides?.clientSecret ?? account.oauthClientSecret;
 
-  const tokenFilePath =
-    account.config.oauthTokenFile ??
-    resolveTokenFilePath(account.accountId);
+  const tokenFilePath = account.config.oauthTokenFile ?? resolveTokenFilePath(account.accountId);
 
   const store = new FileTokenStore(tokenFilePath);
 
@@ -132,12 +116,7 @@ export async function interactiveLogin(
     } catch {
       // Fallback: spawn platform-native opener
       const { exec } = await import("node:child_process");
-      const cmd =
-        process.platform === "darwin"
-          ? "open"
-          : process.platform === "win32"
-            ? "start"
-            : "xdg-open";
+      const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
       exec(`${cmd} ${JSON.stringify(url)}`);
     }
   };

--- a/src/outbound/format.ts
+++ b/src/outbound/format.ts
@@ -10,11 +10,7 @@
 
 /** Escape HTML special characters. */
 function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 /**
@@ -77,15 +73,15 @@ export function markdownToBasecampHtml(md: string): string {
 
     const bodyRows = rows.slice(2);
     const tbody = bodyRows.length
-      ? `<tbody>${bodyRows.map((row) => {
-          const cells = parseRow(row);
-          return `<tr>${cells.map((c) => `<td>${c}</td>`).join("")}</tr>`;
-        }).join("")}</tbody>`
+      ? `<tbody>${bodyRows
+          .map((row) => {
+            const cells = parseRow(row);
+            return `<tr>${cells.map((c) => `<td>${c}</td>`).join("")}</tr>`;
+          })
+          .join("")}</tbody>`
       : "";
 
-    return tbody
-      ? `\n<table>\n${thead}\n${tbody}\n</table>\n`
-      : `\n<table>\n${thead}\n</table>\n`;
+    return tbody ? `\n<table>\n${thead}\n${tbody}\n</table>\n` : `\n<table>\n${thead}\n</table>\n`;
   });
 
   // --- Inline code (`...`) ---

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -8,10 +8,10 @@
  * - ChannelOutboundAdapter.sendText for the OpenClaw outbound pipeline
  */
 
-import type { BasecampRecordableType, ResolvedBasecampAccount } from "../types.js";
-import { getClient, numId, rawOrThrow, type BasecampClient } from "../basecamp-client.js";
+import { type BasecampClient, getClient, numId, rawOrThrow } from "../basecamp-client.js";
 import type { CircuitBreaker } from "../circuit-breaker.js";
-import { withRetry, withCircuitBreaker, isRetryableError } from "../retry.js";
+import { isRetryableError, withCircuitBreaker, withRetry } from "../retry.js";
+import type { BasecampRecordableType, ResolvedBasecampAccount } from "../types.js";
 
 // ---------------------------------------------------------------------------
 // Circle info cache — LRU-bounded to avoid unbounded growth.
@@ -133,10 +133,7 @@ export async function postCampfireLine(params: {
 
   const doPost = async () => {
     const client = getClient(account);
-    return client.campfires.createLine(
-      numId("campfire", transcriptId),
-      { content },
-    );
+    return client.campfires.createLine(numId("campfire", transcriptId), { content });
   };
 
   const wrappedPost = circuitBreaker
@@ -144,20 +141,19 @@ export async function postCampfireLine(params: {
     : doPost;
 
   try {
-    const result = retries && retries > 0
-      ? await withRetry(wrappedPost, { maxAttempts: retries + 1 })
-      : await wrappedPost();
+    const result =
+      retries && retries > 0 ? await withRetry(wrappedPost, { maxAttempts: retries + 1 }) : await wrappedPost();
     console.log(
       `[basecamp:outbound] sent ok — ` +
-      `type=campfire recording=${transcriptId} account=${account.accountId} correlation=${correlationId ?? "none"}`,
+        `type=campfire recording=${transcriptId} account=${account.accountId} correlation=${correlationId ?? "none"}`,
     );
     return { ok: true, recordingId: String((result as any)?.id ?? "") };
   } catch (err) {
     const retryable = isRetryableError(err);
     console.warn(
       `[basecamp:outbound] failed — ` +
-      `type=campfire recording=${transcriptId} account=${account.accountId} ` +
-      `correlation=${correlationId ?? "none"} retryable=${retryable} error=${String(err)}`,
+        `type=campfire recording=${transcriptId} account=${account.accountId} ` +
+        `correlation=${correlationId ?? "none"} retryable=${retryable} error=${String(err)}`,
     );
     return { ok: false, error: err, message: String(err), retryable };
   }
@@ -180,10 +176,7 @@ export async function postComment(params: {
 
   const doPost = async () => {
     const client = getClient(account);
-    return client.comments.create(
-      numId("recording", recordingId),
-      { content },
-    );
+    return client.comments.create(numId("recording", recordingId), { content });
   };
 
   const wrappedPost = circuitBreaker
@@ -191,20 +184,19 @@ export async function postComment(params: {
     : doPost;
 
   try {
-    const result = retries && retries > 0
-      ? await withRetry(wrappedPost, { maxAttempts: retries + 1 })
-      : await wrappedPost();
+    const result =
+      retries && retries > 0 ? await withRetry(wrappedPost, { maxAttempts: retries + 1 }) : await wrappedPost();
     console.log(
       `[basecamp:outbound] sent ok — ` +
-      `type=comment recording=${recordingId} account=${account.accountId} correlation=${correlationId ?? "none"}`,
+        `type=comment recording=${recordingId} account=${account.accountId} correlation=${correlationId ?? "none"}`,
     );
     return { ok: true, commentId: String((result as any)?.id ?? "") };
   } catch (err) {
     const retryable = isRetryableError(err);
     console.warn(
       `[basecamp:outbound] failed — ` +
-      `type=comment recording=${recordingId} account=${account.accountId} ` +
-      `correlation=${correlationId ?? "none"} retryable=${retryable} error=${String(err)}`,
+        `type=comment recording=${recordingId} account=${account.accountId} ` +
+        `correlation=${correlationId ?? "none"} retryable=${retryable} error=${String(err)}`,
     );
     return { ok: false, error: err, message: String(err), retryable };
   }
@@ -241,7 +233,8 @@ export async function postReplyToEvent(params: {
   circuitBreaker?: { instance: CircuitBreaker; key: string };
   correlationId?: string;
 }): Promise<{ ok: boolean; messageId?: string; retryable?: boolean; error?: unknown; message?: string }> {
-  const { bucketId, recordingId, recordableType, peerId, content, account, retries, circuitBreaker, correlationId } = params;
+  const { bucketId, recordingId, recordableType, peerId, content, account, retries, circuitBreaker, correlationId } =
+    params;
   const parsed = parsePeerId(peerId);
 
   // Pings: resolve the transcript ID from the circle's bucket ID
@@ -270,10 +263,7 @@ export async function postReplyToEvent(params: {
   const parentId = peerTarget.prefix === "recording" ? peerTarget.id : undefined;
 
   // Chat lines go to the transcript
-  if (
-    recordableType === "Chat::Transcript" ||
-    recordableType === "Chat::Line"
-  ) {
+  if (recordableType === "Chat::Transcript" || recordableType === "Chat::Line") {
     const transcriptId = parentId ?? recordingId;
     const result = await postCampfireLine({
       bucketId,
@@ -320,7 +310,7 @@ export async function sendBasecampText(params: {
 }): Promise<{ channel: "basecamp"; messageId: string }> {
   throw new Error(
     `Basecamp does not support direct outbound delivery to "${params.to}". ` +
-    `Agent replies flow through the dispatch bridge (dispatchBasecampEvent → postReplyToEvent).`,
+      `Agent replies flow through the dispatch bridge (dispatchBasecampEvent → postReplyToEvent).`,
   );
 }
 
@@ -332,6 +322,6 @@ export async function sendBasecampMedia(params: {
 }): Promise<{ channel: "basecamp"; messageId: string }> {
   throw new Error(
     `Basecamp does not support direct media delivery to "${params.to}". ` +
-    `Media sharing is available via agent tools (basecamp_api_write).`,
+      `Media sharing is available via agent tools (basecamp_api_write).`,
   );
 }

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -33,9 +33,14 @@ function sleep(ms: number): Promise<void> {
 export function isRetryableError(err: unknown): boolean {
   if (!(err instanceof TypeError)) return false;
   const msg = err.message.toLowerCase();
-  return msg.includes("fetch") || msg.includes("failed to fetch") ||
-    msg.includes("network") || msg.includes("econnrefused") ||
-    msg.includes("econnreset") || msg.includes("etimedout");
+  return (
+    msg.includes("fetch") ||
+    msg.includes("failed to fetch") ||
+    msg.includes("network") ||
+    msg.includes("econnrefused") ||
+    msg.includes("econnreset") ||
+    msg.includes("etimedout")
+  );
 }
 
 /**
@@ -71,11 +76,7 @@ export async function withRetry<T>(fn: () => Promise<T>, opts?: RetryOptions): P
  * Wrap a function with circuit breaker checks.
  * Records success/failure on the breaker; throws if the circuit is open.
  */
-export async function withCircuitBreaker<T>(
-  cb: CircuitBreaker,
-  key: string,
-  fn: () => Promise<T>,
-): Promise<T> {
+export async function withCircuitBreaker<T>(cb: CircuitBreaker, key: string, fn: () => Promise<T>): Promise<T> {
   if (cb.isOpen(key)) {
     throw new Error(`Circuit breaker open for ${key}`);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,21 +38,10 @@ export type BasecampRecordableType =
  *   conversation — chat lines, comments in bound surfaces (not addressed)
  *   activity     — general project activity (card moves, todo completions…)
  */
-export type BasecampEngagementType =
-  | "dm"
-  | "mention"
-  | "assignment"
-  | "checkin"
-  | "conversation"
-  | "activity";
+export type BasecampEngagementType = "dm" | "mention" | "assignment" | "checkin" | "conversation" | "activity";
 
 /** Default engagement types that trigger agent response. */
-export const DEFAULT_ENGAGE: BasecampEngagementType[] = [
-  "dm",
-  "mention",
-  "assignment",
-  "checkin",
-];
+export const DEFAULT_ENGAGE: BasecampEngagementType[] = ["dm", "mention", "assignment", "checkin"];
 
 /** Event kinds emitted by the composite event fabric. */
 export type BasecampEventKind =
@@ -606,12 +595,6 @@ export type BasecampPollingCursors = {
 // Column → state mapping
 // ---------------------------------------------------------------------------
 
-export type BasecampWorkState =
-  | "INBOX"
-  | "WORKING"
-  | "PROPOSED"
-  | "APPROVED"
-  | "EXECUTED"
-  | "CLOSED";
+export type BasecampWorkState = "INBOX" | "WORKING" | "PROPOSED" | "APPROVED" | "EXECUTED" | "CLOSED";
 
 export type ColumnStateMap = Record<string, Record<string, BasecampWorkState>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -524,8 +524,6 @@ export type BasecampChannelConfig = {
   safetyNet?: {
     projects?: string[];
     intervalMs?: number;
-    /** @deprecated Accepted but ignored. Frequency escalation deferred. */
-    tier2?: unknown;
   };
   /** Reconciliation pass config. */
   reconciliation?: {

--- a/tests/actions.test.ts
+++ b/tests/actions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -23,7 +23,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (r: any) => r?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
@@ -49,9 +52,9 @@ vi.mock("../src/config.js", () => ({
 }));
 
 import { basecampActionsAdapter } from "../src/adapters/actions.js";
-import { postCampfireLine, postComment } from "../src/outbound/send.js";
-import { markdownToBasecampHtml } from "../src/outbound/format.js";
 import { resolveBasecampAccount } from "../src/config.js";
+import { markdownToBasecampHtml } from "../src/outbound/format.js";
+import { postCampfireLine, postComment } from "../src/outbound/send.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -229,7 +232,11 @@ describe("actions.handleAction — send comment", () => {
   });
 
   it("returns error from failed comment post", async () => {
-    vi.mocked(postComment).mockResolvedValue({ ok: false, message: "403 Forbidden", error: new Error("403 Forbidden") });
+    vi.mocked(postComment).mockResolvedValue({
+      ok: false,
+      message: "403 Forbidden",
+      error: new Error("403 Forbidden"),
+    });
 
     const result = await basecampActionsAdapter.handleAction!(
       actionCtx({
@@ -251,24 +258,18 @@ describe("actions.handleAction — send comment", () => {
 describe("actions.handleAction — send validation", () => {
   it("throws when bucketId is missing", async () => {
     await expect(
-      basecampActionsAdapter.handleAction!(
-        actionCtx({ params: { transcriptId: "2", text: "Hello" } }),
-      ),
+      basecampActionsAdapter.handleAction!(actionCtx({ params: { transcriptId: "2", text: "Hello" } })),
     ).rejects.toThrow(/Bucket ID/);
   });
 
   it("throws when text is missing", async () => {
     await expect(
-      basecampActionsAdapter.handleAction!(
-        actionCtx({ params: { bucketId: "1", transcriptId: "2" } }),
-      ),
+      basecampActionsAdapter.handleAction!(actionCtx({ params: { bucketId: "1", transcriptId: "2" } })),
     ).rejects.toThrow(/Message text/);
   });
 
   it("returns error when neither transcriptId nor recordingId is provided", async () => {
-    const result = await basecampActionsAdapter.handleAction!(
-      actionCtx({ params: { bucketId: "1", text: "Hello" } }),
-    );
+    const result = await basecampActionsAdapter.handleAction!(actionCtx({ params: { bucketId: "1", text: "Hello" } }));
 
     expect(result).toEqual({
       ok: true,
@@ -331,9 +332,7 @@ describe("actions.handleAction — send dryRun", () => {
 
 describe("actions.handleAction — unsupported action", () => {
   it("returns error for unsupported action", async () => {
-    const result = await basecampActionsAdapter.handleAction!(
-      actionCtx({ action: "delete" }),
-    );
+    const result = await basecampActionsAdapter.handleAction!(actionCtx({ action: "delete" }));
 
     expect(result).toEqual({
       ok: true,
@@ -408,10 +407,7 @@ describe("actions.handleAction — react", () => {
       ok: true,
       result: { ok: true, target: "boost", boostId: 55 },
     });
-    expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(
-      500,
-      { content: "🎉" },
-    );
+    expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(500, { content: "🎉" });
   });
 
   it("defaults emoji to thumbs up", async () => {
@@ -424,10 +420,7 @@ describe("actions.handleAction — react", () => {
       }),
     );
 
-    expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(
-      500,
-      { content: "👍" },
-    );
+    expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(500, { content: "👍" });
   });
 
   it("returns error on API failure", async () => {

--- a/tests/activity.test.ts
+++ b/tests/activity.test.ts
@@ -4,7 +4,7 @@
  * Validates SDK-based activity polling, cursor filtering,
  * normalization failure tolerance, and newest-first ordering.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -28,7 +28,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   numId: (_label: string, value: string | number) => Number(value),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
@@ -173,9 +176,7 @@ describe("pollActivityFeed", () => {
 
     expect(result.events).toHaveLength(1);
     expect(result.events[0].dedupKey).toBe("activity:2");
-    expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("failed to normalize"),
-    );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("failed to normalize"));
     // newestAt only tracks successfully processed events (tracking is inside try block)
     expect(result.newestAt).toBe("2025-06-01T11:00:00Z");
   });

--- a/tests/agent-prompt-context.test.ts
+++ b/tests/agent-prompt-context.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getSurfacePrompt } from "../src/hooks/agent-prompt-context.js";
 
 describe("getSurfacePrompt", () => {
@@ -77,10 +77,7 @@ describe("getSurfacePrompt", () => {
   });
 
   it("uses first recordableType match", () => {
-    const ctx = [
-      "[basecamp] recordableType=Chat::Line",
-      "[basecamp] recordableType=Todo",
-    ];
+    const ctx = ["[basecamp] recordableType=Chat::Line", "[basecamp] recordableType=Todo"];
     const prompt = getSurfacePrompt(ctx);
     expect(prompt).toContain("Campfire");
   });

--- a/tests/agent-prompt-context.test.ts
+++ b/tests/agent-prompt-context.test.ts
@@ -30,11 +30,9 @@ describe("getSurfacePrompt", () => {
     expect(prompt).toContain("column");
   });
 
-  it("returns card prompt for Kanban::Triage", () => {
+  it("returns undefined for Kanban::Triage (not a recognized recordable type)", () => {
     const ctx = ["[basecamp] recordableType=Kanban::Triage"];
-    const prompt = getSurfacePrompt(ctx);
-    expect(prompt).toContain("Card Table");
-    expect(prompt).toContain("triage");
+    expect(getSurfacePrompt(ctx)).toBeUndefined();
   });
 
   it("returns check-in prompt for Question", () => {

--- a/tests/agent-prompt.test.ts
+++ b/tests/agent-prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { basecampAgentPromptAdapter } from "../src/adapters/agent-prompt.js";
 
 function cfg(basecamp?: Record<string, unknown>) {

--- a/tests/agent-tools.test.ts
+++ b/tests/agent-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClient = {
   todos: { create: vi.fn(), complete: vi.fn(), uncomplete: vi.fn() },
@@ -23,7 +23,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   }),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
@@ -108,10 +111,13 @@ describe("basecamp_create_todo", () => {
       content: "Buy milk",
     });
 
-    expect(mockClient.todos.create).toHaveBeenCalledWith(
-      200,
-      { content: "Buy milk", description: undefined, assigneeIds: undefined, dueOn: undefined, startsOn: undefined },
-    );
+    expect(mockClient.todos.create).toHaveBeenCalledWith(200, {
+      content: "Buy milk",
+      description: undefined,
+      assigneeIds: undefined,
+      dueOn: undefined,
+      startsOn: undefined,
+    });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, todoId: 42, title: "Buy milk" });
     expect(result.details).toEqual({ ok: true, todoId: 42, title: "Buy milk" });
@@ -130,16 +136,13 @@ describe("basecamp_create_todo", () => {
       startsOn: "2025-02-15",
     });
 
-    expect(mockClient.todos.create).toHaveBeenCalledWith(
-      200,
-      {
-        content: "Review PR",
-        description: "<p>Check edge cases</p>",
-        assigneeIds: [10, 20],
-        dueOn: "2025-03-01",
-        startsOn: "2025-02-15",
-      },
-    );
+    expect(mockClient.todos.create).toHaveBeenCalledWith(200, {
+      content: "Review PR",
+      description: "<p>Check edge cases</p>",
+      assigneeIds: [10, 20],
+      dueOn: "2025-03-01",
+      startsOn: "2025-02-15",
+    });
   });
 
   it("omits optional fields when not provided", async () => {
@@ -267,10 +270,7 @@ describe("basecamp_read_history", () => {
       type: "campfire",
     });
 
-    expect(mockClient.raw.GET).toHaveBeenCalledWith(
-      "/buckets/100/chats/200/lines.json",
-      {},
-    );
+    expect(mockClient.raw.GET).toHaveBeenCalledWith("/buckets/100/chats/200/lines.json", {});
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.count).toBe(2);
@@ -283,7 +283,12 @@ describe("basecamp_read_history", () => {
   it("fetches recording comments", async () => {
     mockClient.raw.GET.mockResolvedValue({
       data: [
-        { id: 5, content: "<strong>Done</strong>", created_at: "2025-01-01T12:00:00Z", creator: { id: 30, name: "Charlie" } },
+        {
+          id: 5,
+          content: "<strong>Done</strong>",
+          created_at: "2025-01-01T12:00:00Z",
+          creator: { id: 30, name: "Charlie" },
+        },
       ],
       error: undefined,
       response: { ok: true, headers: new Headers() },
@@ -295,10 +300,7 @@ describe("basecamp_read_history", () => {
       type: "comments",
     });
 
-    expect(mockClient.raw.GET).toHaveBeenCalledWith(
-      "/buckets/100/recordings/300/comments.json",
-      {},
-    );
+    expect(mockClient.raw.GET).toHaveBeenCalledWith("/buckets/100/recordings/300/comments.json", {});
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
     expect(parsed.count).toBe(1);
@@ -433,9 +435,7 @@ describe("basecamp_read_history", () => {
 
   it("handles entries with missing creator", async () => {
     mockClient.raw.GET.mockResolvedValue({
-      data: [
-        { id: 1, content: "<p>No creator</p>", created_at: "2025-01-01T10:00:00Z" },
-      ],
+      data: [{ id: 1, content: "<p>No creator</p>", created_at: "2025-01-01T10:00:00Z" }],
       error: undefined,
       response: { ok: true, headers: new Headers() },
     });
@@ -467,10 +467,7 @@ describe("basecamp_add_boost", () => {
       recordingId: "500",
     });
 
-    expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(
-      500,
-      { content: "👍" },
-    );
+    expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(500, { content: "👍" });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, boostId: 99 });
     expect(result.details).toEqual({ ok: true, boostId: 99 });
@@ -485,10 +482,7 @@ describe("basecamp_add_boost", () => {
       content: "🎉",
     });
 
-    expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(
-      500,
-      { content: "🎉" },
-    );
+    expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(500, { content: "🎉" });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, boostId: 101 });
   });
@@ -524,10 +518,7 @@ describe("basecamp_move_card", () => {
       columnId: 700,
     });
 
-    expect(mockClient.cards.move).toHaveBeenCalledWith(
-      600,
-      { columnId: 700 },
-    );
+    expect(mockClient.cards.move).toHaveBeenCalledWith(600, { columnId: 700 });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, cardId: "600", columnId: 700 });
     expect(result.details).toEqual({ ok: true, cardId: "600", columnId: 700 });
@@ -565,10 +556,11 @@ describe("basecamp_post_message", () => {
       subject: "Weekly Update",
     });
 
-    expect(mockClient.messages.create).toHaveBeenCalledWith(
-      200,
-      { subject: "Weekly Update", content: undefined, categoryId: undefined },
-    );
+    expect(mockClient.messages.create).toHaveBeenCalledWith(200, {
+      subject: "Weekly Update",
+      content: undefined,
+      categoryId: undefined,
+    });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, messageId: 800, subject: "Weekly Update" });
     expect(result.details).toEqual({ ok: true, messageId: 800, subject: "Weekly Update" });
@@ -585,10 +577,11 @@ describe("basecamp_post_message", () => {
       categoryId: 5,
     });
 
-    expect(mockClient.messages.create).toHaveBeenCalledWith(
-      200,
-      { subject: "Announcement", content: "<p>Big news!</p>", categoryId: 5 },
-    );
+    expect(mockClient.messages.create).toHaveBeenCalledWith(200, {
+      subject: "Announcement",
+      content: "<p>Big news!</p>",
+      categoryId: 5,
+    });
   });
 
   it("omits optional fields when not provided", async () => {
@@ -639,10 +632,7 @@ describe("basecamp_answer_checkin", () => {
       content: "Everything is on track!",
     });
 
-    expect(mockClient.checkins.createAnswer).toHaveBeenCalledWith(
-      300,
-      { content: "Everything is on track!" },
-    );
+    expect(mockClient.checkins.createAnswer).toHaveBeenCalledWith(300, { content: "Everything is on track!" });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, answerId: 900 });
     expect(result.details).toEqual({ ok: true, answerId: 900 });
@@ -708,7 +698,10 @@ describe("basecamp_api_read", () => {
   });
 
   it("reads project list", async () => {
-    const projects = [{ id: 1, name: "Project A" }, { id: 2, name: "Project B" }];
+    const projects = [
+      { id: 1, name: "Project A" },
+      { id: 2, name: "Project B" },
+    ];
     mockClient.raw.GET.mockResolvedValue({
       data: projects,
       error: undefined,
@@ -812,10 +805,9 @@ describe("basecamp_api_write", () => {
       body: { content: "New todo" },
     });
 
-    expect(mockClient.raw.POST).toHaveBeenCalledWith(
-      "/buckets/100/todolists/200/todos.json",
-      { body: { content: "New todo" } },
-    );
+    expect(mockClient.raw.POST).toHaveBeenCalledWith("/buckets/100/todolists/200/todos.json", {
+      body: { content: "New todo" },
+    });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual({ ok: true, data: { id: 50, content: "New todo" } });
   });
@@ -833,10 +825,9 @@ describe("basecamp_api_write", () => {
       body: { content: "Updated", due_on: "2025-12-31" },
     });
 
-    expect(mockClient.raw.PUT).toHaveBeenCalledWith(
-      "/buckets/100/todos/42.json",
-      { body: { content: "Updated", due_on: "2025-12-31" } },
-    );
+    expect(mockClient.raw.PUT).toHaveBeenCalledWith("/buckets/100/todos/42.json", {
+      body: { content: "Updated", due_on: "2025-12-31" },
+    });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
   });
@@ -870,10 +861,7 @@ describe("basecamp_api_write", () => {
       path: "/buckets/100/todos/42/completion.json",
     });
 
-    expect(mockClient.raw.POST).toHaveBeenCalledWith(
-      "/buckets/100/todos/42/completion.json",
-      { body: undefined },
-    );
+    expect(mockClient.raw.POST).toHaveBeenCalledWith("/buckets/100/todos/42/completion.json", { body: undefined });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.ok).toBe(true);
   });
@@ -890,10 +878,7 @@ describe("basecamp_api_write", () => {
       path: "/buckets/100/some/path.json",
     });
 
-    expect(mockClient.raw.PUT).toHaveBeenCalledWith(
-      "/buckets/100/some/path.json",
-      { body: undefined },
-    );
+    expect(mockClient.raw.PUT).toHaveBeenCalledWith("/buckets/100/some/path.json", { body: undefined });
   });
 
   it("returns error on POST failure", async () => {

--- a/tests/assignments.test.ts
+++ b/tests/assignments.test.ts
@@ -1,9 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type {
-  BasecampAssignmentTodo,
-  ResolvedBasecampAccount,
-} from "../src/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeAssignmentTodo } from "../src/inbound/normalize.js";
+import type { BasecampAssignmentTodo, ResolvedBasecampAccount } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
 // Mock basecamp-client
@@ -24,7 +21,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   }),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
@@ -166,9 +166,7 @@ describe("pollAssignments", () => {
 
     expect(result.events).toHaveLength(0);
     expect(result.knownIds).toEqual(new Set(["1", "2", "3"]));
-    expect(log.info).toHaveBeenCalledWith(
-      expect.stringContaining("bootstrap: recording 3 existing assignments"),
-    );
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("bootstrap: recording 3 existing assignments"));
   });
 
   it("emits events for newly assigned todos", async () => {
@@ -272,9 +270,7 @@ describe("pollAssignments", () => {
     // One failed, one succeeded
     expect(result.events).toHaveLength(1);
     expect(result.events[0].meta.recordingId).toBe("2");
-    expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("failed to normalize assignment todo id=1"),
-    );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("failed to normalize assignment todo id=1"));
   });
 
   it("all events have assignedToAgent=true", async () => {
@@ -301,10 +297,7 @@ describe("pollAssignments", () => {
       priorities: [
         makeTodo({
           id: 10,
-          children: [
-            makeTodo({ id: 11 }),
-            makeTodo({ id: 12, children: [makeTodo({ id: 13 })] }),
-          ],
+          children: [makeTodo({ id: 11 }), makeTodo({ id: 12, children: [makeTodo({ id: 13 })] })],
         }),
       ],
       non_priorities: [],

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -76,8 +76,8 @@ vi.mock("../src/adapters/agent-prompt.js", () => ({
 }));
 
 import { basecampChannel } from "../src/channel.js";
-import { interactiveLogin } from "../src/oauth-credentials.js";
 import { resolveBasecampAccount } from "../src/config.js";
+import { interactiveLogin } from "../src/oauth-credentials.js";
 
 const oauthAccount = {
   accountId: "oauth-test",

--- a/tests/basecamp-client.test.ts
+++ b/tests/basecamp-client.test.ts
@@ -4,7 +4,7 @@
  * Covers: numId, rawOrThrow, getClient (client caching + account ID resolution),
  * resolveTokenProvider (config, tokenFile, oauth, none).
  */
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.hoisted ensures these survive vi.mock hoisting
@@ -43,7 +43,7 @@ vi.mock("node:fs/promises", () => ({
   readFile: mockReadFile,
 }));
 
-import { numId, rawOrThrow, getClient, clearClients } from "../src/basecamp-client.js";
+import { clearClients, getClient, numId, rawOrThrow } from "../src/basecamp-client.js";
 import type { ResolvedBasecampAccount } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
@@ -157,9 +157,7 @@ describe("getClient", () => {
     });
     getClient(account);
 
-    expect(mockCreateBasecampClient).toHaveBeenCalledWith(
-      expect.objectContaining({ accountId: "777" }),
-    );
+    expect(mockCreateBasecampClient).toHaveBeenCalledWith(expect.objectContaining({ accountId: "777" }));
   });
 
   it("falls back to numeric accountId when no explicit IDs are set", () => {
@@ -169,9 +167,7 @@ describe("getClient", () => {
     });
     getClient(account);
 
-    expect(mockCreateBasecampClient).toHaveBeenCalledWith(
-      expect.objectContaining({ accountId: "99999" }),
-    );
+    expect(mockCreateBasecampClient).toHaveBeenCalledWith(expect.objectContaining({ accountId: "99999" }));
   });
 
   it("throws on non-numeric accountId with no explicit ID", () => {
@@ -180,9 +176,7 @@ describe("getClient", () => {
       config: { personId: "42" },
     });
 
-    expect(() => getClient(account)).toThrow(
-      'Cannot resolve numeric Basecamp account ID for "my-org"',
-    );
+    expect(() => getClient(account)).toThrow('Cannot resolve numeric Basecamp account ID for "my-org"');
   });
 
   it("returns cached client on second call (same object, factory called once)", () => {
@@ -226,9 +220,7 @@ describe("resolveTokenProvider", () => {
     });
     getClient(account);
 
-    expect(mockCreateBasecampClient).toHaveBeenCalledWith(
-      expect.objectContaining({ accessToken: "direct-token" }),
-    );
+    expect(mockCreateBasecampClient).toHaveBeenCalledWith(expect.objectContaining({ accessToken: "direct-token" }));
   });
 
   it('tokenSource "tokenFile" with pre-loaded token passes string directly', () => {
@@ -261,10 +253,7 @@ describe("resolveTokenProvider", () => {
     const token = await lazyFn();
 
     expect(token).toBe("file-token-value");
-    expect(mockReadFile).toHaveBeenCalledWith(
-      expect.stringContaining("tokens/bc.txt"),
-      "utf-8",
-    );
+    expect(mockReadFile).toHaveBeenCalledWith(expect.stringContaining("tokens/bc.txt"), "utf-8");
     // ~ should be expanded, not present in the resolved path
     expect(mockReadFile.mock.calls[0][0]).not.toContain("~");
   });
@@ -306,7 +295,7 @@ describe("resolveTokenProvider", () => {
     expect(mockReadFile.mock.calls[0][0]).toBe("/etc/tokens/bc.txt");
   });
 
-  it('tokenFile lazy fn throws when tokenFile missing in config', async () => {
+  it("tokenFile lazy fn throws when tokenFile missing in config", async () => {
     const account = makeAccount({
       accountId: "tf-no-file",
       tokenSource: "tokenFile",
@@ -343,8 +332,6 @@ describe("resolveTokenProvider", () => {
       config: { personId: "42", basecampAccountId: "7" },
     });
 
-    expect(() => getClient(account)).toThrow(
-      'No authentication configured for account "none-source"',
-    );
+    expect(() => getClient(account)).toThrow('No authentication configured for account "none-source"');
   });
 });

--- a/tests/channel-gateway.test.ts
+++ b/tests/channel-gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -107,16 +107,21 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   return { ...actual, unlink: mockUnlink };
 });
 
-import { basecampChannel, _resetValidationState } from "../src/channel.js";
-import { resolveBasecampAccount, resolveBasecampAccountAsync, resolveWebhooksConfig, scopeWebhookProjects } from "../src/config.js";
+import { clearClients } from "../src/basecamp-client.js";
 import { bcqAuthStatus } from "../src/bcq.js";
-import { startCompositePoller } from "../src/inbound/poller.js";
-import { reconcileWebhooks, deactivateWebhooks } from "../src/inbound/webhook-lifecycle.js";
+import { _resetValidationState, basecampChannel } from "../src/channel.js";
+import {
+  resolveBasecampAccount,
+  resolveBasecampAccountAsync,
+  resolveWebhooksConfig,
+  scopeWebhookProjects,
+} from "../src/config.js";
 import { dispatchBasecampEvent } from "../src/dispatch.js";
 import { closeAccountDedup } from "../src/inbound/dedup-registry.js";
+import { startCompositePoller } from "../src/inbound/poller.js";
+import { deactivateWebhooks, reconcileWebhooks } from "../src/inbound/webhook-lifecycle.js";
 import { flushWebhookSecrets } from "../src/inbound/webhooks.js";
-import { createTokenManager, clearTokenManagers } from "../src/oauth-credentials.js";
-import { clearClients } from "../src/basecamp-client.js";
+import { clearTokenManagers, createTokenManager } from "../src/oauth-credentials.js";
 
 function makeCtx(cfg: any, accountId = "test") {
   return {
@@ -147,7 +152,9 @@ beforeEach(() => {
   vi.mocked(startCompositePoller).mockResolvedValue(undefined);
   vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(makeAccount() as any);
   vi.mocked(resolveWebhooksConfig).mockReturnValue({
-    autoRegister: false, projects: [], deactivateOnStop: false,
+    autoRegister: false,
+    projects: [],
+    deactivateOnStop: false,
   } as any);
   vi.mocked(scopeWebhookProjects).mockReturnValue([]);
 });
@@ -158,9 +165,7 @@ beforeEach(() => {
 
 describe("phase 4: OAuth validation", () => {
   it("validates token on startup for OAuth tokenSource", async () => {
-    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(
-      makeAccount({ tokenSource: "oauth", token: "" }) as any,
-    );
+    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(makeAccount({ tokenSource: "oauth", token: "" }) as any);
     vi.mocked(createTokenManager).mockReturnValue({
       getToken: vi.fn().mockResolvedValue("valid"),
     } as any);
@@ -172,9 +177,7 @@ describe("phase 4: OAuth validation", () => {
   });
 
   it("returns early when OAuth validation fails", async () => {
-    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(
-      makeAccount({ tokenSource: "oauth", token: "" }) as any,
-    );
+    vi.mocked(resolveBasecampAccountAsync).mockResolvedValue(makeAccount({ tokenSource: "oauth", token: "" }) as any);
     vi.mocked(createTokenManager).mockReturnValue({
       getToken: vi.fn().mockRejectedValue(new Error("expired")),
     } as any);
@@ -184,9 +187,7 @@ describe("phase 4: OAuth validation", () => {
 
     expect(ctx.log.error).toHaveBeenCalledWith(expect.stringContaining("OAuth token invalid"));
     // setStatus(running:true) should never be called
-    const runningCalls = ctx.setStatus.mock.calls.filter(
-      (c: any[]) => c[0]?.running === true,
-    );
+    const runningCalls = ctx.setStatus.mock.calls.filter((c: any[]) => c[0]?.running === true);
     expect(runningCalls).toHaveLength(0);
   });
 });
@@ -228,11 +229,17 @@ describe("phase 6-7: early return guards", () => {
 describe("phase 11: webhook reconciliation", () => {
   it("calls reconcileWebhooks when autoRegister is true", async () => {
     vi.mocked(resolveWebhooksConfig).mockReturnValue({
-      autoRegister: true, payloadUrl: "https://example.com/wh", projects: ["1"], deactivateOnStop: false,
+      autoRegister: true,
+      payloadUrl: "https://example.com/wh",
+      projects: ["1"],
+      deactivateOnStop: false,
     } as any);
     vi.mocked(scopeWebhookProjects).mockReturnValue(["1"]);
     vi.mocked(reconcileWebhooks).mockResolvedValue({
-      created: ["1"], existing: [], recovered: [], failed: [],
+      created: ["1"],
+      existing: [],
+      recovered: [],
+      failed: [],
     } as any);
 
     const ctx = makeCtx({});
@@ -243,7 +250,10 @@ describe("phase 11: webhook reconciliation", () => {
 
   it("swallows reconcileWebhooks error and continues startup", async () => {
     vi.mocked(resolveWebhooksConfig).mockReturnValue({
-      autoRegister: true, payloadUrl: "https://example.com/wh", projects: ["1"], deactivateOnStop: false,
+      autoRegister: true,
+      payloadUrl: "https://example.com/wh",
+      projects: ["1"],
+      deactivateOnStop: false,
     } as any);
     vi.mocked(scopeWebhookProjects).mockReturnValue(["1"]);
     vi.mocked(reconcileWebhooks).mockRejectedValue(new Error("network"));
@@ -257,11 +267,17 @@ describe("phase 11: webhook reconciliation", () => {
 
   it("passes webhookActiveProjects built from reconciliation result to poller", async () => {
     vi.mocked(resolveWebhooksConfig).mockReturnValue({
-      autoRegister: true, payloadUrl: "https://example.com/wh", projects: ["1", "2", "3"], deactivateOnStop: false,
+      autoRegister: true,
+      payloadUrl: "https://example.com/wh",
+      projects: ["1", "2", "3"],
+      deactivateOnStop: false,
     } as any);
     vi.mocked(scopeWebhookProjects).mockReturnValue(["1", "2", "3"]);
     vi.mocked(reconcileWebhooks).mockResolvedValue({
-      created: ["1"], existing: ["2"], recovered: ["3"], failed: [],
+      created: ["1"],
+      existing: ["2"],
+      recovered: ["3"],
+      failed: [],
     } as any);
 
     const ctx = makeCtx({});
@@ -282,12 +298,14 @@ describe("phase 12: onEvent closure", () => {
     let resolvePoller: () => void;
     vi.mocked(startCompositePoller).mockImplementation(async (opts: any) => {
       capturedOnEvent = opts.onEvent;
-      await new Promise<void>(r => { resolvePoller = r; });
+      await new Promise<void>((r) => {
+        resolvePoller = r;
+      });
     });
 
     const ctx = makeCtx({});
     const startPromise = basecampChannel.gateway!.startAccount!(ctx as any);
-    await new Promise(r => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
 
     const msg = { sender: { id: "42" } };
     const result = await capturedOnEvent!(msg);
@@ -304,13 +322,15 @@ describe("phase 12: onEvent closure", () => {
     let resolvePoller: () => void;
     vi.mocked(startCompositePoller).mockImplementation(async (opts: any) => {
       capturedOnEvent = opts.onEvent;
-      await new Promise<void>(r => { resolvePoller = r; });
+      await new Promise<void>((r) => {
+        resolvePoller = r;
+      });
     });
     vi.mocked(dispatchBasecampEvent).mockResolvedValue(true);
 
     const ctx = makeCtx({});
     const startPromise = basecampChannel.gateway!.startAccount!(ctx as any);
-    await new Promise(r => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
 
     const msg = { sender: { id: "99" } };
     const result = await capturedOnEvent!(msg);
@@ -361,7 +381,9 @@ describe("phase 15: finally block", () => {
 
   it("does not call deactivateWebhooks when deactivateOnStop is false", async () => {
     vi.mocked(resolveWebhooksConfig).mockReturnValue({
-      autoRegister: false, projects: [], deactivateOnStop: false,
+      autoRegister: false,
+      projects: [],
+      deactivateOnStop: false,
     } as any);
 
     const ctx = makeCtx({});
@@ -430,9 +452,7 @@ describe("logoutAccount", () => {
   });
 
   it("returns cleared=true when token file already gone (ENOENT)", async () => {
-    mockUnlink.mockRejectedValue(
-      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
-    );
+    mockUnlink.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
     vi.mocked(resolveBasecampAccount).mockReturnValue(
       makeAccount({ config: { personId: "42", oauthTokenFile: "/tmp/gone.json" } }) as any,
     );
@@ -446,9 +466,7 @@ describe("logoutAccount", () => {
   });
 
   it("returns cleared=false when no oauthTokenFile configured", async () => {
-    vi.mocked(resolveBasecampAccount).mockReturnValue(
-      makeAccount({ config: { personId: "42" } }) as any,
-    );
+    vi.mocked(resolveBasecampAccount).mockReturnValue(makeAccount({ config: { personId: "42" } }) as any);
 
     const result = await basecampChannel.gateway!.logoutAccount!({
       accountId: "test",

--- a/tests/channel-gateway.test.ts
+++ b/tests/channel-gateway.test.ts
@@ -30,10 +30,12 @@ vi.mock("../src/config.js", () => ({
 vi.mock("../src/oauth-credentials.js", () => ({
   createTokenManager: vi.fn(),
   clearTokenManagers: vi.fn(),
+  clearTokenManager: vi.fn(),
 }));
 
 vi.mock("../src/basecamp-client.js", () => ({
   clearClients: vi.fn(),
+  clearClient: vi.fn(),
 }));
 
 vi.mock("../src/runtime.js", () => ({
@@ -107,7 +109,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   return { ...actual, unlink: mockUnlink };
 });
 
-import { clearClients } from "../src/basecamp-client.js";
+import { clearClient, clearClients } from "../src/basecamp-client.js";
 import { bcqAuthStatus } from "../src/bcq.js";
 import { _resetValidationState, basecampChannel } from "../src/channel.js";
 import {
@@ -121,7 +123,7 @@ import { closeAccountDedup } from "../src/inbound/dedup-registry.js";
 import { startCompositePoller } from "../src/inbound/poller.js";
 import { deactivateWebhooks, reconcileWebhooks } from "../src/inbound/webhook-lifecycle.js";
 import { flushWebhookSecrets } from "../src/inbound/webhooks.js";
-import { clearTokenManagers, createTokenManager } from "../src/oauth-credentials.js";
+import { clearTokenManager, clearTokenManagers, createTokenManager } from "../src/oauth-credentials.js";
 
 function makeCtx(cfg: any, accountId = "test") {
   return {
@@ -446,8 +448,8 @@ describe("logoutAccount", () => {
 
     expect(result).toEqual({ cleared: true, loggedOut: true });
     expect(mockUnlink).toHaveBeenCalledWith("/tmp/token.json");
-    expect(clearTokenManagers).toHaveBeenCalled();
-    expect(clearClients).toHaveBeenCalled();
+    expect(clearTokenManager).toHaveBeenCalledWith("test");
+    expect(clearClient).toHaveBeenCalledWith("test");
     expect(closeAccountDedup).toHaveBeenCalledWith("test");
   });
 
@@ -474,8 +476,22 @@ describe("logoutAccount", () => {
     } as any);
 
     expect(result).toEqual({ cleared: false, loggedOut: false });
-    expect(clearTokenManagers).toHaveBeenCalled();
-    expect(clearClients).toHaveBeenCalled();
+    expect(clearTokenManager).toHaveBeenCalledWith("test");
+    expect(clearClient).toHaveBeenCalledWith("test");
     expect(closeAccountDedup).toHaveBeenCalledWith("test");
+  });
+
+  it("non-ENOENT unlink error propagates", async () => {
+    mockUnlink.mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    vi.mocked(resolveBasecampAccount).mockReturnValue(
+      makeAccount({ config: { personId: "42", oauthTokenFile: "/tmp/noperm.json" } }) as any,
+    );
+
+    await expect(
+      basecampChannel.gateway!.logoutAccount!({
+        accountId: "test",
+        cfg: {},
+      } as any),
+    ).rejects.toThrow("EACCES");
   });
 });

--- a/tests/channel-gateway.test.ts
+++ b/tests/channel-gateway.test.ts
@@ -29,6 +29,11 @@ vi.mock("../src/config.js", () => ({
 
 vi.mock("../src/oauth-credentials.js", () => ({
   createTokenManager: vi.fn(),
+  clearTokenManagers: vi.fn(),
+}));
+
+vi.mock("../src/basecamp-client.js", () => ({
+  clearClients: vi.fn(),
 }));
 
 vi.mock("../src/runtime.js", () => ({
@@ -96,15 +101,22 @@ vi.mock("../src/util.js", () => ({
   withTimeout: vi.fn((p) => p),
 }));
 
+const mockUnlink = vi.fn();
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, unlink: mockUnlink };
+});
+
 import { basecampChannel, _resetValidationState } from "../src/channel.js";
-import { resolveBasecampAccountAsync, resolveWebhooksConfig, scopeWebhookProjects } from "../src/config.js";
+import { resolveBasecampAccount, resolveBasecampAccountAsync, resolveWebhooksConfig, scopeWebhookProjects } from "../src/config.js";
 import { bcqAuthStatus } from "../src/bcq.js";
 import { startCompositePoller } from "../src/inbound/poller.js";
 import { reconcileWebhooks, deactivateWebhooks } from "../src/inbound/webhook-lifecycle.js";
 import { dispatchBasecampEvent } from "../src/dispatch.js";
 import { closeAccountDedup } from "../src/inbound/dedup-registry.js";
 import { flushWebhookSecrets } from "../src/inbound/webhooks.js";
-import { createTokenManager } from "../src/oauth-credentials.js";
+import { createTokenManager, clearTokenManagers } from "../src/oauth-credentials.js";
+import { clearClients } from "../src/basecamp-client.js";
 
 function makeCtx(cfg: any, accountId = "test") {
   return {
@@ -399,12 +411,53 @@ describe("phase 15: finally block", () => {
 // ---------------------------------------------------------------------------
 
 describe("logoutAccount", () => {
-  it("returns { cleared: false, loggedOut: false }", async () => {
+  it("deletes token file, evicts caches, and closes dedup", async () => {
+    mockUnlink.mockResolvedValue(undefined);
+    vi.mocked(resolveBasecampAccount).mockReturnValue(
+      makeAccount({ config: { personId: "42", oauthTokenFile: "/tmp/token.json" } }) as any,
+    );
+
+    const result = await basecampChannel.gateway!.logoutAccount!({
+      accountId: "test",
+      cfg: {},
+    } as any);
+
+    expect(result).toEqual({ cleared: true, loggedOut: true });
+    expect(mockUnlink).toHaveBeenCalledWith("/tmp/token.json");
+    expect(clearTokenManagers).toHaveBeenCalled();
+    expect(clearClients).toHaveBeenCalled();
+    expect(closeAccountDedup).toHaveBeenCalledWith("test");
+  });
+
+  it("returns cleared=true when token file already gone (ENOENT)", async () => {
+    mockUnlink.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+    vi.mocked(resolveBasecampAccount).mockReturnValue(
+      makeAccount({ config: { personId: "42", oauthTokenFile: "/tmp/gone.json" } }) as any,
+    );
+
+    const result = await basecampChannel.gateway!.logoutAccount!({
+      accountId: "test",
+      cfg: {},
+    } as any);
+
+    expect(result).toEqual({ cleared: true, loggedOut: true });
+  });
+
+  it("returns cleared=false when no oauthTokenFile configured", async () => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue(
+      makeAccount({ config: { personId: "42" } }) as any,
+    );
+
     const result = await basecampChannel.gateway!.logoutAccount!({
       accountId: "test",
       cfg: {},
     } as any);
 
     expect(result).toEqual({ cleared: false, loggedOut: false });
+    expect(clearTokenManagers).toHaveBeenCalled();
+    expect(clearClients).toHaveBeenCalled();
+    expect(closeAccountDedup).toHaveBeenCalledWith("test");
   });
 });

--- a/tests/circuit-breaker.test.ts
+++ b/tests/circuit-breaker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CircuitBreaker } from "../src/circuit-breaker.js";
 
 describe("CircuitBreaker", () => {

--- a/tests/config-adapter.test.ts
+++ b/tests/config-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -52,7 +52,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (result: any) => result?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
   clearClients: vi.fn(),
 }));

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -10,15 +10,15 @@ vi.mock("openclaw/plugin-sdk", () => ({
 
 import {
   listBasecampAccountIds,
-  resolveDefaultBasecampAccountId,
+  resolveAccountForBucket,
   resolveBasecampAccount,
   resolveBasecampAccountAsync,
-  resolvePersonaAccountId,
-  resolvePollingIntervals,
-  resolveBasecampDmPolicy,
   resolveBasecampAllowFrom,
   resolveBasecampBucketAllowFrom,
-  resolveAccountForBucket,
+  resolveBasecampDmPolicy,
+  resolveDefaultBasecampAccountId,
+  resolvePersonaAccountId,
+  resolvePollingIntervals,
 } from "../src/config.js";
 
 // ---------------------------------------------------------------------------
@@ -53,9 +53,7 @@ describe("listBasecampAccountIds", () => {
   });
 
   it("returns the single configured account ID", () => {
-    const result = listBasecampAccountIds(
-      cfgWithAccounts({ myaccount: { personId: "1" } }),
-    );
+    const result = listBasecampAccountIds(cfgWithAccounts({ myaccount: { personId: "1" } }));
     expect(result).toEqual(["myaccount"]);
   });
 
@@ -73,9 +71,7 @@ describe("listBasecampAccountIds", () => {
   it("normalizes numeric-like account IDs to strings", () => {
     // normalizeAccountId converts keys to strings; numeric keys in JS objects
     // are already strings, but this ensures the pipeline handles them.
-    const result = listBasecampAccountIds(
-      cfgWithAccounts({ 123: { personId: "1" } } as any),
-    );
+    const result = listBasecampAccountIds(cfgWithAccounts({ 123: { personId: "1" } } as any));
     expect(result).toEqual(["123"]);
     expect(typeof result[0]).toBe("string");
   });
@@ -91,11 +87,7 @@ describe("resolveDefaultBasecampAccountId", () => {
   });
 
   it("returns the only configured account when there is one", () => {
-    expect(
-      resolveDefaultBasecampAccountId(
-        cfgWithAccounts({ solo: { personId: "1" } }),
-      ),
-    ).toBe("solo");
+    expect(resolveDefaultBasecampAccountId(cfgWithAccounts({ solo: { personId: "1" } }))).toBe("solo");
   });
 
   it("returns 'default' when it is among multiple accounts", () => {
@@ -136,9 +128,7 @@ describe("resolveBasecampAccount", () => {
   });
 
   it("defaults to 'default' account when no accountId is provided", () => {
-    const result = resolveBasecampAccount(
-      cfgWithAccounts({ default: { personId: "42", token: "tok" } }),
-    );
+    const result = resolveBasecampAccount(cfgWithAccounts({ default: { personId: "42", token: "tok" } }));
     expect(result.accountId).toBe("default");
     expect(result.personId).toBe("42");
     expect(result.token).toBe("tok");
@@ -146,19 +136,13 @@ describe("resolveBasecampAccount", () => {
   });
 
   it("defaults to 'default' account when accountId is null", () => {
-    const result = resolveBasecampAccount(
-      cfgWithAccounts({ default: { personId: "42", token: "tok" } }),
-      null,
-    );
+    const result = resolveBasecampAccount(cfgWithAccounts({ default: { personId: "42", token: "tok" } }), null);
     expect(result.accountId).toBe("default");
     expect(result.token).toBe("tok");
   });
 
   it("resolves an account with an inline token", () => {
-    const result = resolveBasecampAccount(
-      cfgWithAccounts({ prod: { personId: "10", token: "secret123" } }),
-      "prod",
-    );
+    const result = resolveBasecampAccount(cfgWithAccounts({ prod: { personId: "10", token: "secret123" } }), "prod");
     expect(result.accountId).toBe("prod");
     expect(result.enabled).toBe(true);
     expect(result.personId).toBe("10");
@@ -167,10 +151,7 @@ describe("resolveBasecampAccount", () => {
   });
 
   it("trims whitespace from inline token", () => {
-    const result = resolveBasecampAccount(
-      cfgWithAccounts({ prod: { personId: "10", token: "  tok  " } }),
-      "prod",
-    );
+    const result = resolveBasecampAccount(cfgWithAccounts({ prod: { personId: "10", token: "  tok  " } }), "prod");
     expect(result.token).toBe("tok");
   });
 
@@ -325,9 +306,7 @@ describe("resolveBasecampAccount", () => {
   });
 
   it("resolves personId from config", () => {
-    const result = resolveBasecampAccount(
-      cfgWithAccounts({ default: { personId: "999", token: "t" } }),
-    );
+    const result = resolveBasecampAccount(cfgWithAccounts({ default: { personId: "999", token: "t" } }));
     expect(result.personId).toBe("999");
   });
 
@@ -350,17 +329,13 @@ describe("resolveBasecampAccount", () => {
   });
 
   it("defaults enabled to true when not specified", () => {
-    const result = resolveBasecampAccount(
-      cfgWithAccounts({ default: { personId: "1", token: "t" } }),
-    );
+    const result = resolveBasecampAccount(cfgWithAccounts({ default: { personId: "1", token: "t" } }));
     expect(result.enabled).toBe(true);
   });
 
   it("includes the raw account config in the config field", () => {
     const accountCfg = { personId: "1", token: "t", displayName: "X" };
-    const result = resolveBasecampAccount(
-      cfgWithAccounts({ default: accountCfg }),
-    );
+    const result = resolveBasecampAccount(cfgWithAccounts({ default: accountCfg }));
     expect(result.config).toEqual(accountCfg);
   });
 });
@@ -400,18 +375,12 @@ describe("resolveBasecampAccountAsync", () => {
 
 describe("resolvePersonaAccountId", () => {
   it("returns the mapped account ID for a known agent", () => {
-    const result = resolvePersonaAccountId(
-      cfg({ personas: { "agent-alpha": "account-one" } }),
-      "agent-alpha",
-    );
+    const result = resolvePersonaAccountId(cfg({ personas: { "agent-alpha": "account-one" } }), "agent-alpha");
     expect(result).toBe("account-one");
   });
 
   it("returns undefined for an unmapped agent", () => {
-    const result = resolvePersonaAccountId(
-      cfg({ personas: { "agent-alpha": "account-one" } }),
-      "agent-beta",
-    );
+    const result = resolvePersonaAccountId(cfg({ personas: { "agent-alpha": "account-one" } }), "agent-beta");
     expect(result).toBeUndefined();
   });
 
@@ -450,18 +419,14 @@ describe("resolvePollingIntervals", () => {
   });
 
   it("overrides activityIntervalMs", () => {
-    const result = resolvePollingIntervals(
-      cfg({ polling: { activityIntervalMs: 30_000 } }),
-    );
+    const result = resolvePollingIntervals(cfg({ polling: { activityIntervalMs: 30_000 } }));
     expect(result.activityIntervalMs).toBe(30_000);
     expect(result.readingsIntervalMs).toBe(60_000);
     expect(result.assignmentsIntervalMs).toBe(300_000);
   });
 
   it("overrides readingsIntervalMs", () => {
-    const result = resolvePollingIntervals(
-      cfg({ polling: { readingsIntervalMs: 10_000 } }),
-    );
+    const result = resolvePollingIntervals(cfg({ polling: { readingsIntervalMs: 10_000 } }));
     expect(result.readingsIntervalMs).toBe(10_000);
   });
 
@@ -501,9 +466,7 @@ describe("resolveBasecampDmPolicy", () => {
   });
 
   it("returns 'pairing' when configured", () => {
-    expect(resolveBasecampDmPolicy(cfg({ dmPolicy: "pairing" }))).toBe(
-      "pairing",
-    );
+    expect(resolveBasecampDmPolicy(cfg({ dmPolicy: "pairing" }))).toBe("pairing");
   });
 
   it("returns 'open' when explicitly configured", () => {
@@ -525,21 +488,15 @@ describe("resolveBasecampAllowFrom", () => {
   });
 
   it("returns string entries as-is", () => {
-    expect(
-      resolveBasecampAllowFrom(cfg({ allowFrom: ["100", "200"] })),
-    ).toEqual(["100", "200"]);
+    expect(resolveBasecampAllowFrom(cfg({ allowFrom: ["100", "200"] }))).toEqual(["100", "200"]);
   });
 
   it("coerces numeric entries to strings", () => {
-    expect(
-      resolveBasecampAllowFrom(cfg({ allowFrom: [100, 200] })),
-    ).toEqual(["100", "200"]);
+    expect(resolveBasecampAllowFrom(cfg({ allowFrom: [100, 200] }))).toEqual(["100", "200"]);
   });
 
   it("handles mixed string and number entries", () => {
-    expect(
-      resolveBasecampAllowFrom(cfg({ allowFrom: ["abc", 42, "def"] })),
-    ).toEqual(["abc", "42", "def"]);
+    expect(resolveBasecampAllowFrom(cfg({ allowFrom: ["abc", 42, "def"] }))).toEqual(["abc", "42", "def"]);
   });
 });
 
@@ -553,30 +510,21 @@ describe("resolveBasecampBucketAllowFrom", () => {
   });
 
   it("returns string array from exact bucket match", () => {
-    expect(
-      resolveBasecampBucketAllowFrom(
-        cfg({ buckets: { "456": { allowFrom: ["100", "200"] } } }),
-        "456",
-      ),
-    ).toEqual(["100", "200"]);
+    expect(resolveBasecampBucketAllowFrom(cfg({ buckets: { "456": { allowFrom: ["100", "200"] } } }), "456")).toEqual([
+      "100",
+      "200",
+    ]);
   });
 
   it("falls back to wildcard", () => {
-    expect(
-      resolveBasecampBucketAllowFrom(
-        cfg({ buckets: { "*": { allowFrom: ["111"] } } }),
-        "456",
-      ),
-    ).toEqual(["111"]);
+    expect(resolveBasecampBucketAllowFrom(cfg({ buckets: { "*": { allowFrom: ["111"] } } }), "456")).toEqual(["111"]);
   });
 
   it("coerces numbers to strings", () => {
-    expect(
-      resolveBasecampBucketAllowFrom(
-        cfg({ buckets: { "456": { allowFrom: [100, 200] } } }),
-        "456",
-      ),
-    ).toEqual(["100", "200"]);
+    expect(resolveBasecampBucketAllowFrom(cfg({ buckets: { "456": { allowFrom: [100, 200] } } }), "456")).toEqual([
+      "100",
+      "200",
+    ]);
   });
 
   it("exact match takes precedence over wildcard", () => {
@@ -621,7 +569,7 @@ describe("resolveAccountForBucket", () => {
   });
 
   it("returns undefined when no virtualAccounts configured", () => {
-    const config = cfg({ accounts: { "default": { personId: "1" } } });
+    const config = cfg({ accounts: { default: { personId: "1" } } });
     expect(resolveAccountForBucket(config, "456")).toBeUndefined();
   });
 
@@ -631,7 +579,7 @@ describe("resolveAccountForBucket", () => {
 
   it("resolves first matching virtualAccount when multiple exist", () => {
     const config = cfg({
-      accounts: { "a1": { personId: "1" }, "a2": { personId: "2" } },
+      accounts: { a1: { personId: "1" }, a2: { personId: "2" } },
       virtualAccounts: {
         "proj-a": { accountId: "a1", bucketId: "100" },
         "proj-b": { accountId: "a2", bucketId: "200" },

--- a/tests/correlation-ids.test.ts
+++ b/tests/correlation-ids.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock basecamp-client (transitive dep via outbound/send.js)
 vi.mock("../src/basecamp-client.js", () => ({
@@ -7,7 +7,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (result: any) => result?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
   clearClients: vi.fn(),
 }));
@@ -27,8 +30,8 @@ vi.mock("../src/outbound/send.js", () => ({
 
 import {
   normalizeActivityEvent,
-  normalizeReadingsEvent,
   normalizeAssignmentTodo,
+  normalizeReadingsEvent,
   normalizeWebhookPayload,
 } from "../src/inbound/normalize.js";
 import type { ResolvedBasecampAccount } from "../src/types.js";

--- a/tests/cross-source-dedup.test.ts
+++ b/tests/cross-source-dedup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { EventDedup } from "../src/inbound/dedup.js";
 
 // Mock external deps used by normalize.ts
@@ -9,15 +9,8 @@ vi.mock("../src/outbound/send.js", () => ({
   resolveCircleInfoCached: vi.fn(() => undefined),
 }));
 
-import {
-  normalizeActivityEvent,
-  normalizeWebhookPayload,
-} from "../src/inbound/normalize.js";
-import type {
-  BasecampActivityEvent,
-  BasecampWebhookPayload,
-  ResolvedBasecampAccount,
-} from "../src/types.js";
+import { normalizeActivityEvent, normalizeWebhookPayload } from "../src/inbound/normalize.js";
+import type { BasecampActivityEvent, BasecampWebhookPayload, ResolvedBasecampAccount } from "../src/types.js";
 
 const account: ResolvedBasecampAccount = {
   accountId: "test",
@@ -81,10 +74,14 @@ describe("cross-source dedup key parity", () => {
 
     // Therefore, the secondary keys are identical:
     const activitySecondary = EventDedup.secondaryKey(
-      activityMsg!.meta.recordingId!, activityMsg!.meta.eventKind, activityMsg!.createdAt,
+      activityMsg!.meta.recordingId!,
+      activityMsg!.meta.eventKind,
+      activityMsg!.createdAt,
     );
     const webhookSecondary = EventDedup.secondaryKey(
-      webhookMsg!.meta.recordingId!, webhookMsg!.meta.eventKind, webhookMsg!.createdAt,
+      webhookMsg!.meta.recordingId!,
+      webhookMsg!.meta.eventKind,
+      webhookMsg!.createdAt,
     );
     expect(activitySecondary).toBe(webhookSecondary);
 
@@ -101,7 +98,7 @@ describe("cross-source dedup key parity", () => {
     const recordingId = "456";
     const eventKind = "created";
     const readingsCreatedAt = "2025-06-15T15:00:00Z"; // unread_at, shifted
-    const webhookCreatedAt = "2025-06-15T14:30:00Z";  // created_at, original
+    const webhookCreatedAt = "2025-06-15T14:30:00Z"; // created_at, original
 
     const readingsSecondary = EventDedup.secondaryKey(recordingId, eventKind, readingsCreatedAt);
     const webhookSecondary = EventDedup.secondaryKey(recordingId, eventKind, webhookCreatedAt);

--- a/tests/cursors.test.ts
+++ b/tests/cursors.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, stat } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { CursorStore } from "../src/inbound/cursors.js";
 
 describe("CursorStore", () => {

--- a/tests/dead-letter.test.ts
+++ b/tests/dead-letter.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
+  clearMetrics,
+  getAccountMetrics,
   recordDispatchFailure,
   recordQueueFullDrop,
-  recordWebhookReceived,
   recordWebhookDispatched,
-  getAccountMetrics,
-  clearMetrics,
+  recordWebhookReceived,
 } from "../src/metrics.js";
 
 beforeEach(() => {

--- a/tests/dedup-registry.test.ts
+++ b/tests/dedup-registry.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let tmpDir: string;
 
@@ -12,10 +12,10 @@ vi.mock("../src/runtime.js", () => ({
 }));
 
 import {
-  getAccountDedup,
-  flushAccountDedup,
   closeAccountDedup,
   closeAllAccountDedup,
+  flushAccountDedup,
+  getAccountDedup,
 } from "../src/inbound/dedup-registry.js";
 import * as sqliteStore from "../src/inbound/dedup-store-sqlite.js";
 

--- a/tests/dedup-store-sqlite.test.ts
+++ b/tests/dedup-store-sqlite.test.ts
@@ -1,12 +1,11 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { DatabaseSync } from "node:sqlite";
-import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-
-import { DedupDb, SqliteDedupStore, openDedupDb } from "../src/inbound/dedup-store-sqlite.js";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
 import { EventDedup } from "../src/inbound/dedup.js";
 import type { DedupSnapshot } from "../src/inbound/dedup-store.js";
+import { DedupDb, openDedupDb, SqliteDedupStore } from "../src/inbound/dedup-store-sqlite.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -26,7 +25,11 @@ function freshDbPath(): string {
 
 afterEach(() => {
   for (const dir of tmpDirs) {
-    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
   }
   tmpDirs = [];
 });
@@ -38,7 +41,7 @@ afterEach(() => {
 const SNAPSHOT: DedupSnapshot = {
   primary: {
     "activity:1": { seenAt: 1000, source: "activity" },
-    "reading:2":  { seenAt: 2000, source: "reading" },
+    "reading:2": { seenAt: 2000, source: "reading" },
   },
   secondary: {
     "100:created:2025-01-01": "activity:1",
@@ -55,9 +58,9 @@ describe("SqliteDedupStore", () => {
     const dedupDb = openDedupDb(dbPath);
     try {
       const raw = new DatabaseSync(dbPath, { open: true });
-      const rows = raw.prepare(
-        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
-      ).all() as Array<{ name: string }>;
+      const rows = raw.prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").all() as Array<{
+        name: string;
+      }>;
       const names = rows.map((r) => r.name);
       expect(names).toContain("dedup_primary");
       expect(names).toContain("dedup_secondary");
@@ -159,9 +162,9 @@ describe("SqliteDedupStore", () => {
 
       // Meta flag set
       const raw = new DatabaseSync(dbPath, { open: true });
-      const flagRow = raw.prepare(
-        "SELECT value FROM dedup_meta WHERE key = 'migrated_json'",
-      ).get() as { value: string } | undefined;
+      const flagRow = raw.prepare("SELECT value FROM dedup_meta WHERE key = 'migrated_json'").get() as
+        | { value: string }
+        | undefined;
       raw.close();
       expect(flagRow?.value).toBe("1");
     } finally {
@@ -176,18 +179,13 @@ describe("SqliteDedupStore", () => {
     const dedupDb = openDedupDb(dbPath);
     try {
       // Paths to non-existent files — should not throw
-      expect(() =>
-        dedupDb.migrateFromJson([
-          join(dir, "nope1.json"),
-          join(dir, "nope2.json"),
-        ]),
-      ).not.toThrow();
+      expect(() => dedupDb.migrateFromJson([join(dir, "nope1.json"), join(dir, "nope2.json")])).not.toThrow();
 
       // Meta flag should still be set (no files → set flag and return)
       const raw = new DatabaseSync(dbPath, { open: true });
-      const flagRow = raw.prepare(
-        "SELECT value FROM dedup_meta WHERE key = 'migrated_json'",
-      ).get() as { value: string } | undefined;
+      const flagRow = raw.prepare("SELECT value FROM dedup_meta WHERE key = 'migrated_json'").get() as
+        | { value: string }
+        | undefined;
       raw.close();
       expect(flagRow?.value).toBe("1");
     } finally {
@@ -308,9 +306,9 @@ describe("SqliteDedupStore", () => {
 
       // Meta flag should now be set
       const raw2 = new DatabaseSync(dbPath, { open: true });
-      const flagRow = raw2.prepare(
-        "SELECT value FROM dedup_meta WHERE key = 'migrated_json'",
-      ).get() as { value: string } | undefined;
+      const flagRow = raw2.prepare("SELECT value FROM dedup_meta WHERE key = 'migrated_json'").get() as
+        | { value: string }
+        | undefined;
       raw2.close();
       expect(flagRow?.value).toBe("1");
     } finally {

--- a/tests/dedup-store.test.ts
+++ b/tests/dedup-store.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { EventDedup } from "../src/inbound/dedup.js";
-import type { DedupStore, DedupSnapshot } from "../src/inbound/dedup-store.js";
-import { JsonFileDedupStore } from "../src/inbound/dedup-store.js";
-import { writeFileSync, mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EventDedup } from "../src/inbound/dedup.js";
+import type { DedupSnapshot, DedupStore } from "../src/inbound/dedup-store.js";
+import { JsonFileDedupStore } from "../src/inbound/dedup-store.js";
 
 // ---------------------------------------------------------------------------
 // In-memory mock store for unit tests

--- a/tests/dedup.test.ts
+++ b/tests/dedup.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { EventDedup } from "../src/inbound/dedup.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DedupSource } from "../src/inbound/dedup.js";
+import { EventDedup } from "../src/inbound/dedup.js";
 
 describe("EventDedup", () => {
   let dedup: EventDedup;
@@ -20,13 +20,11 @@ describe("EventDedup", () => {
 
   describe("secondaryKey", () => {
     it("builds recordingId:action:createdAt strings", () => {
-      expect(
-        EventDedup.secondaryKey("456", "created", "2025-01-15T10:00:00Z"),
-      ).toBe("456:created:2025-01-15T10:00:00Z");
+      expect(EventDedup.secondaryKey("456", "created", "2025-01-15T10:00:00Z")).toBe(
+        "456:created:2025-01-15T10:00:00Z",
+      );
 
-      expect(
-        EventDedup.secondaryKey(789, "updated", "2025-06-01T12:30:00Z"),
-      ).toBe("789:updated:2025-06-01T12:30:00Z");
+      expect(EventDedup.secondaryKey(789, "updated", "2025-06-01T12:30:00Z")).toBe("789:updated:2025-06-01T12:30:00Z");
     });
   });
 

--- a/tests/directory.test.ts
+++ b/tests/directory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -20,7 +20,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (r: any) => r?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
@@ -262,9 +265,7 @@ describe("directory.listGroupsLive", () => {
 
 describe("directory.listGroupMembers", () => {
   it("fetches members for bucket:<id> group", async () => {
-    mockClient.people.listForProject.mockResolvedValue([
-      { id: 5, name: "Carol", email_address: "carol@example.com" },
-    ]);
+    mockClient.people.listForProject.mockResolvedValue([{ id: 5, name: "Carol", email_address: "carol@example.com" }]);
 
     const result = await basecampDirectoryAdapter.listGroupMembers!({
       cfg: cfg({ accounts: { test: {} } }),

--- a/tests/dispatch-enhanced.test.ts
+++ b/tests/dispatch-enhanced.test.ts
@@ -1,11 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { dispatchBasecampEvent } from "../src/dispatch.js";
-import type {
-  BasecampInboundMessage,
-  ResolvedBasecampAccount,
-} from "../src/types.js";
-import { getBasecampRuntime } from "../src/runtime.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolvePersonaAccountId } from "../src/config.js";
+import { dispatchBasecampEvent } from "../src/dispatch.js";
+import { getBasecampRuntime } from "../src/runtime.js";
+import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -91,9 +88,7 @@ beforeEach(() => {
     matchedBy: "peer",
     sessionKey: "session:abc",
   });
-  mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(
-    undefined,
-  );
+  mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -112,9 +107,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
     // Get the onError callback from the dispatch call
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const onError = call.dispatcherOptions.onError;
 
     // Simulate an error
@@ -140,9 +133,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const onError = call.dispatcherOptions.onError;
 
     onError(new Error("401 Unauthorized"));
@@ -161,9 +152,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const onError = call.dispatcherOptions.onError;
 
     onError(new Error("no route matched"));
@@ -182,9 +171,7 @@ describe("dispatchBasecampEvent enhanced onError logging", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const onError = call.dispatcherOptions.onError;
 
     onError(new Error("something unexpected happened"));

--- a/tests/dispatch-outbound.test.ts
+++ b/tests/dispatch-outbound.test.ts
@@ -1,13 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { dispatchBasecampEvent } from "../src/dispatch.js";
-import type {
-  BasecampInboundMessage,
-  ResolvedBasecampAccount,
-} from "../src/types.js";
-import { getBasecampRuntime } from "../src/runtime.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolvePersonaAccountId } from "../src/config.js";
-import { postReplyToEvent } from "../src/outbound/send.js";
+import { dispatchBasecampEvent } from "../src/dispatch.js";
 import { markdownToBasecampHtml } from "../src/outbound/format.js";
+import { postReplyToEvent } from "../src/outbound/send.js";
+import { getBasecampRuntime } from "../src/runtime.js";
+import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -95,9 +92,7 @@ beforeEach(() => {
     matchedBy: "peer",
     sessionKey: "session:abc",
   });
-  mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(
-    undefined,
-  );
+  mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(undefined);
   vi.mocked(postReplyToEvent).mockResolvedValue({ ok: true });
 });
 
@@ -109,9 +104,7 @@ describe("dispatch outbound reliability", () => {
   it("deliver callback calls postReplyToEvent with retries: 2", async () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
 
     await deliver({ text: "Agent reply" }, {});
@@ -132,9 +125,7 @@ describe("dispatch outbound reliability", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const onError = call.dispatcherOptions.onError;
 
     onError(new Error("ETIMEDOUT connecting to host"));
@@ -157,9 +148,7 @@ describe("dispatch outbound reliability", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     call.dispatcherOptions.onError(new Error("401 Unauthorized"));
 
     expect(logError.mock.calls[0][0]).toContain('"type":"auth"');
@@ -171,9 +160,7 @@ describe("dispatch outbound reliability", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     call.dispatcherOptions.onError(new Error("something unexpected"));
 
     expect(logError.mock.calls[0][0]).toContain('"type":"unknown"');
@@ -186,9 +173,7 @@ describe("dispatch outbound reliability", () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
     // The delivery log should be the last info call
-    const deliveryLog = logInfo.mock.calls.find((c: string[]) =>
-      c[0].includes("delivered"),
-    );
+    const deliveryLog = logInfo.mock.calls.find((c: string[]) => c[0].includes("delivered"));
     expect(deliveryLog).toBeDefined();
     expect(deliveryLog![0]).toContain('"agent":"agent-1"');
     expect(deliveryLog![0]).toContain('"event":"created"');
@@ -209,8 +194,8 @@ describe("dispatch outbound reliability", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount, log });
 
-    const deliveryLog = logInfo.mock.calls.find((c: string[]) =>
-      c[0].includes("delivered") && !c[0].includes("delivery_failed"),
+    const deliveryLog = logInfo.mock.calls.find(
+      (c: string[]) => c[0].includes("delivered") && !c[0].includes("delivery_failed"),
     );
     expect(deliveryLog).toBeUndefined();
     expect(logError).toHaveBeenCalled();
@@ -225,9 +210,7 @@ describe("dispatch outbound reliability", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
 
     await expect(deliver({ text: "Reply" }, {})).rejects.toThrow("403 Forbidden");
@@ -236,9 +219,7 @@ describe("dispatch outbound reliability", () => {
   it("chunks long text and sends multiple postReplyToEvent calls", async () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
 
     // Generate text with sentence breaks that exceeds the 10K chunk limit.
@@ -263,9 +244,7 @@ describe("dispatch outbound reliability", () => {
   it("sends single postReplyToEvent call for text under chunk limit", async () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
 
     await deliver({ text: "Short reply" }, {});
@@ -284,9 +263,7 @@ describe("dispatch outbound reliability", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
 
     // ~35K chars with sentence breaks → 3+ chunks
@@ -311,9 +288,7 @@ describe("dispatch outbound reliability", () => {
 
     await dispatchBasecampEvent(childMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
     await deliver({ text: "Reply to thread" }, {});
 
@@ -330,9 +305,7 @@ describe("dispatch outbound reliability", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
     await deliver({ text: "CB test" }, {});
 
@@ -352,8 +325,7 @@ describe("dispatch outbound reliability", () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const calls =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls;
+    const calls = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls;
     const deliver1 = calls[0][0].dispatcherOptions.deliver;
     const deliver2 = calls[1][0].dispatcherOptions.deliver;
     await deliver1({ text: "First" }, {});

--- a/tests/dispatch.test.ts
+++ b/tests/dispatch.test.ts
@@ -1,13 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveBasecampAccount,
+  resolveBasecampAllowFrom,
+  resolveBasecampBucketAllowFrom,
+  resolveBasecampDmPolicy,
+  resolvePersonaAccountId,
+} from "../src/config.js";
 import { dispatchBasecampEvent } from "../src/dispatch.js";
-import type {
-  BasecampInboundMessage,
-  ResolvedBasecampAccount,
-} from "../src/types.js";
-import { getBasecampRuntime } from "../src/runtime.js";
-import { resolvePersonaAccountId, resolveBasecampAccount, resolveBasecampDmPolicy, resolveBasecampAllowFrom, resolveBasecampBucketAllowFrom } from "../src/config.js";
-import { postReplyToEvent } from "../src/outbound/send.js";
 import { markdownToBasecampHtml } from "../src/outbound/format.js";
+import { postReplyToEvent } from "../src/outbound/send.js";
+import { getBasecampRuntime } from "../src/runtime.js";
+import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -104,9 +107,7 @@ beforeEach(() => {
     matchedBy: "peer",
     sessionKey: "session:abc",
   });
-  mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(
-    undefined,
-  );
+  mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -119,9 +120,7 @@ describe("dispatchBasecampEvent", () => {
     const result = await dispatchBasecampEvent(selfMsg, { account: mockAccount });
 
     expect(result).toBe(false);
-    expect(
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
-    ).not.toHaveBeenCalled();
+    expect(mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("returns false when no route is matched", async () => {
@@ -130,22 +129,16 @@ describe("dispatchBasecampEvent", () => {
     const result = await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
     expect(result).toBe(false);
-    expect(
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
-    ).not.toHaveBeenCalled();
+    expect(mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("dispatches successfully with correct MsgContext fields", async () => {
     const result = await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
     expect(result).toBe(true);
-    expect(
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
-    ).toHaveBeenCalledTimes(1);
+    expect(mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const ctx = call.ctx;
 
     expect(ctx.Body).toBe("Hello");
@@ -178,9 +171,7 @@ describe("dispatchBasecampEvent", () => {
 
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
 
     await deliver({ text: "Reply text" }, {});
@@ -207,9 +198,7 @@ describe("dispatchBasecampEvent", () => {
     expect(result).toBe(false);
     expect(log.error).toHaveBeenCalledTimes(1);
     expect(log.error.mock.calls[0][0]).toContain("outbound_account_id_missing");
-    expect(
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
-    ).not.toHaveBeenCalled();
+    expect(mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("accepts basecampAccountId for OAuth accounts", async () => {
@@ -234,8 +223,7 @@ describe("dispatchBasecampEvent", () => {
     const result = await dispatchBasecampEvent(mockMsg, { account: accountNumericId });
 
     expect(result).toBe(true);
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
     await deliver({ text: "Reply" }, {});
 
@@ -249,9 +237,7 @@ describe("dispatchBasecampEvent", () => {
   it("deliver callback calls postReplyToEvent with correct params", async () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
 
     await deliver({ text: "Agent reply" }, {});
@@ -273,9 +259,7 @@ describe("dispatchBasecampEvent", () => {
   it("deliver callback skips postReplyToEvent when payload.text is empty", async () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const deliver = call.dispatcherOptions.deliver;
 
     await deliver({ text: "" }, {});
@@ -286,9 +270,7 @@ describe("dispatchBasecampEvent", () => {
   it("UntrustedContext contains [basecamp] prefixed metadata lines", async () => {
     await dispatchBasecampEvent(mockMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     const ctx = call.ctx;
     const untrusted: string[] = ctx.UntrustedContext;
 
@@ -296,18 +278,10 @@ describe("dispatchBasecampEvent", () => {
     for (const line of untrusted) {
       expect(line).toMatch(/^\[basecamp\] /);
     }
-    expect(untrusted).toContainEqual(
-      expect.stringContaining("recordableType=Chat::Transcript"),
-    );
-    expect(untrusted).toContainEqual(
-      expect.stringContaining("eventKind=created"),
-    );
-    expect(untrusted).toContainEqual(
-      expect.stringContaining("bucketId=456"),
-    );
-    expect(untrusted).toContainEqual(
-      expect.stringContaining("recordingId=123"),
-    );
+    expect(untrusted).toContainEqual(expect.stringContaining("recordableType=Chat::Transcript"));
+    expect(untrusted).toContainEqual(expect.stringContaining("eventKind=created"));
+    expect(untrusted).toContainEqual(expect.stringContaining("bucketId=456"));
+    expect(untrusted).toContainEqual(expect.stringContaining("recordingId=123"));
   });
 
   it("sets ChatType to 'direct' when msg.peer.kind is 'dm'", async () => {
@@ -315,9 +289,7 @@ describe("dispatchBasecampEvent", () => {
 
     await dispatchBasecampEvent(dmMsg, { account: mockAccount });
 
-    const call =
-      mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock
-        .calls[0][0];
+    const call = mockRuntime.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0][0];
     expect(call.ctx.ChatType).toBe("direct");
   });
 

--- a/tests/dock-cache.test.ts
+++ b/tests/dock-cache.test.ts
@@ -4,12 +4,8 @@
  * Validates dock tool ID resolution, caching with TTL, invalidation,
  * error handling, and disabled dock item filtering.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  resolveDockToolIds,
-  invalidateDockCache,
-  clearDockCache,
-} from "../src/inbound/dock-cache.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearDockCache, invalidateDockCache, resolveDockToolIds } from "../src/inbound/dock-cache.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -131,9 +127,7 @@ describe("dock-cache", () => {
   });
 
   it("missing dock items → undefined fields", async () => {
-    const client = makeClient([
-      { name: "todoset", id: 200, enabled: true },
-    ]);
+    const client = makeClient([{ name: "todoset", id: 200, enabled: true }]);
     const ids = await resolveDockToolIds(client, 42);
     expect(ids!.cardTableId).toBeUndefined();
     expect(ids!.todosetId).toBe(200);
@@ -178,9 +172,7 @@ describe("dock-cache", () => {
   });
 
   it("enabled property omitted → item included (default enabled)", async () => {
-    const client = makeClient([
-      { name: "kanban_board", id: 100 },
-    ]);
+    const client = makeClient([{ name: "kanban_board", id: 100 }]);
     const ids = await resolveDockToolIds(client, 42);
     expect(ids!.cardTableId).toBe(100);
   });

--- a/tests/dogfooding/dm-policy.test.ts
+++ b/tests/dogfooding/dm-policy.test.ts
@@ -4,7 +4,7 @@
  * Validates the full dispatch gate pipeline: engagement classification,
  * per-bucket engage overrides, DM policy enforcement, and default behavior.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { dispatchBasecampEvent } from "../../src/dispatch.js";
 import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../../src/types.js";
 

--- a/tests/dogfooding/outbound-cb.test.ts
+++ b/tests/dogfooding/outbound-cb.test.ts
@@ -9,11 +9,16 @@
  *   - Direct CB state machine + metrics sync (DF-018, DF-019, DF-020)
  *   - Full dispatch pipeline with failure attribution (DF-021)
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { dispatchBasecampEvent } from "../../src/dispatch.js";
-import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../../src/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CircuitBreaker } from "../../src/circuit-breaker.js";
-import { getAccountMetrics, clearMetrics, recordCircuitBreakerState, recordDispatchFailure } from "../../src/metrics.js";
+import { dispatchBasecampEvent } from "../../src/dispatch.js";
+import {
+  clearMetrics,
+  getAccountMetrics,
+  recordCircuitBreakerState,
+  recordDispatchFailure,
+} from "../../src/metrics.js";
+import type { BasecampInboundMessage, ResolvedBasecampAccount } from "../../src/types.js";
 
 // ---------------------------------------------------------------------------
 // Mocks — only needed for DF-021 (full dispatch pipeline)

--- a/tests/dogfooding/queue-pressure.test.ts
+++ b/tests/dogfooding/queue-pressure.test.ts
@@ -4,8 +4,9 @@
  * Validates that the webhook handler drops events when the dispatch semaphore
  * is saturated, increments the correct metrics, and recovers after drain.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before imports that reference them
@@ -89,21 +90,22 @@ vi.mock("../../src/inbound/dedup-registry.js", () => {
       flush: vi.fn(),
       size: seen.size,
     })),
-    closeAccountDedup: vi.fn(() => { seen.clear(); }),
-    closeAllAccountDedup: vi.fn(() => { seen.clear(); }),
+    closeAccountDedup: vi.fn(() => {
+      seen.clear();
+    }),
+    closeAllAccountDedup: vi.fn(() => {
+      seen.clear();
+    }),
     flushAccountDedup: vi.fn(),
   };
 });
 
 import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
-import {
-  Semaphore,
-  handleBasecampWebhook,
-} from "../../src/inbound/webhooks.js";
+import { join } from "node:path";
 import { closeAllAccountDedup } from "../../src/inbound/dedup-registry.js";
-import { getAccountMetrics, clearMetrics } from "../../src/metrics.js";
+import { handleBasecampWebhook, Semaphore } from "../../src/inbound/webhooks.js";
+import { clearMetrics, getAccountMetrics } from "../../src/metrics.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -127,8 +129,14 @@ function makeRes(): ServerResponse & { statusCode: number; body: string } {
   const res: any = {
     statusCode: 0,
     body: "",
-    writeHead(code: number) { res.statusCode = code; return res; },
-    end(data?: string) { res.body = data ?? ""; return res; },
+    writeHead(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    end(data?: string) {
+      res.body = data ?? "";
+      return res;
+    },
   };
   return res;
 }
@@ -165,9 +173,7 @@ describe("dogfooding — queue pressure", () => {
     // (10 active + 100 queued) before any handler finishes, then verify the
     // 111th webhook triggers queue_full. Each dispatch takes 200ms — long enough
     // for all 111 handlers to reach the semaphore before the first slot frees.
-    mockDispatch.mockImplementation(
-      () => new Promise<boolean>((r) => setTimeout(() => r(true), 200)),
-    );
+    mockDispatch.mockImplementation(() => new Promise<boolean>((r) => setTimeout(() => r(true), 200)));
 
     const handles: Promise<void>[] = [];
     for (let i = 0; i < 111; i++) {

--- a/tests/dogfooding/webhook-auth.test.ts
+++ b/tests/dogfooding/webhook-auth.test.ts
@@ -4,9 +4,10 @@
  * Validates token auth, HMAC auth, bucket-scoped secret resolution,
  * and fail-closed semantics across multi-account configurations.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
 import crypto from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -83,21 +84,22 @@ vi.mock("../../src/inbound/dedup-registry.js", () => {
       flush: vi.fn(),
       size: seen.size,
     })),
-    closeAccountDedup: vi.fn(() => { seen.clear(); }),
-    closeAllAccountDedup: vi.fn(() => { seen.clear(); }),
+    closeAccountDedup: vi.fn(() => {
+      seen.clear();
+    }),
+    closeAllAccountDedup: vi.fn(() => {
+      seen.clear();
+    }),
     flushAccountDedup: vi.fn(),
   };
 });
 
 import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
-import {
-  handleBasecampWebhook,
-  getWebhookSecretRegistry,
-} from "../../src/inbound/webhooks.js";
-import { closeAllAccountDedup } from "../../src/inbound/dedup-registry.js";
+import { join } from "node:path";
 import { dispatchBasecampEvent } from "../../src/dispatch.js";
+import { closeAllAccountDedup } from "../../src/inbound/dedup-registry.js";
+import { getWebhookSecretRegistry, handleBasecampWebhook } from "../../src/inbound/webhooks.js";
 import { clearMetrics } from "../../src/metrics.js";
 
 // ---------------------------------------------------------------------------
@@ -147,9 +149,7 @@ function makeReq(
   body: string,
   opts?: { token?: string; hmacSignature?: string; hmacTimestamp?: string },
 ): IncomingMessage {
-  const url = opts?.token
-    ? `/webhooks/basecamp?token=${opts.token}`
-    : "/webhooks/basecamp";
+  const url = opts?.token ? `/webhooks/basecamp?token=${opts.token}` : "/webhooks/basecamp";
 
   const headers: Record<string, string> = {
     host: "localhost",
@@ -175,8 +175,14 @@ function makeRes(): ServerResponse & { statusCode: number; body: string } {
   const res: any = {
     statusCode: 0,
     body: "",
-    writeHead(code: number) { res.statusCode = code; return res; },
-    end(data?: string) { res.body = data ?? ""; return res; },
+    writeHead(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    end(data?: string) {
+      res.body = data ?? "";
+      return res;
+    },
   };
   return res;
 }

--- a/tests/error-scenarios.test.ts
+++ b/tests/error-scenarios.test.ts
@@ -6,7 +6,7 @@
  *
  * Only auth-related functions remain in basecamp-cli.ts.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
@@ -18,9 +18,19 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...actual, readFileSync: vi.fn() };
 });
 
-import { cliMe, cliAuthStatus, cliWhich, cliProfileList, cliProfileListFull, exportCliCredentials, execCliAuthLogin, CliError, resolveCliBinaryPath } from "../src/basecamp-cli.js";
 import { execFile, spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
+import {
+  CliError,
+  cliAuthStatus,
+  cliMe,
+  cliProfileList,
+  cliProfileListFull,
+  cliWhich,
+  execCliAuthLogin,
+  exportCliCredentials,
+  resolveCliBinaryPath,
+} from "../src/basecamp-cli.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -287,7 +297,7 @@ describe("cliMe error shapes", () => {
 
   it("throws CliError on JSON parse failure", async () => {
     vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
-      cb(null, 'not json {', "");
+      cb(null, "not json {", "");
       return {} as any;
     });
 
@@ -327,7 +337,6 @@ describe("cliWhich", () => {
 
     await expect(cliWhich()).rejects.toThrow(CliError);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -368,10 +377,14 @@ describe("cliProfileList", () => {
 
   it("extracts names from object-shaped profile entries", async () => {
     vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
-      cb(null, JSON.stringify([
-        { name: "prod", base_url: "https://3.basecampapi.com" },
-        { name: "dev", base_url: "http://3.basecamp.localhost:3001" },
-      ]), "");
+      cb(
+        null,
+        JSON.stringify([
+          { name: "prod", base_url: "https://3.basecampapi.com" },
+          { name: "dev", base_url: "http://3.basecamp.localhost:3001" },
+        ]),
+        "",
+      );
       return {} as any;
     });
 
@@ -381,10 +394,7 @@ describe("cliProfileList", () => {
 
   it("handles mixed string and object entries", async () => {
     vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
-      cb(null, JSON.stringify([
-        "legacy-profile",
-        { name: "new-profile", base_url: "https://3.basecampapi.com" },
-      ]), "");
+      cb(null, JSON.stringify(["legacy-profile", { name: "new-profile", base_url: "https://3.basecampapi.com" }]), "");
       return {} as any;
     });
 
@@ -400,10 +410,14 @@ describe("cliProfileList", () => {
 describe("cliProfileListFull", () => {
   it("returns full profile objects", async () => {
     vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
-      cb(null, JSON.stringify([
-        { name: "prod", base_url: "https://3.basecampapi.com", authenticated: true },
-        { name: "dev", base_url: "http://localhost:3001", active: true },
-      ]), "");
+      cb(
+        null,
+        JSON.stringify([
+          { name: "prod", base_url: "https://3.basecampapi.com", authenticated: true },
+          { name: "dev", base_url: "http://localhost:3001", active: true },
+        ]),
+        "",
+      );
       return {} as any;
     });
 
@@ -415,12 +429,16 @@ describe("cliProfileListFull", () => {
 
   it("filters out entries missing name or base_url", async () => {
     vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
-      cb(null, JSON.stringify([
-        { name: "valid", base_url: "https://example.com" },
-        { name: "no-url" },
-        { base_url: "https://no-name.com" },
-        "string-entry",
-      ]), "");
+      cb(
+        null,
+        JSON.stringify([
+          { name: "valid", base_url: "https://example.com" },
+          { name: "no-url" },
+          { base_url: "https://no-name.com" },
+          "string-entry",
+        ]),
+        "",
+      );
       return {} as any;
     });
 
@@ -486,7 +504,9 @@ describe("exportCliCredentials", () => {
   });
 
   it("returns null when credentials file is missing", () => {
-    vi.mocked(readFileSync).mockImplementation(() => { throw new Error("ENOENT"); });
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
     expect(exportCliCredentials("https://3.basecampapi.com")).toBeNull();
   });
 
@@ -525,8 +545,12 @@ describe("cliAuthStatus non-CliError rethrow", () => {
 function mockSpawnHandle() {
   const handlers: Record<string, Function> = {};
   return {
-    on: vi.fn((event: string, cb: Function) => { handlers[event] = cb; }),
-    _emit(event: string, ...args: any[]) { queueMicrotask(() => handlers[event]?.(...args)); },
+    on: vi.fn((event: string, cb: Function) => {
+      handlers[event] = cb;
+    }),
+    _emit(event: string, ...args: any[]) {
+      queueMicrotask(() => handlers[event]?.(...args));
+    },
   };
 }
 

--- a/tests/error-scenarios.test.ts
+++ b/tests/error-scenarios.test.ts
@@ -13,8 +13,14 @@ vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
 }));
 
-import { cliMe, cliAuthStatus, cliWhich, cliProfileList, execCliAuthLogin, CliError, resolveCliBinaryPath } from "../src/basecamp-cli.js";
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, readFileSync: vi.fn() };
+});
+
+import { cliMe, cliAuthStatus, cliWhich, cliProfileList, cliProfileListFull, exportCliCredentials, execCliAuthLogin, CliError, resolveCliBinaryPath } from "../src/basecamp-cli.js";
 import { execFile, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -358,6 +364,143 @@ describe("cliProfileList", () => {
     });
 
     await expect(cliProfileList()).rejects.toThrow(TypeError);
+  });
+
+  it("extracts names from object-shaped profile entries", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([
+        { name: "prod", base_url: "https://3.basecampapi.com" },
+        { name: "dev", base_url: "http://3.basecamp.localhost:3001" },
+      ]), "");
+      return {} as any;
+    });
+
+    const result = await cliProfileList();
+    expect(result.data).toEqual(["prod", "dev"]);
+  });
+
+  it("handles mixed string and object entries", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([
+        "legacy-profile",
+        { name: "new-profile", base_url: "https://3.basecampapi.com" },
+      ]), "");
+      return {} as any;
+    });
+
+    const result = await cliProfileList();
+    expect(result.data).toEqual(["legacy-profile", "new-profile"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cliProfileListFull
+// ---------------------------------------------------------------------------
+
+describe("cliProfileListFull", () => {
+  it("returns full profile objects", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([
+        { name: "prod", base_url: "https://3.basecampapi.com", authenticated: true },
+        { name: "dev", base_url: "http://localhost:3001", active: true },
+      ]), "");
+      return {} as any;
+    });
+
+    const result = await cliProfileListFull();
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).toEqual(expect.objectContaining({ name: "prod", base_url: "https://3.basecampapi.com" }));
+    expect(result.data[1]).toEqual(expect.objectContaining({ name: "dev", active: true }));
+  });
+
+  it("filters out entries missing name or base_url", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      cb(null, JSON.stringify([
+        { name: "valid", base_url: "https://example.com" },
+        { name: "no-url" },
+        { base_url: "https://no-name.com" },
+        "string-entry",
+      ]), "");
+      return {} as any;
+    });
+
+    const result = await cliProfileListFull();
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]!.name).toBe("valid");
+  });
+
+  it("returns empty array on CliError", async () => {
+    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+      const err = new Error("failed") as any;
+      err.code = 1;
+      cb(err, "", "error");
+      return {} as any;
+    });
+
+    const result = await cliProfileListFull();
+    expect(result.data).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportCliCredentials
+// ---------------------------------------------------------------------------
+
+describe("exportCliCredentials", () => {
+  it("exports credentials for a matching base URL", () => {
+    vi.mocked(readFileSync).mockImplementation((filePath: any) => {
+      if (String(filePath).includes("credentials.json")) {
+        return JSON.stringify({
+          "https://3.basecampapi.com": {
+            access_token: "at-123",
+            refresh_token: "rt-456",
+            expires_at: 1770188269,
+          },
+        });
+      }
+      if (String(filePath).includes("client.json")) {
+        return JSON.stringify({ client_id: "cid-abc", client_secret: "cs-xyz" });
+      }
+      throw new Error("unexpected file");
+    });
+
+    const result = exportCliCredentials("https://3.basecampapi.com");
+    expect(result).toEqual({
+      accessToken: "at-123",
+      refreshToken: "rt-456",
+      expiresAt: 1770188269,
+      clientId: "cid-abc",
+      clientSecret: "cs-xyz",
+    });
+  });
+
+  it("returns null when base URL not found in credentials", () => {
+    vi.mocked(readFileSync).mockImplementation((filePath: any) => {
+      if (String(filePath).includes("credentials.json")) {
+        return JSON.stringify({ "https://other.com": { access_token: "x", refresh_token: "y" } });
+      }
+      return "{}";
+    });
+
+    expect(exportCliCredentials("https://3.basecampapi.com")).toBeNull();
+  });
+
+  it("returns null when credentials file is missing", () => {
+    vi.mocked(readFileSync).mockImplementation(() => { throw new Error("ENOENT"); });
+    expect(exportCliCredentials("https://3.basecampapi.com")).toBeNull();
+  });
+
+  it("returns null when client.json lacks client_id", () => {
+    vi.mocked(readFileSync).mockImplementation((filePath: any) => {
+      if (String(filePath).includes("credentials.json")) {
+        return JSON.stringify({
+          "https://3.basecampapi.com": { access_token: "at", refresh_token: "rt" },
+        });
+      }
+      return JSON.stringify({});
+    });
+
+    expect(exportCliCredentials("https://3.basecampapi.com")).toBeNull();
   });
 });
 

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,9 +1,5 @@
-import { describe, it, expect } from "vitest";
-import {
-  markdownToBasecampHtml,
-  stripHtml,
-  basecampHtmlToPlainText,
-} from "../src/outbound/format.js";
+import { describe, expect, it } from "vitest";
+import { basecampHtmlToPlainText, markdownToBasecampHtml, stripHtml } from "../src/outbound/format.js";
 
 // ---------------------------------------------------------------------------
 // markdownToBasecampHtml
@@ -56,15 +52,11 @@ describe("markdownToBasecampHtml", () => {
 
   // Inline code
   it("converts `inline code` to <code>", () => {
-    expect(markdownToBasecampHtml("`inline code`")).toBe(
-      "<code>inline code</code>"
-    );
+    expect(markdownToBasecampHtml("`inline code`")).toBe("<code>inline code</code>");
   });
 
   it("HTML-escapes content inside inline code", () => {
-    expect(markdownToBasecampHtml("`<div>&</div>`")).toBe(
-      "<code>&lt;div&gt;&amp;&lt;/div&gt;</code>"
-    );
+    expect(markdownToBasecampHtml("`<div>&</div>`")).toBe("<code>&lt;div&gt;&amp;&lt;/div&gt;</code>");
   });
 
   // Fenced code blocks
@@ -114,7 +106,7 @@ describe("markdownToBasecampHtml", () => {
   // Links
   it("converts [text](url) to <a>", () => {
     expect(markdownToBasecampHtml("[click here](https://example.com)")).toBe(
-      '<a href="https://example.com">click here</a>'
+      '<a href="https://example.com">click here</a>',
     );
   });
 
@@ -283,7 +275,8 @@ describe("stripHtml", () => {
   });
 
   it("strips table elements to plain text", () => {
-    const html = "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>";
+    const html =
+      "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>";
     const result = stripHtml(html);
     expect(result).toContain("A");
     expect(result).toContain("B");
@@ -315,9 +308,7 @@ describe("basecampHtmlToPlainText", () => {
   });
 
   it("converts simple HTML to plain text", () => {
-    expect(basecampHtmlToPlainText("<strong>hello</strong> world")).toBe(
-      "hello world"
-    );
+    expect(basecampHtmlToPlainText("<strong>hello</strong> world")).toBe("hello world");
   });
 
   it("delegates to stripHtml for full processing", () => {

--- a/tests/groups.test.ts
+++ b/tests/groups.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { basecampGroupAdapter } from "../src/adapters/groups.js";
-import { resolveBasecampBucketConfig } from "../src/adapters/groups.js";
+import { describe, expect, it } from "vitest";
+import { basecampGroupAdapter, resolveBasecampBucketConfig } from "../src/adapters/groups.js";
 
 function cfg(basecamp?: Record<string, unknown>) {
   if (!basecamp) return {} as any;
@@ -13,18 +12,12 @@ function cfg(basecamp?: Record<string, unknown>) {
 
 describe("resolveBasecampBucketConfig", () => {
   it("returns exact match", () => {
-    const result = resolveBasecampBucketConfig(
-      cfg({ buckets: { "123": { requireMention: true } } }),
-      "123",
-    );
+    const result = resolveBasecampBucketConfig(cfg({ buckets: { "123": { requireMention: true } } }), "123");
     expect(result).toEqual({ requireMention: true });
   });
 
   it("falls back to wildcard", () => {
-    const result = resolveBasecampBucketConfig(
-      cfg({ buckets: { "*": { requireMention: false } } }),
-      "999",
-    );
+    const result = resolveBasecampBucketConfig(cfg({ buckets: { "*": { requireMention: false } } }), "999");
     expect(result).toEqual({ requireMention: false });
   });
 
@@ -47,10 +40,7 @@ describe("resolveBasecampBucketConfig", () => {
   });
 
   it("returns undefined when bucketId not found and no wildcard", () => {
-    const result = resolveBasecampBucketConfig(
-      cfg({ buckets: { "456": { requireMention: true } } }),
-      "123",
-    );
+    const result = resolveBasecampBucketConfig(cfg({ buckets: { "456": { requireMention: true } } }), "123");
     expect(result).toBeUndefined();
   });
 });

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -234,9 +234,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
     expect(result.accountId).toBe("new-one");
 
     // Verify the validator was set up correctly
-    const textCall = prompter.text.mock.calls.find(
-      (c: any) => c[0].message.includes("Account ID key"),
-    );
+    const textCall = prompter.text.mock.calls.find((c: any) => c[0].message.includes("Account ID key"));
     expect(textCall).toBeDefined();
     const validate = textCall![0].validate;
     expect(validate!("existing")).toContain("already in use");
@@ -309,9 +307,7 @@ describe("hatchIdentity — Browser/OAuth path", () => {
 
     expect(result.accountId).toBe("new-acct");
     // Check clientId and clientSecret were prompted
-    expect(prompter.text).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "OAuth client ID" }),
-    );
+    expect(prompter.text).toHaveBeenCalledWith(expect.objectContaining({ message: "OAuth client ID" }));
     expect(prompter.text).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Client Secret (leave blank to skip)" }),
     );
@@ -378,9 +374,7 @@ describe("hatchIdentity — browser auth failure", () => {
       "OAuth client ID": "cid",
     });
 
-    await expect(
-      hatchIdentity(cfg({ oauth: { clientId: "cid" } }), prompter),
-    ).rejects.toThrow("login failed");
+    await expect(hatchIdentity(cfg({ oauth: { clientId: "cid" } }), prompter)).rejects.toThrow("login failed");
   });
 
   it("throws when discoverIdentity fails — no silent broken account", async () => {
@@ -396,9 +390,7 @@ describe("hatchIdentity — browser auth failure", () => {
       "OAuth client ID": "cid",
     });
 
-    await expect(
-      hatchIdentity(cfg({ oauth: { clientId: "cid" } }), prompter),
-    ).rejects.toThrow("network error");
+    await expect(hatchIdentity(cfg({ oauth: { clientId: "cid" } }), prompter)).rejects.toThrow("network error");
   });
 });
 

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,7 +5,7 @@
  * This file does NOT contain any test code (no describe/it/expect).
  * Import these helpers into test files that need them.
  */
-import type { ResolvedBasecampAccount, BasecampInboundMessage, BasecampInboundMeta } from "../src/types.js";
+import type { BasecampInboundMessage, BasecampInboundMeta, ResolvedBasecampAccount } from "../src/types.js";
 
 /**
  * Build a minimal OpenClaw config object with optional basecamp section.
@@ -43,7 +43,9 @@ export function stubAccount(overrides?: Partial<ResolvedBasecampAccount>): Resol
 /**
  * Build a default BasecampInboundMessage for testing.
  */
-export function stubMsg(overrides?: Partial<BasecampInboundMessage> & { meta?: Partial<BasecampInboundMeta> }): BasecampInboundMessage {
+export function stubMsg(
+  overrides?: Partial<BasecampInboundMessage> & { meta?: Partial<BasecampInboundMeta> },
+): BasecampInboundMessage {
   const meta: BasecampInboundMeta = {
     bucketId: "456",
     recordingId: "123",

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createStructuredLog, createConsoleStructuredLog } from "../src/logging.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SdkLog } from "../src/logging.js";
+import { createConsoleStructuredLog, createStructuredLog } from "../src/logging.js";
 
 describe("createStructuredLog", () => {
   let sdkLog: SdkLog;
@@ -31,25 +31,19 @@ describe("createStructuredLog", () => {
   it("delegates warn to sdkLog.warn", () => {
     const slog = createStructuredLog(sdkLog, { accountId: "7", source: "poller" });
     slog.warn("cursor_save_failed", { error: "ENOENT" });
-    expect(sdkLog.warn).toHaveBeenCalledWith(
-      '[basecamp:poller:7] cursor_save_failed {"error":"ENOENT"}',
-    );
+    expect(sdkLog.warn).toHaveBeenCalledWith('[basecamp:poller:7] cursor_save_failed {"error":"ENOENT"}');
   });
 
   it("delegates error to sdkLog.error", () => {
     const slog = createStructuredLog(sdkLog, { accountId: "8", source: "webhook" });
     slog.error("normalization_error", { error: "bad payload" });
-    expect(sdkLog.error).toHaveBeenCalledWith(
-      '[basecamp:webhook:8] normalization_error {"error":"bad payload"}',
-    );
+    expect(sdkLog.error).toHaveBeenCalledWith('[basecamp:webhook:8] normalization_error {"error":"bad payload"}');
   });
 
   it("delegates debug to sdkLog.debug", () => {
     const slog = createStructuredLog(sdkLog, { accountId: "9", source: "gateway" });
     slog.debug("self_message_skipped", { personId: "42" });
-    expect(sdkLog.debug).toHaveBeenCalledWith(
-      '[basecamp:gateway:9] self_message_skipped {"personId":"42"}',
-    );
+    expect(sdkLog.debug).toHaveBeenCalledWith('[basecamp:gateway:9] self_message_skipped {"personId":"42"}');
   });
 
   it("does not throw when sdkLog is undefined (no-op)", () => {
@@ -92,17 +86,13 @@ describe("createConsoleStructuredLog", () => {
   it("formats and delegates info to console.info", () => {
     const slog = createConsoleStructuredLog({ accountId: "100", source: "webhook" });
     slog.info("received", { kind: "todo_created" });
-    expect(console.info).toHaveBeenCalledWith(
-      '[basecamp:webhook:100] received {"kind":"todo_created"}',
-    );
+    expect(console.info).toHaveBeenCalledWith('[basecamp:webhook:100] received {"kind":"todo_created"}');
   });
 
   it("formats and delegates warn to console.warn", () => {
     const slog = createConsoleStructuredLog({ accountId: "200", source: "webhook" });
     slog.warn("backpressure", { queued: 5 });
-    expect(console.warn).toHaveBeenCalledWith(
-      '[basecamp:webhook:200] backpressure {"queued":5}',
-    );
+    expect(console.warn).toHaveBeenCalledWith('[basecamp:webhook:200] backpressure {"queued":5}');
   });
 
   it("formats and delegates error to console.error", () => {

--- a/tests/lru-cache.test.ts
+++ b/tests/lru-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // Mock transitive dependencies to avoid module resolution issues
 vi.mock("../src/basecamp-client.js", () => ({
@@ -7,7 +7,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (result: any) => result?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
   clearClients: vi.fn(),
 }));

--- a/tests/mentions-adapter.test.ts
+++ b/tests/mentions-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",

--- a/tests/mentions.test.ts
+++ b/tests/mentions.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   extractAttachmentSgids,
   extractMentionSgids,
-  personIdFromSgid,
-  parseMentions,
-  mentionsAgent,
   formatMentionTag,
-  stripAttachmentTags,
   htmlToPlainText,
+  mentionsAgent,
+  parseMentions,
+  personIdFromSgid,
+  stripAttachmentTags,
 } from "../src/mentions/parse.js";
 
 const mentionTag = (sgid: string) =>
@@ -38,15 +38,9 @@ describe("extractAttachmentSgids", () => {
 
   it("handles multiple attachments with different SGIDs", () => {
     const html =
-      mentionTag("sgid://bc3/Person/1") +
-      fileAttachment("sgid://bc3/Recording/99") +
-      mentionTag("sgid://bc3/Person/2");
+      mentionTag("sgid://bc3/Person/1") + fileAttachment("sgid://bc3/Recording/99") + mentionTag("sgid://bc3/Person/2");
     const result = extractAttachmentSgids(html);
-    expect(result).toEqual([
-      "sgid://bc3/Person/1",
-      "sgid://bc3/Recording/99",
-      "sgid://bc3/Person/2",
-    ]);
+    expect(result).toEqual(["sgid://bc3/Person/1", "sgid://bc3/Recording/99", "sgid://bc3/Person/2"]);
   });
 });
 
@@ -79,10 +73,7 @@ describe("extractMentionSgids", () => {
 
   it("extracts multiple distinct mentions", () => {
     const html = mentionTag("sgid://bc3/Person/1") + mentionTag("sgid://bc3/Person/2");
-    expect(extractMentionSgids(html)).toEqual([
-      "sgid://bc3/Person/1",
-      "sgid://bc3/Person/2",
-    ]);
+    expect(extractMentionSgids(html)).toEqual(["sgid://bc3/Person/1", "sgid://bc3/Person/2"]);
   });
 });
 
@@ -107,8 +98,7 @@ describe("personIdFromSgid", () => {
 
 describe("parseMentions", () => {
   it("returns array of {sgid, personId} for each mention", () => {
-    const html =
-      mentionTag("sgid://bc3/Person/10") + mentionTag("sgid://bc3/Person/20");
+    const html = mentionTag("sgid://bc3/Person/10") + mentionTag("sgid://bc3/Person/20");
     expect(parseMentions(html)).toEqual([
       { sgid: "sgid://bc3/Person/10", personId: "10" },
       { sgid: "sgid://bc3/Person/20", personId: "20" },
@@ -122,9 +112,7 @@ describe("parseMentions", () => {
   it("returns null personId for non-Person SGIDs in mentions", () => {
     // Contrived: a mention tag whose sgid is not a Person
     const html = mentionTag("sgid://bc3/Circle/5");
-    expect(parseMentions(html)).toEqual([
-      { sgid: "sgid://bc3/Circle/5", personId: null },
-    ]);
+    expect(parseMentions(html)).toEqual([{ sgid: "sgid://bc3/Circle/5", personId: null }]);
   });
 });
 
@@ -184,10 +172,7 @@ describe("stripAttachmentTags", () => {
   });
 
   it("strips multiple attachment tags", () => {
-    const html =
-      mentionTag("sgid://bc3/Person/1") +
-      " and " +
-      fileAttachment("sgid://bc3/Recording/2");
+    const html = mentionTag("sgid://bc3/Person/1") + " and " + fileAttachment("sgid://bc3/Recording/2");
     expect(stripAttachmentTags(html)).toBe(" and ");
   });
 });
@@ -211,7 +196,7 @@ describe("htmlToPlainText", () => {
 
   it("strips all remaining tags", () => {
     expect(htmlToPlainText("<span>text</span>")).toBe("text");
-    expect(htmlToPlainText("<a href=\"#\">link</a>")).toBe("link");
+    expect(htmlToPlainText('<a href="#">link</a>')).toBe("link");
   });
 
   it("collapses triple+ newlines to double", () => {

--- a/tests/messaging.test.ts
+++ b/tests/messaging.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { basecampMessagingAdapter } from "../src/adapters/messaging.js";
 
 // ---------------------------------------------------------------------------
@@ -79,9 +79,7 @@ describe("messaging.targetResolver.looksLikeId", () => {
 
 describe("messaging.targetResolver.hint", () => {
   it("provides format hint", () => {
-    expect(basecampMessagingAdapter.targetResolver!.hint).toBe(
-      "recording:<id> | bucket:<id> | ping:<id>",
-    );
+    expect(basecampMessagingAdapter.targetResolver!.hint).toBe("recording:<id> | bucket:<id> | ping:<id>");
   });
 });
 

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,19 +1,19 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
+  clearMetrics,
+  getAccountMetrics,
+  recordCircuitBreakerState,
+  recordDedupSize,
+  recordDispatchFailure,
   recordPollAttempt,
-  recordPollSuccess,
   recordPollError,
-  recordWebhookReceived,
+  recordPollSuccess,
+  recordQueueFullDrop,
+  recordWebhookDedupSize,
   recordWebhookDispatched,
   recordWebhookDropped,
   recordWebhookError,
-  recordDedupSize,
-  recordWebhookDedupSize,
-  recordCircuitBreakerState,
-  recordDispatchFailure,
-  recordQueueFullDrop,
-  getAccountMetrics,
-  clearMetrics,
+  recordWebhookReceived,
 } from "../src/metrics.js";
 
 beforeEach(() => {

--- a/tests/normalize.test.ts
+++ b/tests/normalize.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // Mock external deps used by normalize.ts
 vi.mock("../src/metrics.js", () => ({
@@ -9,6 +9,7 @@ vi.mock("../src/outbound/send.js", () => ({
 }));
 
 import {
+  isSelfMessage,
   normalizeActivityEvent,
   normalizeReadingsEvent,
   normalizeWebhookPayload,
@@ -16,14 +17,13 @@ import {
   parseRecordingIdFromIdentifier,
   resolveBasecampPeer,
   resolveParentPeer,
-  isSelfMessage,
 } from "../src/inbound/normalize.js";
 import type {
   BasecampActivityEvent,
+  BasecampPeer,
   BasecampReadingsEntry,
   BasecampWebhookPayload,
   ResolvedBasecampAccount,
-  BasecampPeer,
 } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
@@ -377,7 +377,8 @@ describe("normalizeActivityEvent", () => {
   });
 
   it("extracts mentions from HTML content", async () => {
-    const html = '<bc-attachment sgid="sgid://bc3/Person/42" content-type="application/vnd.basecamp.mention"></bc-attachment> hello';
+    const html =
+      '<bc-attachment sgid="sgid://bc3/Person/42" content-type="application/vnd.basecamp.mention"></bc-attachment> hello';
     const raw = makeActivityEvent({
       recording: { id: 207, type: "Comment", content: html },
     });
@@ -387,7 +388,8 @@ describe("normalizeActivityEvent", () => {
   });
 
   it("sets mentionsAgent true when content has bc-attachment matching agent SGID", async () => {
-    const html = '<bc-attachment sgid="sgid://bc3/Person/999" content-type="application/vnd.basecamp.mention"></bc-attachment> hey';
+    const html =
+      '<bc-attachment sgid="sgid://bc3/Person/999" content-type="application/vnd.basecamp.mention"></bc-attachment> hey';
     const raw = makeActivityEvent({
       recording: { id: 208, type: "Comment", content: html },
     });
@@ -768,7 +770,8 @@ describe("normalizeWebhookPayload", () => {
       recording: {
         id: 302,
         type: "Comment",
-        content: '<bc-attachment sgid="sgid://bc3/Person/999" content-type="application/vnd.basecamp.mention"></bc-attachment> ping',
+        content:
+          '<bc-attachment sgid="sgid://bc3/Person/999" content-type="application/vnd.basecamp.mention"></bc-attachment> ping',
         bucket: { id: 100, name: "Test Project" },
       },
     });
@@ -797,8 +800,8 @@ describe("normalizeWebhookPayload", () => {
 // Step 4: Ping enrichment via Circle API
 // ---------------------------------------------------------------------------
 
-import { resolveCircleInfoCached } from "../src/outbound/send.js";
 import { recordUnknownKind } from "../src/metrics.js";
+import { resolveCircleInfoCached } from "../src/outbound/send.js";
 
 describe("Ping participant enrichment", () => {
   it("activity Ping with Circle lookup returning 2 participants → dm", async () => {

--- a/tests/oauth-credentials.test.ts
+++ b/tests/oauth-credentials.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { join } from "node:path";
 import { homedir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock @37signals/basecamp OAuth exports (these are being built in parallel)
 vi.mock("@37signals/basecamp/oauth", () => {
@@ -32,13 +32,13 @@ vi.mock("openclaw/plugin-sdk", () => ({
   },
 }));
 
+import { FileTokenStore, performInteractiveLogin, refreshToken, TokenManager } from "@37signals/basecamp/oauth";
 import {
-  resolveTokenFilePath,
-  createTokenManager,
   clearTokenManagers,
+  createTokenManager,
   interactiveLogin,
+  resolveTokenFilePath,
 } from "../src/oauth-credentials.js";
-import { TokenManager, FileTokenStore, performInteractiveLogin, refreshToken } from "@37signals/basecamp/oauth";
 import type { ResolvedBasecampAccount } from "../src/types.js";
 
 function makeAccount(overrides?: Partial<ResolvedBasecampAccount>): ResolvedBasecampAccount {
@@ -70,15 +70,7 @@ describe("resolveTokenFilePath", () => {
 
   it("uses default path when stateDir is omitted", () => {
     const result = resolveTokenFilePath("acme");
-    const expected = join(
-      homedir(),
-      ".local",
-      "share",
-      "openclaw",
-      "basecamp",
-      "tokens",
-      "acme.json",
-    );
+    const expected = join(homedir(), ".local", "share", "openclaw", "basecamp", "tokens", "acme.json");
     expect(result).toBe(expected);
   });
 });
@@ -132,15 +124,7 @@ describe("createTokenManager", () => {
       config: { personId: "42" },
     });
     createTokenManager(account);
-    const expectedPath = join(
-      homedir(),
-      ".local",
-      "share",
-      "openclaw",
-      "basecamp",
-      "tokens",
-      "work.json",
-    );
+    const expectedPath = join(homedir(), ".local", "share", "openclaw", "basecamp", "tokens", "work.json");
     expect(FileTokenStore).toHaveBeenCalledWith(expectedPath);
   });
 });

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -207,7 +207,7 @@ function createPrompter(overrides?: { selectAnswers?: string[]; textAnswers?: st
 
 describe("basecampOnboardingAdapter", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   describe("channel", () => {
@@ -439,24 +439,35 @@ describe("basecampOnboardingAdapter", () => {
       expect(account.oauthClientId).toBe("cli-client-id");
       // Should import CLI credentials, not run interactiveLogin
       expect(mockInteractiveLogin).not.toHaveBeenCalled();
-      expect(mockFileTokenStoreSave).toHaveBeenCalled();
+      expect(mockFileTokenStoreSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessToken: "cli-access-token",
+          refreshToken: "cli-refresh-token",
+          tokenType: "Bearer",
+          expiresAt: new Date(1770188269 * 1000),
+        }),
+      );
       expect(mockExportCliCredentials).toHaveBeenCalledWith("http://3.basecamp.localhost:3001");
       // Channel-level OAuth should be preserved (not overwritten by CLI creds)
       expect(result.cfg.channels.basecamp.oauth).toBeUndefined();
     });
 
-    it("prompts for person ID when CLI token extraction fails", async () => {
+    it("prompts for person ID when CLI token extraction and identity discovery both fail", async () => {
       mockCliProfileListFull.mockResolvedValue({
         data: [{ name: "default", base_url: "https://3.basecampapi.com", authenticated: true }],
       });
       mockExtractCliBootstrapToken.mockRejectedValue(new Error("CLI not authenticated"));
       mockExportCliCredentials.mockReturnValue(null);
+      // Fallback triggers OAuth — login succeeds but discovery fails
+      mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
+      mockInteractiveLogin.mockResolvedValue({ accessToken: "fallback-token", tokenType: "Bearer" });
+      mockDiscoverIdentity.mockRejectedValue(new Error("discovery failed"));
 
       // Select: auth method → "cli", then "What would you like to do?" → "done"
-      // Text: personId prompt (no OAuth prompts — credential import failed gracefully)
+      // Text: fallback OAuth clientId, clientSecret (empty), then personId
       const prompter = createPrompter({
         selectAnswers: ["cli", "done"],
-        textAnswers: ["42"],
+        textAnswers: ["fallback-client", "", "42"],
       });
 
       const result = await basecampOnboardingAdapter.configure({
@@ -470,6 +481,94 @@ describe("basecampOnboardingAdapter", () => {
 
       const account = result.cfg.channels.basecamp.accounts.default;
       expect(account.personId).toBe("42");
+      expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
+      expect(mockInteractiveLogin).toHaveBeenCalled();
+    });
+
+    it("falls back to OAuth when CLI credential import fails", async () => {
+      mockCliProfileListFull.mockResolvedValue({
+        data: [{ name: "dev", base_url: "http://3.basecamp.localhost:3001", authenticated: true }],
+      });
+      mockExtractCliBootstrapToken.mockResolvedValue("cli-bootstrap-token");
+      mockExportCliCredentials.mockReturnValue(null);
+      mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
+      mockInteractiveLogin.mockResolvedValue({ accessToken: "oauth-token", tokenType: "Bearer" });
+      mockDiscoverIdentity.mockResolvedValue({
+        identity: { id: 42, firstName: "Bot", lastName: "", emailAddress: "b@t.com" },
+        accounts: [{ id: 100, name: "Co", product: "bc3" }],
+      });
+
+      // Select: auth method → "cli", then "done"
+      // Text: fallback OAuth clientId, clientSecret (empty)
+      const prompter = createPrompter({
+        selectAnswers: ["cli", "done"],
+        textAnswers: ["fallback-client", ""],
+      });
+
+      const result = await basecampOnboardingAdapter.configure({
+        cfg: {} as any,
+        runtime: {} as any,
+        prompter,
+        accountOverrides: {},
+        shouldPromptAccountIds: false,
+        forceAllowFrom: false,
+      });
+
+      const account = result.cfg.channels.basecamp.accounts.default;
+      expect(mockInteractiveLogin).toHaveBeenCalled();
+      expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
+      expect(account.personId).toBe("42");
+      expect(mockExportCliCredentials).toHaveBeenCalled();
+    });
+
+    it("resolves active/default profile when user picks 'Use default (no profile)'", async () => {
+      mockCliProfileListFull.mockResolvedValue({
+        data: [
+          { name: "prod", base_url: "https://3.basecampapi.com", authenticated: true, active: true, default: false },
+          {
+            name: "dev",
+            base_url: "http://3.basecamp.localhost:3001",
+            authenticated: true,
+            active: false,
+            default: false,
+          },
+        ],
+      });
+      mockExtractCliBootstrapToken.mockResolvedValue("cli-token");
+      mockDiscoverIdentity.mockResolvedValue({
+        identity: { id: 7, firstName: "Bot", lastName: "", emailAddress: "b@t.com" },
+        accounts: [{ id: 200, name: "Acme", product: "bc3" }],
+      });
+      mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
+      mockExportCliCredentials.mockReturnValue({
+        accessToken: "cli-token",
+        refreshToken: "cli-refresh",
+        expiresAt: 1770188269,
+        clientId: "cli-client-id",
+        clientSecret: "",
+      });
+
+      // Select: auth method → "cli", profile → "__none__", then "done"
+      const prompter = createPrompter({
+        selectAnswers: ["cli", "__none__", "done"],
+      });
+
+      const result = await basecampOnboardingAdapter.configure({
+        cfg: {} as any,
+        runtime: {} as any,
+        prompter,
+        accountOverrides: {},
+        shouldPromptAccountIds: false,
+        forceAllowFrom: false,
+      });
+
+      const account = result.cfg.channels.basecamp.accounts.default;
+      // Should use active profile's base_url for credential export
+      expect(mockExportCliCredentials).toHaveBeenCalledWith("https://3.basecampapi.com");
+      // No explicit profile stored when user picks "Use default"
+      expect(account.cliProfile).toBeUndefined();
+      // Credentials were still imported
+      expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
     });
   });
 

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mock openclaw/plugin-sdk
@@ -10,12 +10,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
     const trimmed = (value ?? "").trim();
     return trimmed || "default";
   },
-  applyAccountNameToChannelSection: (params: {
-    cfg: any;
-    channelKey: string;
-    accountId: string;
-    name?: string;
-  }) => {
+  applyAccountNameToChannelSection: (params: { cfg: any; channelKey: string; accountId: string; name?: string }) => {
     if (!params.name?.trim()) return params.cfg;
     const section = params.cfg.channels?.[params.channelKey] ?? {};
     const accounts = section.accounts ?? {};
@@ -37,8 +32,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
     };
   },
   buildChannelConfigSchema: (schema: any) => schema,
-  PAIRING_APPROVED_MESSAGE:
-    "You have been approved to message this agent.",
+  PAIRING_APPROVED_MESSAGE: "You have been approved to message this agent.",
   createDefaultChannelRuntimeState: (accountId: string) => ({
     accountId,
     running: false,
@@ -169,9 +163,9 @@ vi.mock("../src/config.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { basecampOnboardingAdapter } from "../src/adapters/onboarding.js";
+import { basecampPairingAdapter } from "../src/adapters/pairing.js";
 import { basecampSetupAdapter } from "../src/adapters/setup.js";
 import { basecampStatusAdapter } from "../src/adapters/status.js";
-import { basecampPairingAdapter } from "../src/adapters/pairing.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -187,11 +181,7 @@ function cfgWithAccounts(accounts: Record<string, Record<string, unknown>>) {
 }
 
 /** Creates a minimal WizardPrompter mock. */
-function createPrompter(overrides?: {
-  selectAnswers?: string[];
-  textAnswers?: string[];
-  confirmAnswer?: boolean;
-}) {
+function createPrompter(overrides?: { selectAnswers?: string[]; textAnswers?: string[]; confirmAnswer?: boolean }) {
   let selectIdx = 0;
   let textIdx = 0;
   const selectAnswers = overrides?.selectAnswers ?? [];
@@ -351,10 +341,7 @@ describe("basecampOnboardingAdapter", () => {
       expect(account.personId).toBe("42");
       expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
       // Should NOT have prompted for clientId — no text calls for it
-      expect(prompter.note).not.toHaveBeenCalledWith(
-        expect.stringContaining("OAuth app"),
-        expect.any(String),
-      );
+      expect(prompter.note).not.toHaveBeenCalledWith(expect.stringContaining("OAuth app"), expect.any(String));
     });
 
     it("preserves per-account oauthClientId when not prompting for new credentials", async () => {
@@ -688,15 +675,11 @@ describe("basecampOnboardingAdapter", () => {
 describe("basecampSetupAdapter", () => {
   describe("resolveAccountId", () => {
     it("normalizes account ID", () => {
-      expect(basecampSetupAdapter.resolveAccountId!({ cfg: {} as any, accountId: "  foo  " })).toBe(
-        "foo",
-      );
+      expect(basecampSetupAdapter.resolveAccountId!({ cfg: {} as any, accountId: "  foo  " })).toBe("foo");
     });
 
     it("returns 'default' for empty input", () => {
-      expect(basecampSetupAdapter.resolveAccountId!({ cfg: {} as any, accountId: "" })).toBe(
-        "default",
-      );
+      expect(basecampSetupAdapter.resolveAccountId!({ cfg: {} as any, accountId: "" })).toBe("default");
     });
   });
 
@@ -1003,9 +986,7 @@ describe("basecampPairingAdapter", () => {
       const testCfg = cfgWithAccounts({
         default: { personId: "1", token: "tok" },
       });
-      await expect(
-        basecampPairingAdapter.notifyApproval!({ cfg: testCfg, id: "42" }),
-      ).resolves.toBeUndefined();
+      await expect(basecampPairingAdapter.notifyApproval!({ cfg: testCfg, id: "42" })).resolves.toBeUndefined();
     });
   });
 });

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -60,11 +60,15 @@ vi.mock("openclaw/plugin-sdk", () => ({
 // ---------------------------------------------------------------------------
 
 const mockCliProfileList = vi.fn();
+const mockCliProfileListFull = vi.fn();
 const mockExtractCliBootstrapToken = vi.fn();
+const mockExportCliCredentials = vi.fn();
 
 vi.mock("../src/basecamp-cli.js", () => ({
   cliProfileList: (...args: any[]) => mockCliProfileList(...args),
+  cliProfileListFull: (...args: any[]) => mockCliProfileListFull(...args),
   extractCliBootstrapToken: (...args: any[]) => mockExtractCliBootstrapToken(...args),
+  exportCliCredentials: (...args: any[]) => mockExportCliCredentials(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -98,9 +102,14 @@ vi.mock("../src/basecamp-client.js", () => ({
 // ---------------------------------------------------------------------------
 
 const mockDiscoverIdentity = vi.fn();
+const mockFileTokenStoreSave = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@37signals/basecamp/oauth", () => ({
   discoverIdentity: (...args: any[]) => mockDiscoverIdentity(...args),
+  FileTokenStore: class {
+    constructor(public path: string) {}
+    save = mockFileTokenStoreSave;
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -263,7 +272,7 @@ describe("basecampOnboardingAdapter", () => {
   describe("configure — OAuth path", () => {
     it("configures a new account via OAuth when no CLI profiles available", async () => {
       // No CLI → auto-selects OAuth
-      mockCliProfileList.mockRejectedValue(new Error("not installed"));
+      mockCliProfileListFull.mockRejectedValue(new Error("not installed"));
       mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
       mockInteractiveLogin.mockResolvedValue({
         accessToken: "new-access-token",
@@ -308,7 +317,7 @@ describe("basecampOnboardingAdapter", () => {
     });
 
     it("uses existing channel-level OAuth clientId without prompting", async () => {
-      mockCliProfileList.mockRejectedValue(new Error("not installed"));
+      mockCliProfileListFull.mockRejectedValue(new Error("not installed"));
       mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
       mockInteractiveLogin.mockResolvedValue({
         accessToken: "tok",
@@ -349,7 +358,7 @@ describe("basecampOnboardingAdapter", () => {
     });
 
     it("preserves per-account oauthClientId when not prompting for new credentials", async () => {
-      mockCliProfileList.mockRejectedValue(new Error("not installed"));
+      mockCliProfileListFull.mockRejectedValue(new Error("not installed"));
       mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/work.json");
       mockInteractiveLogin.mockResolvedValue({
         accessToken: "tok",
@@ -394,29 +403,35 @@ describe("basecampOnboardingAdapter", () => {
     });
   });
 
-  describe("configure — CLI path (chains into OAuth)", () => {
-    it("discovers identity via CLI then chains into OAuth", async () => {
-      mockCliProfileList.mockResolvedValue({ data: ["prod", "dev"] });
+  describe("configure — CLI path (imports credentials)", () => {
+    it("discovers identity via CLI and imports credentials", async () => {
+      mockCliProfileListFull.mockResolvedValue({
+        data: [
+          { name: "prod", base_url: "https://3.basecampapi.com", authenticated: true },
+          { name: "dev", base_url: "http://3.basecamp.localhost:3001", authenticated: true },
+        ],
+      });
       mockExtractCliBootstrapToken.mockResolvedValue("cli-access-token");
       mockDiscoverIdentity.mockResolvedValue({
         identity: { id: 5, firstName: "Service", lastName: "", emailAddress: "svc@test.com" },
         accounts: [{ id: 100, name: "Acme", product: "bc3" }],
       });
       mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
-      mockInteractiveLogin.mockResolvedValue({
-        accessToken: "oauth-access-token",
-        refreshToken: "oauth-refresh",
-        tokenType: "Bearer",
+      mockExportCliCredentials.mockReturnValue({
+        accessToken: "cli-access-token",
+        refreshToken: "cli-refresh-token",
+        expiresAt: 1770188269,
+        clientId: "cli-client-id",
+        clientSecret: "",
       });
 
       // Select answers in order:
       // 1. Auth method: "cli"
       // 2. Profile: "dev"
       // 3. "What would you like to do?" → "done"
-      // Text answers: clientId, clientSecret (blank)
       const prompter = createPrompter({
         selectAnswers: ["cli", "dev", "done"],
-        textAnswers: ["test-client-id", ""],
+        textAnswers: [],
       });
 
       const result = await basecampOnboardingAdapter.configure({
@@ -432,31 +447,25 @@ describe("basecampOnboardingAdapter", () => {
       expect(account.cliProfile).toBe("dev");
       expect(account.personId).toBe("5");
       expect(account.basecampAccountId).toBe("100");
-      // CLI path chains into OAuth — oauthTokenFile should be set
       expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
-      // interactiveLogin should have been called for OAuth chain-through
-      expect(mockInteractiveLogin).toHaveBeenCalled();
+      // Should import CLI credentials, not run interactiveLogin
+      expect(mockInteractiveLogin).not.toHaveBeenCalled();
+      expect(mockFileTokenStoreSave).toHaveBeenCalled();
+      expect(mockExportCliCredentials).toHaveBeenCalledWith("http://3.basecamp.localhost:3001");
     });
 
     it("prompts for person ID when CLI token extraction fails", async () => {
-      mockCliProfileList.mockResolvedValue({ data: ["default"] });
+      mockCliProfileListFull.mockResolvedValue({
+        data: [{ name: "default", base_url: "https://3.basecampapi.com", authenticated: true }],
+      });
       mockExtractCliBootstrapToken.mockRejectedValue(new Error("CLI not authenticated"));
-      mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
-      mockInteractiveLogin.mockResolvedValue({
-        accessToken: "oauth-tok",
-        refreshToken: "ref",
-        tokenType: "Bearer",
-      });
-      mockDiscoverIdentity.mockResolvedValue({
-        identity: { id: 42, firstName: "Manual", lastName: "User", emailAddress: "m@test.com" },
-        accounts: [],
-      });
+      mockExportCliCredentials.mockReturnValue(null);
 
       // Select: auth method → "cli", then "What would you like to do?" → "done"
-      // Text: personId prompt, then clientId, clientSecret
+      // Text: personId prompt (no OAuth prompts — credential import failed gracefully)
       const prompter = createPrompter({
         selectAnswers: ["cli", "done"],
-        textAnswers: ["42", "client-id", ""],
+        textAnswers: ["42"],
       });
 
       const result = await basecampOnboardingAdapter.configure({
@@ -475,7 +484,7 @@ describe("basecampOnboardingAdapter", () => {
 
   describe("configure — auth-method cleanup", () => {
     it("preserves existing cliProfile as diagnostic metadata when switching to OAuth", async () => {
-      mockCliProfileList.mockRejectedValue(new Error("not installed"));
+      mockCliProfileListFull.mockRejectedValue(new Error("not installed"));
       mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
       mockInteractiveLogin.mockResolvedValue({
         accessToken: "tok",
@@ -512,21 +521,25 @@ describe("basecampOnboardingAdapter", () => {
       expect(account.cliProfile).toBe("old-profile");
     });
 
-    it("CLI path preserves cliProfile alongside OAuth token file", async () => {
-      mockCliProfileList.mockResolvedValue({ data: ["dev"] });
+    it("CLI path preserves cliProfile alongside imported credentials", async () => {
+      mockCliProfileListFull.mockResolvedValue({
+        data: [{ name: "dev", base_url: "http://3.basecamp.localhost:3001", authenticated: true }],
+      });
       mockExtractCliBootstrapToken.mockResolvedValue("cli-token");
       mockDiscoverIdentity.mockResolvedValue({
         identity: { id: 10, firstName: "Bot", lastName: "", emailAddress: "b@t.com" },
         accounts: [{ id: 1, name: "Co", product: "bc3" }],
       });
       mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
-      mockInteractiveLogin.mockResolvedValue({
-        accessToken: "oauth-tok",
-        refreshToken: "ref",
-        tokenType: "Bearer",
+      mockExportCliCredentials.mockReturnValue({
+        accessToken: "cli-token",
+        refreshToken: "cli-refresh",
+        expiresAt: 1770188269,
+        clientId: "cli-client-id",
+        clientSecret: "",
       });
 
-      // Start with OAuth-configured account — CLI path still chains into OAuth
+      // Start with OAuth-configured account
       const existingCfg = cfg({
         oauth: { clientId: "existing-client", clientSecret: "existing-secret" },
       });
@@ -547,14 +560,14 @@ describe("basecampOnboardingAdapter", () => {
 
       const account = result.cfg.channels.basecamp.accounts.default;
       expect(account.cliProfile).toBe("dev");
-      // CLI path chains into OAuth — oauthTokenFile should be set
       expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
+      expect(mockInteractiveLogin).not.toHaveBeenCalled();
     });
   });
 
   describe("configure — general", () => {
     it("respects accountOverrides for basecamp", async () => {
-      mockCliProfileList.mockRejectedValue(new Error("not installed"));
+      mockCliProfileListFull.mockRejectedValue(new Error("not installed"));
       mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/my-custom-id.json");
       mockInteractiveLogin.mockResolvedValue({
         accessToken: "tok",
@@ -585,7 +598,7 @@ describe("basecampOnboardingAdapter", () => {
     });
 
     it("prompts for OpenClaw account ID when shouldPromptAccountIds is true", async () => {
-      mockCliProfileList.mockRejectedValue(new Error("not installed"));
+      mockCliProfileListFull.mockRejectedValue(new Error("not installed"));
       mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/staging.json");
       mockInteractiveLogin.mockResolvedValue({
         accessToken: "tok",

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -448,10 +448,14 @@ describe("basecampOnboardingAdapter", () => {
       expect(account.personId).toBe("5");
       expect(account.basecampAccountId).toBe("100");
       expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
+      // CLI-imported client creds go per-account, not channel-level
+      expect(account.oauthClientId).toBe("cli-client-id");
       // Should import CLI credentials, not run interactiveLogin
       expect(mockInteractiveLogin).not.toHaveBeenCalled();
       expect(mockFileTokenStoreSave).toHaveBeenCalled();
       expect(mockExportCliCredentials).toHaveBeenCalledWith("http://3.basecamp.localhost:3001");
+      // Channel-level OAuth should be preserved (not overwritten by CLI creds)
+      expect(result.cfg.channels.basecamp.oauth).toBeUndefined();
     });
 
     it("prompts for person ID when CLI token extraction fails", async () => {
@@ -561,6 +565,13 @@ describe("basecampOnboardingAdapter", () => {
       const account = result.cfg.channels.basecamp.accounts.default;
       expect(account.cliProfile).toBe("dev");
       expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
+      // CLI-imported creds are per-account, not channel-level
+      expect(account.oauthClientId).toBe("cli-client-id");
+      // Existing channel-level OAuth must be preserved
+      expect(result.cfg.channels.basecamp.oauth).toEqual({
+        clientId: "existing-client",
+        clientSecret: "existing-secret",
+      });
       expect(mockInteractiveLogin).not.toHaveBeenCalled();
     });
   });

--- a/tests/outbound-retry.test.ts
+++ b/tests/outbound-retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClient = {
   projects: { list: vi.fn() },
@@ -21,7 +21,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (result: any) => result?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
   clearClients: vi.fn(),
 }));
@@ -158,9 +161,7 @@ describe("postComment", () => {
   });
 
   it("retries on retryable TypeError and succeeds", async () => {
-    mockClient.comments.create
-      .mockRejectedValueOnce(new TypeError("fetch failed"))
-      .mockResolvedValueOnce({ id: 77 });
+    mockClient.comments.create.mockRejectedValueOnce(new TypeError("fetch failed")).mockResolvedValueOnce({ id: 77 });
 
     const result = await postComment({
       bucketId: "1",

--- a/tests/outbound.test.ts
+++ b/tests/outbound.test.ts
@@ -1,9 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
-import {
-  resolveOutboundTarget,
-  chunkMarkdownText,
-} from "../src/adapters/outbound.js";
-import { sendBasecampText, sendBasecampMedia } from "../src/outbound/send.js";
+import { describe, expect, it, vi } from "vitest";
+import { chunkMarkdownText, resolveOutboundTarget } from "../src/adapters/outbound.js";
+import { sendBasecampMedia, sendBasecampText } from "../src/outbound/send.js";
 
 // --- Mocks required to import channel.ts without pulling in heavy deps ---
 vi.mock("openclaw/plugin-sdk", () => ({
@@ -22,7 +19,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (result: any) => result?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
   clearClients: vi.fn(),
 }));
@@ -174,9 +174,7 @@ describe("outbound.chunkMarkdownText", () => {
 
 describe("outbound.sendBasecampText", () => {
   it("throws with diagnostic message for any target", async () => {
-    await expect(
-      sendBasecampText({ to: "recording:123", text: "hello" }),
-    ).rejects.toThrow("dispatch bridge");
+    await expect(sendBasecampText({ to: "recording:123", text: "hello" })).rejects.toThrow("dispatch bridge");
   });
 });
 

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -3,7 +3,7 @@
  *
  * Validates allowlist entry normalization and approval notification.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -97,9 +97,7 @@ describe("basecampPairingAdapter", () => {
       mockClient.raw.POST.mockRejectedValue(new Error("network error"));
 
       // Should not throw
-      await expect(
-        basecampPairingAdapter.notifyApproval!({ cfg: {} as any, id: "42" }),
-      ).resolves.toBeUndefined();
+      await expect(basecampPairingAdapter.notifyApproval!({ cfg: {} as any, id: "42" })).resolves.toBeUndefined();
     });
   });
 });

--- a/tests/peer.test.ts
+++ b/tests/peer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/metrics.js", () => ({
   recordUnknownKind: vi.fn(),

--- a/tests/poller-circuit-breaker.test.ts
+++ b/tests/poller-circuit-breaker.test.ts
@@ -5,11 +5,12 @@
  * instance, failures update its internal state, and syncCircuitBreakerMetrics
  * propagates that state to the metrics registry (read by the status adapter).
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
 import { mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { getAccountMetrics, clearMetrics } from "../src/metrics.js";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearMetrics, getAccountMetrics } from "../src/metrics.js";
 
 // ---------------------------------------------------------------------------
 // Module mocks -- intercept poll functions and config at the module boundary
@@ -91,7 +92,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (result: any) => result?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
   clearClients: vi.fn(),
 }));

--- a/tests/poller-dispatch.test.ts
+++ b/tests/poller-dispatch.test.ts
@@ -9,11 +9,12 @@
  * - Self-message filtering
  * - Webhook-active → 5x activity interval (via log assertion)
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm } from "node:fs/promises";
+
 import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -63,7 +64,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   numId: (_label: string, value: string | number) => Number(value),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
   clearClients: vi.fn(),
 }));
@@ -102,8 +106,8 @@ vi.mock("../src/inbound/normalize.js", () => ({
 }));
 
 import { CursorStore } from "../src/inbound/cursors.js";
-import { startCompositePoller } from "../src/inbound/poller.js";
 import { closeAccountDedup } from "../src/inbound/dedup-registry.js";
+import { startCompositePoller } from "../src/inbound/poller.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -190,7 +194,10 @@ describe("poller dispatch flow", () => {
       account: baseAccount,
       cfg: {},
       abortSignal: ac.signal,
-      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      onEvent: async (msg) => {
+        dispatched.push(msg);
+        return true;
+      },
       log,
       stateDir: tmpDir,
     });
@@ -215,7 +222,10 @@ describe("poller dispatch flow", () => {
       account: baseAccount,
       cfg: {},
       abortSignal: ac.signal,
-      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      onEvent: async (msg) => {
+        dispatched.push(msg);
+        return true;
+      },
       log,
       stateDir: tmpDir,
     });
@@ -240,7 +250,10 @@ describe("poller dispatch flow", () => {
       account: baseAccount,
       cfg: {},
       abortSignal: ac.signal,
-      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      onEvent: async (msg) => {
+        dispatched.push(msg);
+        return true;
+      },
       log,
       stateDir: tmpDir,
     });
@@ -265,7 +278,10 @@ describe("poller dispatch flow", () => {
       account: baseAccount,
       cfg: {},
       abortSignal: ac.signal,
-      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      onEvent: async (msg) => {
+        dispatched.push(msg);
+        return true;
+      },
       log,
       stateDir: tmpDir,
     });
@@ -288,7 +304,10 @@ describe("poller dispatch flow", () => {
       account: baseAccount,
       cfg: {},
       abortSignal: ac.signal,
-      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      onEvent: async (msg) => {
+        dispatched.push(msg);
+        return true;
+      },
       log,
       stateDir: tmpDir,
     });
@@ -318,7 +337,10 @@ describe("poller dispatch flow", () => {
       account: baseAccount,
       cfg: {},
       abortSignal: ac.signal,
-      onEvent: async (msg) => { dispatched.push(msg); return true; },
+      onEvent: async (msg) => {
+        dispatched.push(msg);
+        return true;
+      },
       log,
       stateDir: tmpDir,
     });

--- a/tests/poller-hardening.test.ts
+++ b/tests/poller-hardening.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, rm, stat } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CursorStore } from "../src/inbound/cursors.js";
 
 // ---------------------------------------------------------------------------
@@ -29,9 +29,7 @@ describe("CursorStore monotonicity", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     store.setActivitySince("2025-01-01T00:00:00Z");
     expect(store.get().activitySince).toBe("2025-06-01T00:00:00Z");
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("clock skew detected: new activitySince"),
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("clock skew detected: new activitySince"));
     warnSpy.mockRestore();
   });
 
@@ -45,9 +43,7 @@ describe("CursorStore monotonicity", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     store.setReadingsSince("2025-01-01T00:00:00Z");
     expect(store.get().readingsSince).toBe("2025-06-01T00:00:00Z");
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("clock skew detected: new readingsSince"),
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("clock skew detected: new readingsSince"));
     warnSpy.mockRestore();
   });
 

--- a/tests/poller-shutdown-timeout.test.ts
+++ b/tests/poller-shutdown-timeout.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/config.js", () => ({
   resolvePollingIntervals: () => ({
@@ -32,7 +32,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (result: any) => result?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
   clearClients: vi.fn(),
 }));

--- a/tests/project-scoping.test.ts
+++ b/tests/project-scoping.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -8,11 +8,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
   },
 }));
 
-import {
-  listBasecampAccountIds,
-  resolveBasecampAccount,
-  resolveProjectScope,
-} from "../src/config.js";
+import { listBasecampAccountIds, resolveBasecampAccount, resolveProjectScope } from "../src/config.js";
 
 function cfg(basecamp?: Record<string, unknown>) {
   if (!basecamp) return {} as any;
@@ -43,10 +39,7 @@ describe("resolveProjectScope", () => {
   });
 
   it("returns undefined when virtualAccounts is empty", () => {
-    const result = resolveProjectScope(
-      cfg({ virtualAccounts: {} }),
-      "anything",
-    );
+    const result = resolveProjectScope(cfg({ virtualAccounts: {} }), "anything");
     expect(result).toBeUndefined();
   });
 });
@@ -154,8 +147,8 @@ describe("dispatch project-scope routing", () => {
     const config = cfg({
       accounts: { primary: { personId: "1" } },
       virtualAccounts: {
-        "design": { accountId: "primary", bucketId: "456" },
-        "eng": { accountId: "primary", bucketId: "789" },
+        design: { accountId: "primary", bucketId: "456" },
+        eng: { accountId: "primary", bucketId: "789" },
       },
     });
 

--- a/tests/readings.test.ts
+++ b/tests/readings.test.ts
@@ -1,8 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type {
-  BasecampReadingsEntry,
-  ResolvedBasecampAccount,
-} from "../src/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BasecampReadingsEntry, ResolvedBasecampAccount } from "../src/types.js";
 
 const mockClient = {
   raw: {
@@ -19,7 +16,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   }),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
@@ -30,8 +30,8 @@ vi.mock("../src/outbound/send.js", () => ({
   resolveCircleInfoCached: vi.fn(() => undefined),
 }));
 
-import { recordUnknownKind } from "../src/metrics.js";
 import { pollReadings } from "../src/inbound/readings.js";
+import { recordUnknownKind } from "../src/metrics.js";
 
 const mockAccount: ResolvedBasecampAccount = {
   accountId: "test-acct",

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -5,10 +5,11 @@
  * and promotion hysteresis logic (promote after 2 gap cycles, demote
  * after 3 clean cycles, TTL expiry, MAX_PROMOTIONS cap).
  */
-import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vitest";
+
 import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // State dir mock — EventDedup needs it for SQLite backend
 const testStateDir = mkdtempSync(join(tmpdir(), "rc-state-"));
@@ -16,13 +17,13 @@ vi.mock("../src/inbound/state-dir.js", () => ({
   resolvePluginStateDir: () => testStateDir,
 }));
 
+import { EventDedup } from "../src/inbound/dedup.js";
+import type { PromotionEntry, PromotionState } from "../src/inbound/reconciliation.js";
 import {
+  deserializePromotionState,
   runReconciliation,
   serializePromotionState,
-  deserializePromotionState,
 } from "../src/inbound/reconciliation.js";
-import type { PromotionState, PromotionEntry } from "../src/inbound/reconciliation.js";
-import { EventDedup } from "../src/inbound/dedup.js";
 import type { ResolvedBasecampAccount } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
@@ -41,20 +42,13 @@ const account: ResolvedBasecampAccount = {
 function makeClient(events: any[] | Error = []) {
   return {
     reports: {
-      progress: events instanceof Error
-        ? vi.fn().mockRejectedValue(events)
-        : vi.fn().mockResolvedValue(events),
+      progress: events instanceof Error ? vi.fn().mockRejectedValue(events) : vi.fn().mockResolvedValue(events),
     },
   };
 }
 
 /** Build a Basecamp activity event with required fields. */
-function activityEvent(opts: {
-  id: number;
-  kind: string;
-  created_at?: string;
-  recordingId?: number;
-}) {
+function activityEvent(opts: { id: number; kind: string; created_at?: string; recordingId?: number }) {
   return {
     id: opts.id,
     kind: opts.kind,
@@ -147,9 +141,7 @@ describe("reconciliation", () => {
 
   it("events before 24h window skipped", async () => {
     const old = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
-    const client = makeClient([
-      activityEvent({ id: 1, kind: "todo_created", created_at: old }),
-    ]);
+    const client = makeClient([activityEvent({ id: 1, kind: "todo_created", created_at: old })]);
     const result = await runReconciliation({
       account,
       client,
@@ -161,9 +153,7 @@ describe("reconciliation", () => {
   });
 
   it("non-normalizable kinds skipped", async () => {
-    const client = makeClient([
-      activityEvent({ id: 1, kind: "unknown_weird_kind" }),
-    ]);
+    const client = makeClient([activityEvent({ id: 1, kind: "unknown_weird_kind" })]);
     const result = await runReconciliation({
       account,
       client,
@@ -206,12 +196,14 @@ describe("reconciliation", () => {
   // ---- Serialization ----
 
   it("serialization round-trip", () => {
-    const promotions: PromotionEntry[] = [{
-      type: "Todo",
-      promotedAt: Date.now(),
-      consecutiveGapCycles: 2,
-      consecutiveCleanCycles: 0,
-    }];
+    const promotions: PromotionEntry[] = [
+      {
+        type: "Todo",
+        promotedAt: Date.now(),
+        consecutiveGapCycles: 2,
+        consecutiveCleanCycles: 0,
+      },
+    ];
     const gaps = { Todo: 5 };
     const raw = serializePromotionState(promotions, gaps);
     const restored = deserializePromotionState(raw);
@@ -228,9 +220,7 @@ describe("reconciliation", () => {
 
   it("gaps below threshold → no promotion", async () => {
     // 1 gap < threshold of 3
-    const client = makeClient([
-      activityEvent({ id: 1, kind: "todo_created" }),
-    ]);
+    const client = makeClient([activityEvent({ id: 1, kind: "todo_created" })]);
     const result = await runReconciliation({
       account,
       client,
@@ -395,7 +385,7 @@ describe("reconciliation", () => {
       client,
       dedup,
       gapThreshold: 1,
-      promotionState: { promotions: existing, previousGaps: { "Kanban::Card": 5, "Todo": 5, "Question::Answer": 5 } },
+      promotionState: { promotions: existing, previousGaps: { "Kanban::Card": 5, Todo: 5, "Question::Answer": 5 } },
       log,
     });
     // All 3 retained, none added beyond 3

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -19,7 +19,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (r: any) => r?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
@@ -72,9 +75,7 @@ describe("resolver.resolveTargets (users)", () => {
       runtime: {} as any,
     });
 
-    expect(results).toEqual([
-      { input: "10", resolved: true, id: "10", name: "Alice Smith" },
-    ]);
+    expect(results).toEqual([{ input: "10", resolved: true, id: "10", name: "Alice Smith" }]);
   });
 
   it("resolves by exact name (case-insensitive)", async () => {
@@ -87,9 +88,7 @@ describe("resolver.resolveTargets (users)", () => {
       runtime: {} as any,
     });
 
-    expect(results).toEqual([
-      { input: "bob jones", resolved: true, id: "20", name: "Bob Jones" },
-    ]);
+    expect(results).toEqual([{ input: "bob jones", resolved: true, id: "20", name: "Bob Jones" }]);
   });
 
   it("resolves by partial name", async () => {
@@ -102,9 +101,7 @@ describe("resolver.resolveTargets (users)", () => {
       runtime: {} as any,
     });
 
-    expect(results).toEqual([
-      { input: "carol", resolved: true, id: "30", name: "Carol Davis" },
-    ]);
+    expect(results).toEqual([{ input: "carol", resolved: true, id: "30", name: "Carol Davis" }]);
   });
 
   it("resolves by email prefix", async () => {
@@ -117,9 +114,7 @@ describe("resolver.resolveTargets (users)", () => {
       runtime: {} as any,
     });
 
-    expect(results).toEqual([
-      { input: "alice@", resolved: true, id: "10", name: "Alice Smith" },
-    ]);
+    expect(results).toEqual([{ input: "alice@", resolved: true, id: "10", name: "Alice Smith" }]);
   });
 
   it("returns unresolved for no match", async () => {
@@ -145,9 +140,7 @@ describe("resolver.resolveTargets (users)", () => {
       runtime: {} as any,
     });
 
-    expect(results).toEqual([
-      { input: "alice", resolved: false, note: "Failed to fetch people list" },
-    ]);
+    expect(results).toEqual([{ input: "alice", resolved: false, note: "Failed to fetch people list" }]);
   });
 
   it("resolves multiple inputs in one call", async () => {
@@ -184,9 +177,7 @@ describe("resolver.resolveTargets (groups)", () => {
       runtime: {} as any,
     });
 
-    expect(results).toEqual([
-      { input: "100", resolved: true, id: "bucket:100", name: "Design Project" },
-    ]);
+    expect(results).toEqual([{ input: "100", resolved: true, id: "bucket:100", name: "Design Project" }]);
   });
 
   it("resolves by bucket:<id> prefix", async () => {
@@ -199,9 +190,7 @@ describe("resolver.resolveTargets (groups)", () => {
       runtime: {} as any,
     });
 
-    expect(results).toEqual([
-      { input: "bucket:200", resolved: true, id: "bucket:200", name: "Engineering" },
-    ]);
+    expect(results).toEqual([{ input: "bucket:200", resolved: true, id: "bucket:200", name: "Engineering" }]);
   });
 
   it("resolves by project name", async () => {
@@ -214,9 +203,7 @@ describe("resolver.resolveTargets (groups)", () => {
       runtime: {} as any,
     });
 
-    expect(results).toEqual([
-      { input: "marketing", resolved: true, id: "bucket:300", name: "Marketing Campaign" },
-    ]);
+    expect(results).toEqual([{ input: "marketing", resolved: true, id: "bucket:300", name: "Marketing Campaign" }]);
   });
 
   it("returns unresolved for no match", async () => {

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isRetryableError, withRetry } from "../src/retry.js";
 
 // ---------------------------------------------------------------------------
@@ -55,10 +55,7 @@ describe("withRetry", () => {
   const fast = { baseDelayMs: 1, maxDelayMs: 4, jitter: false };
 
   it("retries on retryable TypeError and succeeds on 2nd attempt", async () => {
-    const fn = vi
-      .fn()
-      .mockRejectedValueOnce(new TypeError("fetch failed"))
-      .mockResolvedValueOnce({ data: "ok" });
+    const fn = vi.fn().mockRejectedValueOnce(new TypeError("fetch failed")).mockResolvedValueOnce({ data: "ok" });
 
     const result = await withRetry(fn, { ...fast, maxAttempts: 3 });
 
@@ -103,9 +100,7 @@ describe("withRetry", () => {
         return origSetTimeout(cb, 0, ...args);
       });
 
-    await expect(
-      withRetry(fn, { maxAttempts: 4, baseDelayMs: 100, jitter: false }),
-    ).rejects.toThrow();
+    await expect(withRetry(fn, { maxAttempts: 4, baseDelayMs: 100, jitter: false })).rejects.toThrow();
 
     expect(delays).toEqual([100, 200, 400]);
     timeoutSpy.mockRestore();
@@ -126,9 +121,7 @@ describe("withRetry", () => {
         return origSetTimeout(cb, 0, ...args);
       });
 
-    await expect(
-      withRetry(fn, { maxAttempts: 2, baseDelayMs: 1000, jitter: true }),
-    ).rejects.toThrow();
+    await expect(withRetry(fn, { maxAttempts: 2, baseDelayMs: 1000, jitter: true })).rejects.toThrow();
 
     // With random()=1, jitter = 1000 * 1 * 0.25 = 250, so delay = 750
     expect(delays).toEqual([750]);
@@ -138,10 +131,7 @@ describe("withRetry", () => {
 
   it("custom retryable function overrides default", async () => {
     // Regular Error is normally not retryable, but custom function says yes
-    const fn = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("server error"))
-      .mockResolvedValueOnce({ data: "found" });
+    const fn = vi.fn().mockRejectedValueOnce(new Error("server error")).mockResolvedValueOnce({ data: "found" });
 
     const result = await withRetry(fn, {
       ...fast,

--- a/tests/safety-net.test.ts
+++ b/tests/safety-net.test.ts
@@ -6,7 +6,7 @@
  * check-in answer detection, serialization, error handling, and
  * invalidateDockCache on 404/410 errors.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mock dock-cache
@@ -35,19 +35,19 @@ vi.mock("../src/basecamp-client.js", () => {
   return { BasecampError };
 });
 
-import { resolveDockToolIds, invalidateDockCache } from "../src/inbound/dock-cache.js";
-import {
-  pollSafetyNet,
-  serializeSnapshot,
-  deserializeSnapshot,
-  serializePending,
-  deserializePending,
-} from "../src/inbound/safety-net.js";
+import { invalidateDockCache, resolveDockToolIds } from "../src/inbound/dock-cache.js";
 import type {
-  SafetyNetSnapshot,
-  SafetyNetPollOptions,
   DisappearedPending,
   ProjectSnapshot,
+  SafetyNetPollOptions,
+  SafetyNetSnapshot,
+} from "../src/inbound/safety-net.js";
+import {
+  deserializePending,
+  deserializeSnapshot,
+  pollSafetyNet,
+  serializePending,
+  serializeSnapshot,
 } from "../src/inbound/safety-net.js";
 import type { ResolvedBasecampAccount } from "../src/types.js";
 
@@ -173,9 +173,7 @@ describe("safety-net", () => {
     client.cardTables.get.mockResolvedValue({
       lists: [{ id: 100, title: "Backlog" }],
     });
-    client.cards.list.mockResolvedValue([
-      { id: 501, updated_at: "2026-01-01T00:00:00Z", assignees: [] },
-    ]);
+    client.cards.list.mockResolvedValue([{ id: 501, updated_at: "2026-01-01T00:00:00Z", assignees: [] }]);
 
     const prev = emptySnapshot(1);
     const result = await pollSafetyNet(baseOpts(client, { previousSnapshot: prev }));
@@ -196,9 +194,7 @@ describe("safety-net", () => {
     client.cardTables.get.mockResolvedValue({
       lists: [{ id: 200, title: "In Progress" }],
     });
-    client.cards.list.mockResolvedValue([
-      { id: 501, updated_at: "2026-01-02T00:00:00Z", assignees: [] },
-    ]);
+    client.cards.list.mockResolvedValue([{ id: 501, updated_at: "2026-01-02T00:00:00Z", assignees: [] }]);
 
     const prev = snapshotWithCards(1, {
       "501": { columnId: 100, columnName: "Backlog", updatedAt: "2026-01-01T00:00:00Z", assignees: [] },
@@ -246,19 +242,23 @@ describe("safety-net", () => {
     });
 
     // Deep crawl #1: card missing → pending count=1
-    const r1 = await pollSafetyNet(baseOpts(client, {
-      previousSnapshot: prev,
-      isDeepCrawl: true,
-    }));
+    const r1 = await pollSafetyNet(
+      baseOpts(client, {
+        previousSnapshot: prev,
+        isDeepCrawl: true,
+      }),
+    );
     expect(r1.events.filter((e) => e.meta.eventKind === "disappeared")).toEqual([]);
     expect(r1.pending.entries["card:501"]).toBe(1);
 
     // Deep crawl #2: still missing → disappeared event
-    const r2 = await pollSafetyNet(baseOpts(client, {
-      previousSnapshot: prev,
-      previousPending: r1.pending,
-      isDeepCrawl: true,
-    }));
+    const r2 = await pollSafetyNet(
+      baseOpts(client, {
+        previousSnapshot: prev,
+        previousPending: r1.pending,
+        isDeepCrawl: true,
+      }),
+    );
     const disappeared = r2.events.find((e) => e.meta.eventKind === "disappeared");
     expect(disappeared).toBeDefined();
     expect(disappeared!.meta.recordableType).toBe("Kanban::Card");
@@ -276,10 +276,12 @@ describe("safety-net", () => {
       "501": { columnId: 100, columnName: "Backlog", updatedAt: "2026-01-01T00:00:00Z", assignees: [] },
     });
 
-    const result = await pollSafetyNet(baseOpts(client, {
-      previousSnapshot: prev,
-      isDeepCrawl: false, // capped
-    }));
+    const result = await pollSafetyNet(
+      baseOpts(client, {
+        previousSnapshot: prev,
+        isDeepCrawl: false, // capped
+      }),
+    );
     // No disappeared detection on capped crawl
     expect(result.events.filter((e) => e.meta.eventKind === "disappeared")).toEqual([]);
   });
@@ -291,20 +293,20 @@ describe("safety-net", () => {
     setupDock({ cardTableId: 10 });
     client.cardTables.get.mockResolvedValue({ lists: [{ id: 100, title: "Backlog" }] });
     // Card is present
-    client.cards.list.mockResolvedValue([
-      { id: 501, updated_at: "2026-01-01T00:00:00Z", assignees: [] },
-    ]);
+    client.cards.list.mockResolvedValue([{ id: 501, updated_at: "2026-01-01T00:00:00Z", assignees: [] }]);
 
     const prev = snapshotWithCards(1, {
       "501": { columnId: 100, columnName: "Backlog", updatedAt: "2026-01-01T00:00:00Z", assignees: [] },
     });
 
     const pendingBefore: DisappearedPending = { entries: { "card:501": 1 } };
-    const result = await pollSafetyNet(baseOpts(client, {
-      previousSnapshot: prev,
-      previousPending: pendingBefore,
-      isDeepCrawl: true,
-    }));
+    const result = await pollSafetyNet(
+      baseOpts(client, {
+        previousSnapshot: prev,
+        previousPending: pendingBefore,
+        isDeepCrawl: true,
+      }),
+    );
 
     // Pending counter should be cleared
     expect(result.pending.entries["card:501"]).toBeUndefined();
@@ -358,18 +360,22 @@ describe("safety-net", () => {
     });
 
     // Miss 1
-    const r1 = await pollSafetyNet(baseOpts(client, {
-      previousSnapshot: prev,
-      isDeepCrawl: true,
-    }));
+    const r1 = await pollSafetyNet(
+      baseOpts(client, {
+        previousSnapshot: prev,
+        isDeepCrawl: true,
+      }),
+    );
     expect(r1.pending.entries["todo:601"]).toBe(1);
 
     // Miss 2
-    const r2 = await pollSafetyNet(baseOpts(client, {
-      previousSnapshot: prev,
-      previousPending: r1.pending,
-      isDeepCrawl: true,
-    }));
+    const r2 = await pollSafetyNet(
+      baseOpts(client, {
+        previousSnapshot: prev,
+        previousPending: r1.pending,
+        isDeepCrawl: true,
+      }),
+    );
     const disappeared = r2.events.find((e) => e.meta.eventKind === "disappeared");
     expect(disappeared).toBeDefined();
     expect(disappeared!.meta.recordableType).toBe("Todo");
@@ -380,13 +386,8 @@ describe("safety-net", () => {
   it("check-in new answers → checkin_answered per answer", async () => {
     const client = makeClient();
     setupDock({ questionnaireId: 30 });
-    client.checkins.listQuestions.mockResolvedValue([
-      { id: 701 },
-    ]);
-    client.checkins.listAnswers.mockResolvedValue([
-      { id: 801 },
-      { id: 802 },
-    ]);
+    client.checkins.listQuestions.mockResolvedValue([{ id: 701 }]);
+    client.checkins.listAnswers.mockResolvedValue([{ id: 801 }, { id: 802 }]);
 
     const prev = snapshotWithCheckins(1, {
       "701": { answerIds: ["801"] }, // only 801 was known
@@ -435,9 +436,7 @@ describe("safety-net", () => {
     client.cardTables.get.mockRejectedValue(new Error("cards exploded"));
 
     // Todos crawl works
-    client.recordings.list.mockResolvedValue([
-      { id: 601, updated_at: "2026-01-01T00:00:00Z", assignees: [] },
-    ]);
+    client.recordings.list.mockResolvedValue([{ id: 601, updated_at: "2026-01-01T00:00:00Z", assignees: [] }]);
 
     const prev = emptySnapshot(1);
     const result = await pollSafetyNet(baseOpts(client, { previousSnapshot: prev }));
@@ -514,7 +513,9 @@ describe("safety-net", () => {
       updatedAt: "2026-01-01T00:00:00Z",
       projects: {
         "1": {
-          cards: { "501": { columnId: 1, columnName: "Backlog", updatedAt: "2026-01-01T00:00:00Z", assignees: ["42"] } },
+          cards: {
+            "501": { columnId: 1, columnName: "Backlog", updatedAt: "2026-01-01T00:00:00Z", assignees: ["42"] },
+          },
           todos: {},
           checkins: {},
         },
@@ -554,9 +555,7 @@ describe("safety-net", () => {
     setupDock({ cardTableId: 10, todosetId: 20 });
 
     // Cards crawl throws a 404 BasecampError
-    client.cardTables.get.mockRejectedValue(
-      new BasecampError("not_found", "Not found", { httpStatus: 404 }),
-    );
+    client.cardTables.get.mockRejectedValue(new BasecampError("not_found", "Not found", { httpStatus: 404 }));
     // Todos work fine
     client.recordings.list.mockResolvedValue([]);
 
@@ -569,9 +568,7 @@ describe("safety-net", () => {
     const client = makeClient();
     setupDock({ todosetId: 20 });
 
-    client.recordings.list.mockRejectedValue(
-      new BasecampError("api_error", "Gone", { httpStatus: 410 }),
-    );
+    client.recordings.list.mockRejectedValue(new BasecampError("api_error", "Gone", { httpStatus: 410 }));
 
     await pollSafetyNet(baseOpts(client));
     expect(invalidateDockCache).toHaveBeenCalledWith(1);
@@ -582,9 +579,7 @@ describe("safety-net", () => {
     const client = makeClient();
     setupDock({ questionnaireId: 30 });
 
-    client.checkins.listQuestions.mockRejectedValue(
-      new BasecampError("not_found", "Not found", { httpStatus: 404 }),
-    );
+    client.checkins.listQuestions.mockRejectedValue(new BasecampError("not_found", "Not found", { httpStatus: 404 }));
 
     await pollSafetyNet(baseOpts(client));
     expect(invalidateDockCache).toHaveBeenCalledWith(1);
@@ -596,9 +591,7 @@ describe("safety-net", () => {
     setupDock({ cardTableId: 10, todosetId: 20 });
 
     // 404 httpStatus but code is "api_error" — should still invalidate
-    client.cardTables.get.mockRejectedValue(
-      new BasecampError("api_error", "Not found", { httpStatus: 404 }),
-    );
+    client.cardTables.get.mockRejectedValue(new BasecampError("api_error", "Not found", { httpStatus: 404 }));
     client.recordings.list.mockResolvedValue([]);
 
     await pollSafetyNet(baseOpts(client));
@@ -633,11 +626,13 @@ describe("safety-net", () => {
 
     // Even with 2 deep crawl cycles, truncated results suppress disappeared
     const pending: DisappearedPending = { entries: { "card:501": 1 } };
-    const result = await pollSafetyNet(baseOpts(client, {
-      previousSnapshot: prev,
-      previousPending: pending,
-      isDeepCrawl: true,
-    }));
+    const result = await pollSafetyNet(
+      baseOpts(client, {
+        previousSnapshot: prev,
+        previousPending: pending,
+        isDeepCrawl: true,
+      }),
+    );
 
     expect(result.events.filter((e) => e.meta.eventKind === "disappeared")).toEqual([]);
   });
@@ -660,10 +655,12 @@ describe("safety-net", () => {
       },
     };
 
-    const result = await pollSafetyNet(baseOpts(client, {
-      projectIds: [1, 2],
-      previousSnapshot: prev,
-    }));
+    const result = await pollSafetyNet(
+      baseOpts(client, {
+        projectIds: [1, 2],
+        previousSnapshot: prev,
+      }),
+    );
 
     expect(result.events.length).toBe(2);
     expect(result.snapshot.projects["1"]).toBeDefined();

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -114,12 +114,8 @@ describe("security.collectWarnings", () => {
       }),
       account: stubAccount,
     });
-    expect(warnings).toContainEqual(
-      expect.stringContaining("agent-1"),
-    );
-    expect(warnings).toContainEqual(
-      expect.stringContaining("missing"),
-    );
+    expect(warnings).toContainEqual(expect.stringContaining("agent-1"));
+    expect(warnings).toContainEqual(expect.stringContaining("missing"));
   });
 
   it("does not warn on persona referencing existing account", async () => {
@@ -142,12 +138,8 @@ describe("security.collectWarnings", () => {
       }),
       account: stubAccount,
     });
-    expect(warnings).toContainEqual(
-      expect.stringContaining("project-x"),
-    );
-    expect(warnings).toContainEqual(
-      expect.stringContaining("ghost"),
-    );
+    expect(warnings).toContainEqual(expect.stringContaining("project-x"));
+    expect(warnings).toContainEqual(expect.stringContaining("ghost"));
   });
 
   it("warns on duplicate personId across accounts", async () => {
@@ -160,15 +152,9 @@ describe("security.collectWarnings", () => {
       }),
       account: stubAccount,
     });
-    expect(warnings).toContainEqual(
-      expect.stringContaining("Person ID 42"),
-    );
-    expect(warnings).toContainEqual(
-      expect.stringContaining("alpha"),
-    );
-    expect(warnings).toContainEqual(
-      expect.stringContaining("beta"),
-    );
+    expect(warnings).toContainEqual(expect.stringContaining("Person ID 42"));
+    expect(warnings).toContainEqual(expect.stringContaining("alpha"));
+    expect(warnings).toContainEqual(expect.stringContaining("beta"));
   });
 
   it("warns on account with no auth configured", async () => {
@@ -180,12 +166,8 @@ describe("security.collectWarnings", () => {
       }),
       account: stubAccount,
     });
-    expect(warnings).toContainEqual(
-      expect.stringContaining("broken"),
-    );
-    expect(warnings).toContainEqual(
-      expect.stringContaining("no token"),
-    );
+    expect(warnings).toContainEqual(expect.stringContaining("broken"));
+    expect(warnings).toContainEqual(expect.stringContaining("no token"));
   });
 
   it("warns on account with only cliProfile (no runtime auth)", async () => {
@@ -222,9 +204,7 @@ describe("security.collectWarnings", () => {
       }),
       account: stubAccount,
     });
-    expect(warnings).toContainEqual(
-      expect.stringContaining("not-a-number"),
-    );
+    expect(warnings).toContainEqual(expect.stringContaining("not-a-number"));
     // Only one bad entry
     const formatWarnings = warnings.filter((w) => w.includes("does not look like"));
     expect(formatWarnings).toHaveLength(1);

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -4,7 +4,7 @@
  * Validates account ID normalization, input validation,
  * and config application for the setup flow.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -11,7 +11,7 @@
  * Run with: OPENCLAW_INTEGRATION=1 npx vitest run tests/smoke.test.ts
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/metrics.js", () => ({
   recordUnknownKind: vi.fn(),
@@ -23,8 +23,8 @@ vi.mock("../src/outbound/send.js", () => ({
 import { cliMe } from "../src/basecamp-cli.js";
 import { getClient, rawOrThrow } from "../src/basecamp-client.js";
 import { pollActivityFeed } from "../src/inbound/activity.js";
-import { pollReadings } from "../src/inbound/readings.js";
 import { EventDedup } from "../src/inbound/dedup.js";
+import { pollReadings } from "../src/inbound/readings.js";
 import type { ResolvedBasecampAccount } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
@@ -69,7 +69,7 @@ describeIntegration("smoke: SDK client", () => {
 
   it("client.reports.progress() returns activity events", async () => {
     const client = getClient(testAccount);
-    const events = await client.reports.progress() as any[];
+    const events = (await client.reports.progress()) as any[];
     expect(Array.isArray(events)).toBe(true);
     expect(events.length).toBeGreaterThan(0);
     const first = events[0];
@@ -104,9 +104,7 @@ describeIntegration("smoke: pollActivityFeed", () => {
       log,
     });
 
-    console.log(
-      `pollActivityFeed: ${result.events.length} events, newestAt=${result.newestAt}`,
-    );
+    console.log(`pollActivityFeed: ${result.events.length} events, newestAt=${result.newestAt}`);
 
     // Should get events from a real active account
     expect(result.events.length).toBeGreaterThan(0);
@@ -144,21 +142,28 @@ describeIntegration("smoke: pollActivityFeed", () => {
     // Log first event for manual inspection
     if (result.events.length > 0) {
       const first = result.events[0];
-      console.log("First event:", JSON.stringify({
-        dedupKey: first.dedupKey,
-        peer: first.peer,
-        parentPeer: first.parentPeer,
-        sender: { id: first.sender.id, name: first.sender.name },
-        text: first.text?.slice(0, 80),
-        meta: {
-          bucketId: first.meta.bucketId,
-          recordingId: first.meta.recordingId,
-          recordableType: first.meta.recordableType,
-          eventKind: first.meta.eventKind,
-          mentionsAgent: first.meta.mentionsAgent,
-          matchedPatterns: first.meta.matchedPatterns,
-        },
-      }, null, 2));
+      console.log(
+        "First event:",
+        JSON.stringify(
+          {
+            dedupKey: first.dedupKey,
+            peer: first.peer,
+            parentPeer: first.parentPeer,
+            sender: { id: first.sender.id, name: first.sender.name },
+            text: first.text?.slice(0, 80),
+            meta: {
+              bucketId: first.meta.bucketId,
+              recordingId: first.meta.recordingId,
+              recordableType: first.meta.recordableType,
+              eventKind: first.meta.eventKind,
+              mentionsAgent: first.meta.mentionsAgent,
+              matchedPatterns: first.meta.matchedPatterns,
+            },
+          },
+          null,
+          2,
+        ),
+      );
     }
   });
 
@@ -189,9 +194,7 @@ describeIntegration("smoke: pollReadings", () => {
   it("pollReadings handles empty and populated responses", async () => {
     const result = await pollReadings({ account: testAccount, log });
 
-    console.log(
-      `pollReadings: ${result.events.length} events, newestAt=${result.newestAt}`,
-    );
+    console.log(`pollReadings: ${result.events.length} events, newestAt=${result.newestAt}`);
 
     // Whether 0 or N events, the shape contract holds
     for (const msg of result.events) {
@@ -266,7 +269,7 @@ describeIntegration("smoke: URL parsing with real data", () => {
 describeIntegration("smoke: directory integration", () => {
   it("client.people.list returns people array", async () => {
     const client = getClient(testAccount);
-    const people = await client.people.list(Number(testAccount.accountId)) as any[];
+    const people = (await client.people.list(Number(testAccount.accountId))) as any[];
     expect(Array.isArray(people)).toBe(true);
     expect(people.length).toBeGreaterThan(0);
     expect(people[0]).toHaveProperty("id");

--- a/tests/startup-validation.test.ts
+++ b/tests/startup-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -80,7 +80,7 @@ vi.mock("../src/inbound/poller.js", () => {
   throw new Error("test: skip poller startup");
 });
 
-import { basecampChannel, _resetValidationState } from "../src/channel.js";
+import { _resetValidationState, basecampChannel } from "../src/channel.js";
 import { resolveBasecampAccountAsync } from "../src/config.js";
 
 function makeCtx(cfg: any, accountId = "test") {
@@ -138,17 +138,13 @@ describe("PF-002: config-hash re-validation", () => {
     await basecampChannel.gateway!.startAccount!(ctx1 as any);
 
     // Should warn about the bad persona
-    expect(ctx1.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining('persona "agent-1"'),
-    );
+    expect(ctx1.log.warn).toHaveBeenCalledWith(expect.stringContaining('persona "agent-1"'));
 
     // Second call: same config → should NOT re-validate
     const ctx2 = makeCtx(cfg1);
     await basecampChannel.gateway!.startAccount!(ctx2 as any);
 
-    const personaWarns2 = vi.mocked(ctx2.log.warn).mock.calls.filter(
-      (c) => String(c[0]).includes("persona"),
-    );
+    const personaWarns2 = vi.mocked(ctx2.log.warn).mock.calls.filter((c) => String(c[0]).includes("persona"));
     expect(personaWarns2).toHaveLength(0);
 
     // Third call: different config → should re-validate
@@ -163,9 +159,7 @@ describe("PF-002: config-hash re-validation", () => {
     const ctx3 = makeCtx(cfg3);
     await basecampChannel.gateway!.startAccount!(ctx3 as any);
 
-    expect(ctx3.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining('persona "agent-2"'),
-    );
+    expect(ctx3.log.warn).toHaveBeenCalledWith(expect.stringContaining('persona "agent-2"'));
   });
 
   it("re-validates when accounts change even if personas are the same", async () => {
@@ -195,9 +189,7 @@ describe("PF-002: config-hash re-validation", () => {
     const ctx2 = makeCtx(cfg2);
     await basecampChannel.gateway!.startAccount!(ctx2 as any);
 
-    expect(ctx2.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining('persona "agent-1"'),
-    );
+    expect(ctx2.log.warn).toHaveBeenCalledWith(expect.stringContaining('persona "agent-1"'));
   });
 });
 
@@ -217,12 +209,8 @@ describe("PF-003: basecampAccountId startup warning", () => {
     const ctx = makeCtx({}, "my-org");
     await basecampChannel.gateway!.startAccount!(ctx as any);
 
-    expect(ctx.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("Basecamp account ID could not be resolved"),
-    );
-    expect(ctx.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("my-org"),
-    );
+    expect(ctx.log.warn).toHaveBeenCalledWith(expect.stringContaining("Basecamp account ID could not be resolved"));
+    expect(ctx.log.warn).toHaveBeenCalledWith(expect.stringContaining("my-org"));
   });
 
   it("does not warn when accountId is numeric (implicit basecampAccountId)", async () => {
@@ -235,9 +223,9 @@ describe("PF-003: basecampAccountId startup warning", () => {
     const ctx = makeCtx({}, "12345");
     await basecampChannel.gateway!.startAccount!(ctx as any);
 
-    const accountIdWarns = vi.mocked(ctx.log.warn).mock.calls.filter(
-      (c) => String(c[0]).includes("Basecamp account ID"),
-    );
+    const accountIdWarns = vi
+      .mocked(ctx.log.warn)
+      .mock.calls.filter((c) => String(c[0]).includes("Basecamp account ID"));
     expect(accountIdWarns).toHaveLength(0);
   });
 
@@ -251,9 +239,9 @@ describe("PF-003: basecampAccountId startup warning", () => {
     const ctx = makeCtx({}, "my-org");
     await basecampChannel.gateway!.startAccount!(ctx as any);
 
-    const accountIdWarns = vi.mocked(ctx.log.warn).mock.calls.filter(
-      (c) => String(c[0]).includes("Basecamp account ID"),
-    );
+    const accountIdWarns = vi
+      .mocked(ctx.log.warn)
+      .mock.calls.filter((c) => String(c[0]).includes("Basecamp account ID"));
     expect(accountIdWarns).toHaveLength(0);
   });
 });

--- a/tests/status-enhanced.test.ts
+++ b/tests/status-enhanced.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -35,7 +35,10 @@ vi.mock("../src/basecamp-client.js", () => ({
   rawOrThrow: vi.fn(async (r: any) => r?.data),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
@@ -43,22 +46,22 @@ vi.mock("../src/config.js", () => ({
   resolveBasecampAccount: vi.fn(),
 }));
 
+import type { BasecampAudit, BasecampProbe } from "../src/adapters/status.js";
 import { basecampStatusAdapter } from "../src/adapters/status.js";
-import type { BasecampProbe, BasecampAudit } from "../src/adapters/status.js";
 import { resolveBasecampAccount } from "../src/config.js";
-import type { ResolvedBasecampAccount } from "../src/types.js";
 import {
+  clearMetrics,
+  recordCircuitBreakerState,
+  recordDedupSize,
   recordPollAttempt,
   recordPollSuccess,
-  recordWebhookReceived,
+  recordWebhookDedupSize,
   recordWebhookDispatched,
   recordWebhookDropped,
   recordWebhookError,
-  recordDedupSize,
-  recordWebhookDedupSize,
-  recordCircuitBreakerState,
-  clearMetrics,
+  recordWebhookReceived,
 } from "../src/metrics.js";
+import type { ResolvedBasecampAccount } from "../src/types.js";
 
 function cfg(basecamp?: Record<string, unknown>) {
   if (!basecamp) return {} as any;
@@ -790,9 +793,7 @@ describe("collectStatusIssues (audit.errors)", () => {
       projectsAccessible: 1,
       personasMapped: 1,
       personasValid: 0,
-      errors: [
-        { kind: "config", message: 'Persona "agent-1" \u2192 account "missing": account does not exist' },
-      ],
+      errors: [{ kind: "config", message: 'Persona "agent-1" \u2192 account "missing": account does not exist' }],
       personIdSet: true,
     };
 
@@ -821,9 +822,7 @@ describe("collectStatusIssues (audit.errors)", () => {
       projectsAccessible: 0,
       personasMapped: 0,
       personasValid: 0,
-      errors: [
-        { kind: "runtime", message: "Failed to verify project access: Error: forbidden" },
-      ],
+      errors: [{ kind: "runtime", message: "Failed to verify project access: Error: forbidden" }],
       personIdSet: true,
     };
 

--- a/tests/webhook-hmac.test.ts
+++ b/tests/webhook-hmac.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import crypto from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/dispatch.js", () => ({
   dispatchBasecampEvent: vi.fn().mockResolvedValue(true),
@@ -66,34 +66,22 @@ vi.mock("../src/inbound/normalize.js", () => ({
 }));
 
 import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
-import {
-  verifyWebhookSignature,
-  handleBasecampWebhook,
-  getWebhookSecretRegistry,
-} from "../src/inbound/webhooks.js";
-import { closeAllAccountDedup } from "../src/inbound/dedup-registry.js";
-import { WebhookSecretRegistry, JsonFileWebhookSecretStore } from "../src/inbound/webhook-secrets.js";
+import { join } from "node:path";
 import { resolveAccountForBucket } from "../src/config.js";
+import { closeAllAccountDedup } from "../src/inbound/dedup-registry.js";
+import { JsonFileWebhookSecretStore, WebhookSecretRegistry } from "../src/inbound/webhook-secrets.js";
+import { getWebhookSecretRegistry, handleBasecampWebhook, verifyWebhookSignature } from "../src/inbound/webhooks.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function signPayload(secret: string, timestamp: string, body: string): string {
-  return (
-    "sha256=" +
-    crypto.createHmac("sha256", secret).update(`${timestamp}.${body}`).digest("hex")
-  );
+  return "sha256=" + crypto.createHmac("sha256", secret).update(`${timestamp}.${body}`).digest("hex");
 }
 
-function mockReq(
-  method: string,
-  url: string,
-  body?: string,
-  headers?: Record<string, string>,
-): IncomingMessage {
+function mockReq(method: string, url: string, body?: string, headers?: Record<string, string>): IncomingMessage {
   const { Readable } = require("node:stream");
   const req = new Readable({
     read() {

--- a/tests/webhook-lifecycle.test.ts
+++ b/tests/webhook-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClient = {
   webhooks: { list: vi.fn(), delete: vi.fn() },
@@ -16,13 +16,16 @@ vi.mock("../src/basecamp-client.js", () => ({
   }),
   BasecampError: class BasecampError extends Error {
     code: string;
-    constructor(msg: string, code: string) { super(msg); this.code = code; }
+    constructor(msg: string, code: string) {
+      super(msg);
+      this.code = code;
+    }
   },
 }));
 
-import { WebhookSecretRegistry } from "../src/inbound/webhook-secrets.js";
-import { reconcileWebhooks, deactivateWebhooks } from "../src/inbound/webhook-lifecycle.js";
 import type { WebhookLifecycleConfig } from "../src/inbound/webhook-lifecycle.js";
+import { deactivateWebhooks, reconcileWebhooks } from "../src/inbound/webhook-lifecycle.js";
+import { WebhookSecretRegistry } from "../src/inbound/webhook-secrets.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -146,10 +149,7 @@ describe("reconcileWebhooks", () => {
       types: ["Comment", "Todo"],
     });
 
-    const result = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-    );
+    const result = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry);
 
     expect(result.existing).toEqual(["100"]);
     // Secret should be preserved
@@ -180,11 +180,7 @@ describe("reconcileWebhooks", () => {
 
     const registry = new WebhookSecretRegistry();
     const log = mockLog();
-    const result = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-      log,
-    );
+    const result = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry, log);
 
     // Old webhook should be deleted, new one created
     expect(mockClient.webhooks.delete).toHaveBeenCalledWith(42);
@@ -211,19 +207,18 @@ describe("reconcileWebhooks", () => {
 
     const registry = new WebhookSecretRegistry();
     const log = mockLog();
-    const result = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-      log,
-    );
+    const result = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry, log);
 
     // No-secret is not a failure — BC3 never returns secrets
     expect(result.created).toEqual(["100"]);
     expect(result.failed).toEqual([]);
     expect(registry.get("100")!.secret).toBe("");
-    expect(log.info).toHaveBeenCalledWith("webhook_create_no_secret", expect.objectContaining({
-      project: "100",
-    }));
+    expect(log.info).toHaveBeenCalledWith(
+      "webhook_create_no_secret",
+      expect.objectContaining({
+        project: "100",
+      }),
+    );
   });
 
   it("records failed projects when create returns no ID", async () => {
@@ -270,10 +265,7 @@ describe("reconcileWebhooks", () => {
     });
 
     const registry = new WebhookSecretRegistry();
-    const result = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-    );
+    const result = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry);
 
     expect(result.created).toEqual(["100"]);
     expect(mockClient.raw.POST).toHaveBeenCalledTimes(1);
@@ -302,10 +294,7 @@ describe("reconcileWebhooks", () => {
     });
 
     const registry = new WebhookSecretRegistry();
-    const result = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-    );
+    const result = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry);
 
     // Inactive match should not count — should create new
     expect(result.created).toEqual(["100"]);
@@ -327,10 +316,7 @@ describe("reconcileWebhooks", () => {
 
     const registry = new WebhookSecretRegistry();
     const { getClient } = await import("../src/basecamp-client.js");
-    await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-    );
+    await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry);
 
     expect(getClient).toHaveBeenCalledWith(TEST_ACCOUNT);
   });
@@ -354,10 +340,7 @@ describe("reconcileWebhooks", () => {
       types: ["Todo", "Comment"],
     });
 
-    const result = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-    );
+    const result = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry);
 
     expect(result.existing).toEqual(["100"]);
     expect(result.recovered).toEqual([]);
@@ -386,11 +369,7 @@ describe("reconcileWebhooks", () => {
     });
 
     const log = mockLog();
-    const result = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-      log,
-    );
+    const result = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry, log);
 
     // Should be existing — no delete/recreate
     expect(result.existing).toEqual(["100"]);
@@ -414,11 +393,7 @@ describe("reconcileWebhooks", () => {
     const registry = new WebhookSecretRegistry();
     const log = mockLog();
 
-    const result1 = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-      log,
-    );
+    const result1 = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry, log);
     expect(result1.existing).toEqual(["100"]);
 
     // Second call: same state
@@ -432,11 +407,7 @@ describe("reconcileWebhooks", () => {
       },
     ]);
 
-    const result2 = await reconcileWebhooks(
-      makeConfig({ projects: ["100"] }),
-      registry,
-      log,
-    );
+    const result2 = await reconcileWebhooks(makeConfig({ projects: ["100"] }), registry, log);
 
     expect(result2.existing).toEqual(["100"]);
     expect(mockClient.webhooks.delete).not.toHaveBeenCalled();
@@ -457,10 +428,7 @@ describe("reconcileWebhooks", () => {
     });
 
     const registry = new WebhookSecretRegistry();
-    await reconcileWebhooks(
-      makeConfig({ projects: ["100"], types: [] }),
-      registry,
-    );
+    await reconcileWebhooks(makeConfig({ projects: ["100"], types: [] }), registry);
 
     // raw.POST should be called with body that doesn't include types
     const postCallArgs = mockClient.raw.POST.mock.calls[0]!;

--- a/tests/webhook-project-scoping.test.ts
+++ b/tests/webhook-project-scoping.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
@@ -8,11 +8,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
   },
 }));
 
-import {
-  scopeWebhookProjects,
-  resolveAccountForBucket,
-  listBasecampAccountIds,
-} from "../src/config.js";
+import { listBasecampAccountIds, resolveAccountForBucket, scopeWebhookProjects } from "../src/config.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/dispatch.js", () => ({
   dispatchBasecampEvent: vi.fn().mockResolvedValue(true),
@@ -47,7 +47,16 @@ vi.mock("../src/inbound/normalize.js", () => ({
       sender: { id: "2", name: "Tester" },
       text: "hi",
       html: "<p>hi</p>",
-      meta: { bucketId: "1", recordingId: String(seq), recordableType: "Chat::Line", eventKind: "line_created", mentions: [], mentionsAgent: false, attachments: [], sources: ["webhook"] },
+      meta: {
+        bucketId: "1",
+        recordingId: String(seq),
+        recordableType: "Chat::Line",
+        eventKind: "line_created",
+        mentions: [],
+        mentionsAgent: false,
+        attachments: [],
+        sources: ["webhook"],
+      },
       dedupKey: `webhook:${seq}`,
       createdAt: `2025-01-01T00:00:${String(seq).padStart(2, "0")}Z`,
     };
@@ -56,13 +65,18 @@ vi.mock("../src/inbound/normalize.js", () => ({
 }));
 
 import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { Semaphore, handleBasecampWebhook } from "../src/inbound/webhooks.js";
-import { closeAllAccountDedup } from "../src/inbound/dedup-registry.js";
-import { resolveDefaultBasecampAccountId, resolveWebhookSecret, resolveAccountForBucket, listBasecampAccountIds } from "../src/config.js";
+import { join } from "node:path";
+import {
+  listBasecampAccountIds,
+  resolveAccountForBucket,
+  resolveDefaultBasecampAccountId,
+  resolveWebhookSecret,
+} from "../src/config.js";
 import { dispatchBasecampEvent } from "../src/dispatch.js";
-import { getAccountMetrics, clearMetrics } from "../src/metrics.js";
+import { closeAllAccountDedup } from "../src/inbound/dedup-registry.js";
+import { handleBasecampWebhook, Semaphore } from "../src/inbound/webhooks.js";
+import { clearMetrics, getAccountMetrics } from "../src/metrics.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -100,7 +114,9 @@ describe("Semaphore", () => {
 
     // This should queue
     let resolved = false;
-    const p = sem.acquire().then(() => { resolved = true; });
+    const p = sem.acquire().then(() => {
+      resolved = true;
+    });
 
     // Give microtask a chance
     await Promise.resolve();
@@ -120,8 +136,12 @@ describe("Semaphore", () => {
 
     await sem.acquire();
 
-    const p1 = sem.acquire().then(() => { order.push(1); });
-    const p2 = sem.acquire().then(() => { order.push(2); });
+    const p1 = sem.acquire().then(() => {
+      order.push(1);
+    });
+    const p2 = sem.acquire().then(() => {
+      order.push(2);
+    });
 
     expect(sem.pending).toBe(2);
 
@@ -192,11 +212,7 @@ describe("Semaphore", () => {
 // Webhook handler hardening
 // ---------------------------------------------------------------------------
 
-function mockReq(
-  method: string,
-  url: string,
-  body?: string,
-): IncomingMessage {
+function mockReq(method: string, url: string, body?: string): IncomingMessage {
   const { Readable } = require("node:stream");
   const req = new Readable({
     read() {
@@ -351,10 +367,7 @@ describe("handleBasecampWebhook — hardening", () => {
 
     expect(res.status).toBe(200);
     expect(dispatchBasecampEvent).toHaveBeenCalled();
-    expect(resolveBasecampAccount).toHaveBeenCalledWith(
-      expect.anything(),
-      "work",
-    );
+    expect(resolveBasecampAccount).toHaveBeenCalledWith(expect.anything(), "work");
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,11 @@
-import path from "path";
 import { defineConfig } from "vitest/config";
+
+// When OPENCLAW_PLUGIN_SDK_PATH is set, alias openclaw/plugin-sdk to local
+// source for development. Otherwise let Node resolve from node_modules.
+const alias: Record<string, string> = {};
+if (process.env.OPENCLAW_PLUGIN_SDK_PATH) {
+  alias["openclaw/plugin-sdk"] = process.env.OPENCLAW_PLUGIN_SDK_PATH;
+}
 
 export default defineConfig({
   test: {
@@ -12,13 +18,5 @@ export default defineConfig({
       thresholds: { lines: 85, functions: 85, branches: 82, statements: 85 },
     },
   },
-  resolve: {
-    alias: {
-      // Resolve openclaw/plugin-sdk to local source for testing.
-      // Set OPENCLAW_PLUGIN_SDK_PATH to override the default location.
-      "openclaw/plugin-sdk":
-        process.env.OPENCLAW_PLUGIN_SDK_PATH ??
-        path.resolve(process.env.HOME ?? "~", "Work/basecamp/openclaw/src/plugin-sdk/index.ts"),
-    },
-  },
+  resolve: { alias },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config";
 import path from "path";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
@@ -16,11 +16,9 @@ export default defineConfig({
     alias: {
       // Resolve openclaw/plugin-sdk to local source for testing.
       // Set OPENCLAW_PLUGIN_SDK_PATH to override the default location.
-      "openclaw/plugin-sdk": process.env.OPENCLAW_PLUGIN_SDK_PATH ??
-        path.resolve(
-          process.env.HOME ?? "~",
-          "Work/basecamp/openclaw/src/plugin-sdk/index.ts",
-        ),
+      "openclaw/plugin-sdk":
+        process.env.OPENCLAW_PLUGIN_SDK_PATH ??
+        path.resolve(process.env.HOME ?? "~", "Work/basecamp/openclaw/src/plugin-sdk/index.ts"),
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/types.ts", "src/**/*.d.ts"],
       reporter: ["text", "json-summary"],
-      thresholds: { lines: 50, functions: 50, branches: 40, statements: 50 },
+      thresholds: { lines: 85, functions: 85, branches: 82, statements: 85 },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- **Fix `cliProfileList` crash**: CLI returns profile objects (`{ name, base_url, ... }`), not strings — extract `.name` to fix `TypeError: t.includes is not a function`
- **Import CLI credentials directly**: Instead of forcing users through a separate OAuth app registration, the CLI onboarding path now reads `~/.config/basecamp/credentials.json` and `client.json` to import the CLI's existing OAuth tokens
- **Add `cliProfileListFull` / `exportCliCredentials`**: New helpers in `basecamp-cli.ts` for full profile objects and credential export

## Test plan
- [x] All 1116 tests pass
- [ ] Run onboarding with CLI path — verify credentials are imported without OAuth app prompt
- [ ] Run onboarding with browser OAuth path — verify redirect URI guidance shown
- [ ] Verify token refresh works with imported CLI credentials