### PR TITLE
Scope logout cache eviction to target account

### DIFF
--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -42,9 +42,13 @@ export function getClient(account: ResolvedBasecampAccount): BasecampClient {
   return client;
 }
 
-/** Clear all cached clients (for shutdown). */
-export function clearClients(): void {
-  clientCache.clear();
+/** Clear cached clients. Pass accountId to evict one; omit to clear all (shutdown). */
+export function clearClients(accountId?: string): void {
+  if (accountId) {
+    clientCache.delete(accountId);
+  } else {
+    clientCache.clear();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -521,10 +521,10 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         }
       }
 
-      // Evict cached TokenManagers and SDK clients
+      // Evict cached TokenManager and SDK client for this account only
       const { clearTokenManagers } = await import("./oauth-credentials.js");
-      clearTokenManagers();
-      clearClients();
+      clearTokenManagers(accountId);
+      clearClients(accountId);
 
       // Close account dedup DB
       closeAccountDedup(accountId);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -521,13 +521,25 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
         }
       }
 
-      // Evict cached TokenManager and SDK client for this account only
+      // Evict cached TokenManager and SDK client for this account and any
+      // virtual-account aliases that resolve to the same concrete account.
+      const resolvedId = account.accountId;
       const { clearTokenManagers } = await import("./oauth-credentials.js");
-      clearTokenManagers(accountId);
-      clearClients(accountId);
+      clearTokenManagers(resolvedId);
+      clearClients(resolvedId);
+      closeAccountDedup(resolvedId);
 
-      // Close account dedup DB
-      closeAccountDedup(accountId);
+      // Also evict virtual-account aliases pointing to this concrete account
+      const section = (cfg as any)?.channels?.basecamp as BasecampChannelConfig | undefined;
+      if (section?.virtualAccounts) {
+        for (const [alias, va] of Object.entries(section.virtualAccounts)) {
+          if (va.accountId === resolvedId) {
+            clearTokenManagers(alias);
+            clearClients(alias);
+            closeAccountDedup(alias);
+          }
+        }
+      }
 
       return { cleared, loggedOut: cleared };
     },

--- a/src/oauth-credentials.ts
+++ b/src/oauth-credentials.ts
@@ -73,9 +73,13 @@ export function createTokenManager(account: ResolvedBasecampAccount): TokenManag
   return tm;
 }
 
-/** Clear all cached TokenManagers (for shutdown / tests). */
-export function clearTokenManagers(): void {
-  managerCache.clear();
+/** Clear cached TokenManagers. Pass accountId to evict one; omit to clear all (shutdown). */
+export function clearTokenManagers(accountId?: string): void {
+  if (accountId) {
+    managerCache.delete(accountId);
+  } else {
+    managerCache.clear();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/channel-gateway.test.ts
+++ b/tests/channel-gateway.test.ts
@@ -451,6 +451,57 @@ describe("logoutAccount", () => {
     expect(closeAccountDedup).toHaveBeenCalledWith("test");
   });
 
+  it("uses resolved account.accountId for cache eviction, not raw input", async () => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue(
+      makeAccount({ accountId: "normalized", config: { personId: "42" } }) as any,
+    );
+
+    await basecampChannel.gateway!.logoutAccount!({
+      accountId: "  NORMALIZED  ",
+      cfg: {},
+    } as any);
+
+    // Should use the resolved "normalized", not the raw "  NORMALIZED  "
+    expect(clearTokenManagers).toHaveBeenCalledWith("normalized");
+    expect(clearClients).toHaveBeenCalledWith("normalized");
+    expect(closeAccountDedup).toHaveBeenCalledWith("normalized");
+  });
+
+  it("evicts virtual-account alias caches that point to the concrete account", async () => {
+    vi.mocked(resolveBasecampAccount).mockReturnValue(
+      makeAccount({ accountId: "main", config: { personId: "42" } }) as any,
+    );
+
+    const cfg = {
+      channels: {
+        basecamp: {
+          virtualAccounts: {
+            "project-a": { accountId: "main", bucketId: "111" },
+            "project-b": { accountId: "main", bucketId: "222" },
+            "project-c": { accountId: "other", bucketId: "333" },
+          },
+        },
+      },
+    };
+
+    await basecampChannel.gateway!.logoutAccount!({ accountId: "main", cfg } as any);
+
+    // Concrete account evicted
+    expect(clearTokenManagers).toHaveBeenCalledWith("main");
+    expect(clearClients).toHaveBeenCalledWith("main");
+    expect(closeAccountDedup).toHaveBeenCalledWith("main");
+    // Aliases pointing to "main" evicted
+    expect(clearTokenManagers).toHaveBeenCalledWith("project-a");
+    expect(clearClients).toHaveBeenCalledWith("project-a");
+    expect(closeAccountDedup).toHaveBeenCalledWith("project-a");
+    expect(clearTokenManagers).toHaveBeenCalledWith("project-b");
+    expect(clearClients).toHaveBeenCalledWith("project-b");
+    expect(closeAccountDedup).toHaveBeenCalledWith("project-b");
+    // Alias pointing to "other" NOT evicted
+    expect(clearTokenManagers).not.toHaveBeenCalledWith("project-c");
+    expect(clearClients).not.toHaveBeenCalledWith("project-c");
+  });
+
   it("returns cleared=true when token file already gone (ENOENT)", async () => {
     mockUnlink.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
     vi.mocked(resolveBasecampAccount).mockReturnValue(

--- a/tests/channel-gateway.test.ts
+++ b/tests/channel-gateway.test.ts
@@ -446,8 +446,8 @@ describe("logoutAccount", () => {
 
     expect(result).toEqual({ cleared: true, loggedOut: true });
     expect(mockUnlink).toHaveBeenCalledWith("/tmp/token.json");
-    expect(clearTokenManagers).toHaveBeenCalled();
-    expect(clearClients).toHaveBeenCalled();
+    expect(clearTokenManagers).toHaveBeenCalledWith("test");
+    expect(clearClients).toHaveBeenCalledWith("test");
     expect(closeAccountDedup).toHaveBeenCalledWith("test");
   });
 
@@ -474,8 +474,8 @@ describe("logoutAccount", () => {
     } as any);
 
     expect(result).toEqual({ cleared: false, loggedOut: false });
-    expect(clearTokenManagers).toHaveBeenCalled();
-    expect(clearClients).toHaveBeenCalled();
+    expect(clearTokenManagers).toHaveBeenCalledWith("test");
+    expect(clearClients).toHaveBeenCalledWith("test");
     expect(closeAccountDedup).toHaveBeenCalledWith("test");
   });
 });


### PR DESCRIPTION
## Summary

`logoutAccount` called `clearTokenManagers()` and `clearClients()` which cleared **all** cached entries, disrupting other running accounts in multi-account setups.

Both functions now accept an optional `accountId` parameter. `logoutAccount` passes the target account ID so only that account's TokenManager and SDK client are evicted.

## Changes

- `clearTokenManagers(accountId?)` — deletes single entry when accountId provided
- `clearClients(accountId?)` — same pattern
- `logoutAccount` passes `accountId` to both
- Tests assert account-scoped calls (`toHaveBeenCalledWith("test")`)

Backward compatible: omitting the parameter still clears all (used by shutdown).