### PR TITLE
Fix OAuth login using DCR placeholder instead of valid Launchpad client

### DIFF
--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -458,7 +458,9 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
       ? {
           ...(section.oauth ?? {}),
           clientId: oauthClientId,
-          ...(promptedClientSecret && oauthClientSecret ? { clientSecret: oauthClientSecret } : {}),
+          // Always set clientSecret explicitly when replacing the client ID —
+          // a stale secret from the old (invalid) client must not survive the spread.
+          clientSecret: promptedClientSecret && oauthClientSecret ? oauthClientSecret : undefined,
         }
       : section.oauth;
 

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -19,7 +19,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { normalizeAccountId } from "openclaw/plugin-sdk";
 import { cliMe, cliProfileList } from "../basecamp-cli.js";
 import { listBasecampAccountIds } from "../config.js";
-import { interactiveLogin, resolveTokenFilePath } from "../oauth-credentials.js";
+import { interactiveLogin, isValidLaunchpadClientId, resolveTokenFilePath } from "../oauth-credentials.js";
 import type { BasecampChannelConfig, ResolvedBasecampAccount } from "../types.js";
 
 type WizardPrompter = {
@@ -80,20 +80,20 @@ async function discoverViaBrowser(
 ): Promise<OAuthDiscoveryResult & { info: AuthorizationInfo }> {
   const section = getBasecampSection(cfg);
 
-  // Resolve or prompt for clientId
-  let clientId = section?.oauth?.clientId;
+  // Resolve or prompt for clientId — validate before use
+  let clientId = isValidLaunchpadClientId(section?.oauth?.clientId) ? section!.oauth!.clientId : undefined;
   let promptedClientId = false;
   if (!clientId) {
     clientId = await prompter.text({
       message: "OAuth client ID",
-      validate: (v) => (v?.trim() ? undefined : "Required"),
+      validate: (v) => (isValidLaunchpadClientId(v?.trim()) ? undefined : "Must be a 40-character hex string"),
     });
     clientId = clientId.trim();
     promptedClientId = true;
   }
 
   // Resolve or prompt for clientSecret
-  let clientSecret = section?.oauth?.clientSecret;
+  let clientSecret = clientId === section?.oauth?.clientId ? section?.oauth?.clientSecret : undefined;
   let promptedClientSecret = false;
   if (!clientSecret && promptedClientId) {
     const entered = await prompter.text({
@@ -318,20 +318,20 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
   if (authMethod === "cli" && !oauthResult) {
     const cliSection = getBasecampSection(cfg);
 
-    // Resolve or prompt for clientId
-    let cliClientId = cliSection?.oauth?.clientId;
+    // Resolve or prompt for clientId — validate before use
+    let cliClientId = isValidLaunchpadClientId(cliSection?.oauth?.clientId) ? cliSection!.oauth!.clientId : undefined;
     let cliPromptedClientId = false;
     if (!cliClientId) {
       cliClientId = await prompter.text({
         message: "OAuth client ID",
-        validate: (v) => (v?.trim() ? undefined : "Required"),
+        validate: (v) => (isValidLaunchpadClientId(v?.trim()) ? undefined : "Must be a 40-character hex string"),
       });
       cliClientId = cliClientId.trim();
       cliPromptedClientId = true;
     }
 
     // Resolve or prompt for clientSecret
-    let cliClientSecret = cliSection?.oauth?.clientSecret;
+    let cliClientSecret = cliClientId === cliSection?.oauth?.clientId ? cliSection?.oauth?.clientSecret : undefined;
     let cliPromptedClientSecret = false;
     if (!cliClientSecret && cliPromptedClientId) {
       const entered = await prompter.text({

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -22,6 +22,7 @@ import {
   extractCliBootstrapToken,
 } from "../basecamp-cli.js";
 import { listBasecampAccountIds, resolveBasecampAccount, resolveDefaultBasecampAccountId } from "../config.js";
+import { isValidLaunchpadClientId } from "../oauth-credentials.js";
 import type { BasecampChannelConfig } from "../types.js";
 
 const channel = "basecamp" as const;
@@ -48,7 +49,10 @@ async function runOAuthLogin(params: { cfg: OpenClawConfig; accountId: string; p
   let promptedClientId: string | undefined;
   let promptedClientSecret: string | undefined;
 
-  if (!clientId) {
+  if (!isValidLaunchpadClientId(clientId)) {
+    // Discard paired secret when client ID is invalid (e.g. DCR placeholder)
+    clientId = undefined;
+    clientSecret = undefined;
     await prompter.note(
       "You'll need a Basecamp OAuth app. Register one at:\n" +
         "https://launchpad.37signals.com/integrations\n\n" +
@@ -59,7 +63,8 @@ async function runOAuthLogin(params: { cfg: OpenClawConfig; accountId: string; p
     );
     const enteredId = await prompter.text({
       message: "Enter your Basecamp OAuth app Client ID",
-      validate: (value: string) => (value?.trim() ? undefined : "Required"),
+      validate: (value: string) =>
+        isValidLaunchpadClientId(value?.trim()) ? undefined : "Must be a 40-character hex string",
     });
     clientId = String(enteredId).trim();
     promptedClientId = clientId;

--- a/src/basecamp-cli.ts
+++ b/src/basecamp-cli.ts
@@ -312,6 +312,8 @@ export function exportCliCredentials(baseUrl: string): CliCredentials | null {
     const clientRaw = readFileSync(join(CLI_CONFIG_DIR, "client.json"), "utf-8");
     const client = JSON.parse(clientRaw) as Record<string, unknown>;
     if (!client.client_id) return null;
+    const clientId = String(client.client_id);
+    if (!/^[0-9a-f]{40}$/.test(clientId)) return null;
 
     return {
       accessToken: String(entry.access_token),

--- a/src/basecamp-cli.ts
+++ b/src/basecamp-cli.ts
@@ -319,7 +319,7 @@ export function exportCliCredentials(baseUrl: string): CliCredentials | null {
       accessToken: String(entry.access_token),
       refreshToken: String(entry.refresh_token),
       expiresAt: typeof entry.expires_at === "number" ? entry.expires_at : 0,
-      clientId: String(client.client_id),
+      clientId,
       clientSecret: String(client.client_secret ?? ""),
     };
   } catch {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
 import { z } from "zod";
+import { isValidLaunchpadClientId } from "./oauth-credentials.js";
 import type {
   BasecampAccountConfig,
   BasecampChannelConfig,
@@ -272,8 +273,12 @@ export function resolveBasecampAccount(
     token,
     tokenSource,
     cliProfile: accountCfg.cliProfile,
-    oauthClientId: accountCfg.oauthClientId ?? section?.oauth?.clientId,
-    oauthClientSecret: accountCfg.oauthClientSecret ?? section?.oauth?.clientSecret,
+    oauthClientId: isValidLaunchpadClientId(accountCfg.oauthClientId)
+      ? accountCfg.oauthClientId
+      : section?.oauth?.clientId,
+    oauthClientSecret: isValidLaunchpadClientId(accountCfg.oauthClientId)
+      ? accountCfg.oauthClientSecret
+      : section?.oauth?.clientSecret,
     config: accountCfg,
   };
 }

--- a/src/oauth-credentials.ts
+++ b/src/oauth-credentials.ts
@@ -23,6 +23,51 @@ import type { ResolvedBasecampAccount } from "./types.js";
 
 const LAUNCHPAD_TOKEN_ENDPOINT = "https://launchpad.37signals.com/authorization/token";
 
+/**
+ * Built-in Launchpad OAuth client ID for the OpenClaw Basecamp plugin.
+ *
+ * This is a public identifier (like Basecamp CLI's launchpadClientID) — it
+ * identifies the app to Launchpad but is not a secret. The SDK negotiates
+ * PKCE automatically, so a client secret is optional.
+ */
+const DEFAULT_LAUNCHPAD_CLIENT_ID = "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef";
+
+/** Valid Launchpad OAuth client IDs are 40-character lowercase hex (SHA-1). */
+export function isValidLaunchpadClientId(id: string | undefined): id is string {
+  return !!id && /^[0-9a-f]{40}$/.test(id);
+}
+
+/**
+ * Resolve a valid OAuth client ID/secret pair.
+ *
+ * Priority: valid overrides → valid account config → env vars → built-in default.
+ * Client ID and secret are treated as a pair — if a source's client ID is
+ * invalid (e.g. DCR placeholder "dcr-id"), both are discarded and the next
+ * source is tried.
+ */
+function resolveOAuthClient(
+  account: ResolvedBasecampAccount,
+  overrides?: { clientId?: string; clientSecret?: string },
+): { clientId: string; clientSecret: string | undefined } {
+  // Overrides are validated too — callers (onboarding, hatch) may pass
+  // invalid values from config without realizing it.
+  if (isValidLaunchpadClientId(overrides?.clientId)) {
+    return { clientId: overrides.clientId, clientSecret: overrides.clientSecret };
+  }
+
+  if (isValidLaunchpadClientId(account.oauthClientId)) {
+    return { clientId: account.oauthClientId, clientSecret: account.oauthClientSecret };
+  }
+
+  const envClientId = process.env.LAUNCHPAD_CLIENT_ID;
+  const envClientSecret = process.env.LAUNCHPAD_CLIENT_SECRET;
+  if (isValidLaunchpadClientId(envClientId)) {
+    return { clientId: envClientId, clientSecret: envClientSecret };
+  }
+
+  return { clientId: DEFAULT_LAUNCHPAD_CLIENT_ID, clientSecret: undefined };
+}
+
 // ---------------------------------------------------------------------------
 // Token file path resolution
 // ---------------------------------------------------------------------------
@@ -60,12 +105,14 @@ export function createTokenManager(account: ResolvedBasecampAccount): TokenManag
 
   const store = new FileTokenStore(tokenFilePath);
 
+  const oauthClient = resolveOAuthClient(account);
+
   const tm = new TokenManager({
     store,
     refreshToken: sdkRefreshToken,
     tokenEndpoint: LAUNCHPAD_TOKEN_ENDPOINT,
-    clientId: account.oauthClientId,
-    clientSecret: account.oauthClientSecret,
+    clientId: oauthClient.clientId,
+    clientSecret: oauthClient.clientSecret,
     useLegacyFormat: true, // Launchpad
   });
 
@@ -99,14 +146,7 @@ export async function interactiveLogin(
   account: ResolvedBasecampAccount,
   overrides?: { clientId?: string; clientSecret?: string },
 ): Promise<OAuthToken> {
-  const clientId = overrides?.clientId ?? account.oauthClientId;
-  if (!clientId) {
-    throw new Error(
-      `No OAuth clientId available for account "${account.accountId}". ` +
-        `Set oauthClientId on the account or oauth.clientId at the channel level.`,
-    );
-  }
-  const clientSecret = overrides?.clientSecret ?? account.oauthClientSecret;
+  const oauthClient = resolveOAuthClient(account, overrides);
 
   const tokenFilePath = account.config.oauthTokenFile ?? resolveTokenFilePath(account.accountId);
 
@@ -127,8 +167,8 @@ export async function interactiveLogin(
   };
 
   return performInteractiveLogin({
-    clientId,
-    clientSecret,
+    clientId: oauthClient.clientId,
+    clientSecret: oauthClient.clientSecret,
     store,
     useLegacyFormat: true,
     openBrowser,

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -85,7 +85,7 @@ const oauthAccount = {
   personId: "42",
   token: "",
   tokenSource: "oauth" as const,
-  oauthClientId: "client123",
+  oauthClientId: "aabbccdd00112233445566778899aabbccddeeff",
   config: { personId: "42", oauthTokenFile: "/tmp/token.json" },
 };
 
@@ -198,6 +198,32 @@ describe("auth.login", () => {
 
     expect(resolveBasecampAccount).toHaveBeenCalledWith({}, undefined);
     expect(interactiveLogin).toHaveBeenCalled();
+  });
+
+  it("passes channel-level recovered client to interactiveLogin when per-account was invalid", async () => {
+    const channelRecoveredAccount = {
+      ...oauthAccount,
+      accountId: "poisoned",
+      // Simulates resolveBasecampAccount output: invalid per-account "dcr-id"
+      // was discarded, channel-level valid ID was selected instead.
+      oauthClientId: "1122334455667788990011223344556677889900",
+      oauthClientSecret: "channel-secret",
+    };
+    vi.mocked(resolveBasecampAccount).mockReturnValue(channelRecoveredAccount as any);
+    vi.mocked(interactiveLogin).mockResolvedValue({} as any);
+
+    await basecampChannel.auth!.login!({
+      cfg: {} as any,
+      accountId: "poisoned",
+      runtime: {} as any,
+    });
+
+    expect(interactiveLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oauthClientId: "1122334455667788990011223344556677889900",
+        oauthClientSecret: "channel-secret",
+      }),
+    );
   });
 });
 

--- a/tests/config-adapter.test.ts
+++ b/tests/config-adapter.test.ts
@@ -359,19 +359,20 @@ describe("resolveBasecampAccount — OAuth", () => {
   });
 
   it("resolves oauthClientId from per-account config", () => {
+    const validId = "aabbccdd00112233445566778899aabbccddeeff";
     const result = resolveBasecampAccount(
       cfg({
         accounts: {
           work: {
             personId: "42",
             oauthTokenFile: "/tmp/tok.json",
-            oauthClientId: "per-account-id",
+            oauthClientId: validId,
           },
         },
       }),
       "work",
     );
-    expect(result.oauthClientId).toBe("per-account-id");
+    expect(result.oauthClientId).toBe(validId);
   });
 
   it("resolves oauthClientId from channel-level oauth fallback", () => {
@@ -391,21 +392,63 @@ describe("resolveBasecampAccount — OAuth", () => {
     expect(result.oauthClientSecret).toBe("channel-secret");
   });
 
-  it("per-account oauthClientId overrides channel-level", () => {
+  it("valid per-account oauthClientId overrides channel-level", () => {
+    const validAccountId = "aabbccdd00112233445566778899aabbccddeeff";
     const result = resolveBasecampAccount(
       cfg({
         accounts: {
           work: {
             personId: "42",
             oauthTokenFile: "/tmp/tok.json",
-            oauthClientId: "override-id",
+            oauthClientId: validAccountId,
+            oauthClientSecret: "account-secret",
           },
         },
-        oauth: { clientId: "channel-level-id" },
+        oauth: { clientId: "1122334455667788990011223344556677889900", clientSecret: "channel-secret" },
       }),
       "work",
     );
-    expect(result.oauthClientId).toBe("override-id");
+    expect(result.oauthClientId).toBe(validAccountId);
+    expect(result.oauthClientSecret).toBe("account-secret");
+  });
+
+  it("invalid per-account oauthClientId falls through to valid channel-level", () => {
+    const channelId = "1122334455667788990011223344556677889900";
+    const result = resolveBasecampAccount(
+      cfg({
+        accounts: {
+          work: {
+            personId: "42",
+            oauthTokenFile: "/tmp/tok.json",
+            oauthClientId: "dcr-id",
+            oauthClientSecret: "stale-secret",
+          },
+        },
+        oauth: { clientId: channelId, clientSecret: "channel-secret" },
+      }),
+      "work",
+    );
+    expect(result.oauthClientId).toBe(channelId);
+    expect(result.oauthClientSecret).toBe("channel-secret");
+  });
+
+  it("valid per-account oauthClientId does not inherit unrelated channel-level secret", () => {
+    const validAccountId = "aabbccdd00112233445566778899aabbccddeeff";
+    const result = resolveBasecampAccount(
+      cfg({
+        accounts: {
+          work: {
+            personId: "42",
+            oauthTokenFile: "/tmp/tok.json",
+            oauthClientId: validAccountId,
+          },
+        },
+        oauth: { clientId: "1122334455667788990011223344556677889900", clientSecret: "channel-secret" },
+      }),
+      "work",
+    );
+    expect(result.oauthClientId).toBe(validAccountId);
+    expect(result.oauthClientSecret).toBeUndefined();
   });
 
   it("basecampAccountId field is preserved in config", () => {

--- a/tests/error-scenarios.test.ts
+++ b/tests/error-scenarios.test.ts
@@ -6,7 +6,7 @@
  *
  * Only auth-related functions remain in basecamp-cli.ts.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),

--- a/tests/error-scenarios.test.ts
+++ b/tests/error-scenarios.test.ts
@@ -477,7 +477,7 @@ describe("exportCliCredentials", () => {
         });
       }
       if (String(filePath).includes("client.json")) {
-        return JSON.stringify({ client_id: "cid-abc", client_secret: "cs-xyz" });
+        return JSON.stringify({ client_id: "abcdef0123456789abcdef0123456789abcdef01", client_secret: "cs-xyz" });
       }
       throw new Error("unexpected file");
     });
@@ -487,7 +487,7 @@ describe("exportCliCredentials", () => {
       accessToken: "at-123",
       refreshToken: "rt-456",
       expiresAt: 1770188269,
-      clientId: "cid-abc",
+      clientId: "abcdef0123456789abcdef0123456789abcdef01",
       clientSecret: "cs-xyz",
     });
   });
@@ -507,6 +507,32 @@ describe("exportCliCredentials", () => {
     vi.mocked(readFileSync).mockImplementation(() => {
       throw new Error("ENOENT");
     });
+    expect(exportCliCredentials("https://3.basecampapi.com")).toBeNull();
+  });
+
+  it("returns null when client_id is a DCR placeholder", () => {
+    vi.mocked(readFileSync).mockImplementation((filePath: any) => {
+      if (String(filePath).includes("credentials.json")) {
+        return JSON.stringify({
+          "https://3.basecampapi.com": { access_token: "at", refresh_token: "rt" },
+        });
+      }
+      return JSON.stringify({ client_id: "dcr-id", client_secret: "cs" });
+    });
+
+    expect(exportCliCredentials("https://3.basecampapi.com")).toBeNull();
+  });
+
+  it("returns null when client_id is not 40-char hex", () => {
+    vi.mocked(readFileSync).mockImplementation((filePath: any) => {
+      if (String(filePath).includes("credentials.json")) {
+        return JSON.stringify({
+          "https://3.basecampapi.com": { access_token: "at", refresh_token: "rt" },
+        });
+      }
+      return JSON.stringify({ client_id: "short-id", client_secret: "cs" });
+    });
+
     expect(exportCliCredentials("https://3.basecampapi.com")).toBeNull();
   });
 

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -40,6 +40,7 @@ vi.mock("../src/oauth-credentials.js", () => ({
   interactiveLogin: (...args: any[]) => mockInteractiveLogin(...args),
   resolveTokenFilePath: (...args: any[]) => mockResolveTokenFilePath(...args),
   createTokenManager: (...args: any[]) => mockCreateTokenManager(...args),
+  isValidLaunchpadClientId: (id: string | undefined) => !!id && /^[0-9a-f]{40}$/.test(id),
 }));
 
 // ---------------------------------------------------------------------------
@@ -146,7 +147,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       "How do you want to authenticate this identity?": "cli",
       "Account ID key for this identity (e.g. 'security', 'design-bot')": "security",
       "Map this identity to an agent?": "__skip__",
-      "OAuth client ID": "test-cid",
+      "OAuth client ID": "aabbccddee00112233445566778899aabbccddee",
       "Client Secret (leave blank to skip)": "",
     });
 
@@ -190,7 +191,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       "Account ID key for this identity (e.g. 'security', 'design-bot')": "bot-acct",
       "Map this identity to an agent?": "__enter__",
       "Agent ID to use this identity": "security-agent",
-      "OAuth client ID": "cid",
+      "OAuth client ID": "aabbccddee00112233445566778899aabbccddee",
       "Client Secret (leave blank to skip)": "",
     });
 
@@ -226,7 +227,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       "How do you want to authenticate this identity?": "cli",
       "Account ID key for this identity (e.g. 'security', 'design-bot')": "new-one",
       "Map this identity to an agent?": "__skip__",
-      "OAuth client ID": "cid",
+      "OAuth client ID": "aabbccddee00112233445566778899aabbccddee",
       "Client Secret (leave blank to skip)": "",
     });
 
@@ -239,6 +240,56 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
     const validate = textCall![0].validate;
     expect(validate!("existing")).toContain("already in use");
     expect(validate!("new-one")).toBeUndefined();
+
+    // Verify the OAuth client ID prompt rejects invalid values
+    const oauthPrompt = prompter.text.mock.calls.find((c: any) => c[0].message.includes("OAuth client ID"));
+    expect(oauthPrompt).toBeDefined();
+    const oauthValidate = oauthPrompt![0].validate;
+    expect(oauthValidate!("dcr-id")).toBe("Must be a 40-character hex string");
+    expect(oauthValidate!("")).toBe("Must be a 40-character hex string");
+    expect(oauthValidate!(undefined)).toBe("Must be a 40-character hex string");
+    expect(oauthValidate!("aabbccdd00112233445566778899aabbccddeeff")).toBeUndefined();
+  });
+
+  it("persists only valid prompted client ID into config", async () => {
+    const validPromptedId = "ff00112233445566778899aabbccddeeff001122";
+    mockCliProfileList.mockResolvedValue({ data: ["default"], raw: "" });
+    mockCliMe.mockResolvedValue({
+      data: {
+        identity: { id: 42, name: "Test", email_address: "t@t.com" },
+        accounts: [{ id: 1, name: "Co" }],
+      } as any,
+      raw: "",
+    });
+    mockInteractiveLogin.mockResolvedValue({
+      accessToken: "tok",
+      refreshToken: "ref",
+      tokenType: "Bearer",
+    });
+    mockDiscoverIdentity.mockResolvedValue({
+      identity: { id: 42, firstName: "Test", lastName: "", emailAddress: "t@t.com" },
+      accounts: [{ id: 1, name: "Co", product: "bc3" }],
+    });
+    mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
+
+    const { prompter } = createMockPrompter({
+      "How do you want to authenticate this identity?": "cli",
+      "Account ID key for this identity (e.g. 'security', 'design-bot')": "test-acct",
+      "Map this identity to an agent?": "__skip__",
+      "OAuth client ID": validPromptedId,
+      "Client Secret (leave blank to skip)": "",
+    });
+
+    const result = await hatchIdentity(cfg({}), prompter);
+
+    // The valid prompted ID should appear in channel-level oauth config
+    const section = (result.cfg.channels as any).basecamp;
+    expect(section.oauth?.clientId).toBe(validPromptedId);
+    // The prompted ID was passed to interactiveLogin as an override
+    expect(mockInteractiveLogin).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ clientId: validPromptedId }),
+    );
   });
 });
 
@@ -261,12 +312,12 @@ describe("hatchIdentity — Browser/OAuth path", () => {
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
-      "OAuth client ID": "test-cid",
+      "OAuth client ID": "aabbccddee00112233445566778899aabbccddee",
       "Account ID key for this identity (e.g. 'security', 'design-bot')": "oauth-acct",
       "Map this identity to an agent?": "__skip__",
     });
 
-    const baseCfg = cfg({ oauth: { clientId: "existing-cid" } });
+    const baseCfg = cfg({ oauth: { clientId: "aabbccdd00112233445566778899aabbccddeeff" } });
     const result = await hatchIdentity(baseCfg, prompter);
 
     expect(result.accountId).toBe("oauth-acct");
@@ -336,7 +387,7 @@ describe("hatchIdentity — Browser/OAuth path", () => {
       "Account ID key for this identity (e.g. 'security', 'design-bot')": "acct-one",
       "Map this identity to an agent?": "__skip__",
     });
-    const baseCfg = cfg({ oauth: { clientId: "cid" } });
+    const baseCfg = cfg({ oauth: { clientId: "1122334455667788990011223344556677889900" } });
     const r1 = await hatchIdentity(baseCfg, p1);
 
     // Second hatch run
@@ -371,10 +422,12 @@ describe("hatchIdentity — browser auth failure", () => {
     mockInteractiveLogin.mockRejectedValue(new Error("login failed"));
 
     const { prompter } = createMockPrompter({
-      "OAuth client ID": "cid",
+      "OAuth client ID": "aabbccddee00112233445566778899aabbccddee",
     });
 
-    await expect(hatchIdentity(cfg({ oauth: { clientId: "cid" } }), prompter)).rejects.toThrow("login failed");
+    await expect(
+      hatchIdentity(cfg({ oauth: { clientId: "1122334455667788990011223344556677889900" } }), prompter),
+    ).rejects.toThrow("login failed");
   });
 
   it("throws when discoverIdentity fails — no silent broken account", async () => {
@@ -387,10 +440,12 @@ describe("hatchIdentity — browser auth failure", () => {
     mockDiscoverIdentity.mockRejectedValue(new Error("network error"));
 
     const { prompter } = createMockPrompter({
-      "OAuth client ID": "cid",
+      "OAuth client ID": "aabbccddee00112233445566778899aabbccddee",
     });
 
-    await expect(hatchIdentity(cfg({ oauth: { clientId: "cid" } }), prompter)).rejects.toThrow("network error");
+    await expect(
+      hatchIdentity(cfg({ oauth: { clientId: "1122334455667788990011223344556677889900" } }), prompter),
+    ).rejects.toThrow("network error");
   });
 });
 
@@ -419,7 +474,7 @@ describe("hatchIdentity — token file relocation", () => {
       "Account ID key for this identity (e.g. 'security', 'design-bot')": "my-acct",
       "Map this identity to an agent?": "__skip__",
     });
-    const baseCfg = cfg({ oauth: { clientId: "cid" } });
+    const baseCfg = cfg({ oauth: { clientId: "1122334455667788990011223344556677889900" } });
 
     const result = await hatchIdentity(baseCfg, prompter);
 
@@ -449,7 +504,7 @@ describe("hatchIdentity — token file relocation", () => {
       "Account ID key for this identity (e.g. 'security', 'design-bot')": "my-acct",
       "Map this identity to an agent?": "__skip__",
     });
-    const baseCfg = cfg({ oauth: { clientId: "cid" } });
+    const baseCfg = cfg({ oauth: { clientId: "1122334455667788990011223344556677889900" } });
 
     const result = await hatchIdentity(baseCfg, prompter);
 

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -322,10 +322,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       "Client Secret (leave blank to skip)": "",
     });
 
-    const result = await hatchIdentity(
-      cfg({ oauth: { clientId: "dcr-id", clientSecret: "stale-secret" } }),
-      prompter,
-    );
+    const result = await hatchIdentity(cfg({ oauth: { clientId: "dcr-id", clientSecret: "stale-secret" } }), prompter);
 
     const section = (result.cfg.channels as any).basecamp;
     expect(section.oauth?.clientId).toBe(newClientId);

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -291,6 +291,47 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       expect.objectContaining({ clientId: validPromptedId }),
     );
   });
+
+  it("drops stale secret when replacing invalid client ID without entering new secret", async () => {
+    const newClientId = "ff00112233445566778899aabbccddeeff001122";
+    mockCliProfileList.mockResolvedValue({ data: ["default"], raw: "" });
+    mockCliMe.mockResolvedValue({
+      data: {
+        identity: { id: 42, name: "Test", email_address: "t@t.com" },
+        accounts: [{ id: 1, name: "Co" }],
+      } as any,
+      raw: "",
+    });
+    mockInteractiveLogin.mockResolvedValue({
+      accessToken: "tok",
+      refreshToken: "ref",
+      tokenType: "Bearer",
+    });
+    mockDiscoverIdentity.mockResolvedValue({
+      identity: { id: 42, firstName: "Test", lastName: "", emailAddress: "t@t.com" },
+      accounts: [{ id: 1, name: "Co", product: "bc3" }],
+    });
+    mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
+
+    // Config has an invalid client ID with a stale secret
+    const { prompter } = createMockPrompter({
+      "How do you want to authenticate this identity?": "cli",
+      "Account ID key for this identity (e.g. 'security', 'design-bot')": "test-acct",
+      "Map this identity to an agent?": "__skip__",
+      "OAuth client ID": newClientId,
+      "Client Secret (leave blank to skip)": "",
+    });
+
+    const result = await hatchIdentity(
+      cfg({ oauth: { clientId: "dcr-id", clientSecret: "stale-secret" } }),
+      prompter,
+    );
+
+    const section = (result.cfg.channels as any).basecamp;
+    expect(section.oauth?.clientId).toBe(newClientId);
+    // Stale secret from old invalid client must NOT survive
+    expect(section.oauth?.clientSecret).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/oauth-credentials.test.ts
+++ b/tests/oauth-credentials.test.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock @37signals/basecamp OAuth exports (these are being built in parallel)
 vi.mock("@37signals/basecamp/oauth", () => {
@@ -37,6 +37,7 @@ import {
   clearTokenManagers,
   createTokenManager,
   interactiveLogin,
+  isValidLaunchpadClientId,
   resolveTokenFilePath,
 } from "../src/oauth-credentials.js";
 import type { ResolvedBasecampAccount } from "../src/types.js";
@@ -48,7 +49,7 @@ function makeAccount(overrides?: Partial<ResolvedBasecampAccount>): ResolvedBase
     personId: "42",
     token: "",
     tokenSource: "oauth",
-    oauthClientId: "test-client-id",
+    oauthClientId: "aabbccdd00112233445566778899aabbccddeeff",
     oauthClientSecret: "test-client-secret",
     config: {
       personId: "42",
@@ -95,7 +96,7 @@ describe("createTokenManager", () => {
       expect.objectContaining({
         refreshToken,
         tokenEndpoint: "https://launchpad.37signals.com/authorization/token",
-        clientId: "test-client-id",
+        clientId: "aabbccdd00112233445566778899aabbccddeeff",
         clientSecret: "test-client-secret",
         useLegacyFormat: true,
       }),
@@ -149,28 +150,167 @@ describe("interactiveLogin", () => {
     });
     expect(performInteractiveLogin).toHaveBeenCalledWith(
       expect.objectContaining({
-        clientId: "test-client-id",
+        clientId: "aabbccdd00112233445566778899aabbccddeeff",
         clientSecret: "test-client-secret",
         useLegacyFormat: true,
       }),
     );
   });
 
-  it("uses override clientId when provided", async () => {
+  it("uses valid override clientId and clientSecret as a pair", async () => {
+    const overrideId = "ff00112233445566778899aabbccddeeff001122";
     const account = makeAccount();
-    await interactiveLogin(account, { clientId: "override-id" });
+    await interactiveLogin(account, { clientId: overrideId, clientSecret: "override-secret" });
     expect(performInteractiveLogin).toHaveBeenCalledWith(
       expect.objectContaining({
-        clientId: "override-id",
+        clientId: overrideId,
+        clientSecret: "override-secret",
+      }),
+    );
+  });
+
+  it("uses valid override clientId with undefined secret when only clientId overridden", async () => {
+    const overrideId = "ff00112233445566778899aabbccddeeff001122";
+    const account = makeAccount();
+    await interactiveLogin(account, { clientId: overrideId });
+    expect(performInteractiveLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: overrideId,
+        clientSecret: undefined,
+      }),
+    );
+  });
+
+  it("uses built-in default when clientId is missing", async () => {
+    const account = makeAccount({
+      oauthClientId: undefined,
+      oauthClientSecret: undefined,
+    });
+    await interactiveLogin(account);
+    expect(performInteractiveLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef",
+        clientSecret: undefined,
+      }),
+    );
+  });
+
+  it("uses built-in default when clientId is invalid (DCR placeholder), discards stale secret", async () => {
+    const account = makeAccount({
+      oauthClientId: "dcr-id",
+      oauthClientSecret: "stale-secret",
+    });
+    await interactiveLogin(account);
+    expect(performInteractiveLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef",
+        clientSecret: undefined,
+      }),
+    );
+  });
+
+  it("validates override clientId — invalid override falls through to account", async () => {
+    const account = makeAccount();
+    await interactiveLogin(account, { clientId: "dcr-id", clientSecret: "bad-secret" });
+    expect(performInteractiveLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "aabbccdd00112233445566778899aabbccddeeff",
         clientSecret: "test-client-secret",
       }),
     );
   });
 
-  it("throws when no clientId is available", async () => {
-    const account = makeAccount({
-      oauthClientId: undefined,
-    });
-    await expect(interactiveLogin(account)).rejects.toThrow("No OAuth clientId");
+  it("prefers env vars over built-in default", async () => {
+    const envId = "ff00112233445566778899aabbccddeeff001122";
+    process.env.LAUNCHPAD_CLIENT_ID = envId;
+    process.env.LAUNCHPAD_CLIENT_SECRET = "env-secret";
+    try {
+      const account = makeAccount({ oauthClientId: undefined, oauthClientSecret: undefined });
+      await interactiveLogin(account);
+      expect(performInteractiveLogin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientId: envId,
+          clientSecret: "env-secret",
+        }),
+      );
+    } finally {
+      delete process.env.LAUNCHPAD_CLIENT_ID;
+      delete process.env.LAUNCHPAD_CLIENT_SECRET;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidLaunchpadClientId
+// ---------------------------------------------------------------------------
+
+describe("isValidLaunchpadClientId", () => {
+  it("accepts valid 40-char hex", () => {
+    expect(isValidLaunchpadClientId("aabbccdd00112233445566778899aabbccddeeff")).toBe(true);
+  });
+
+  it("rejects undefined", () => {
+    expect(isValidLaunchpadClientId(undefined)).toBe(false);
+  });
+
+  it("rejects short strings", () => {
+    expect(isValidLaunchpadClientId("dcr-id")).toBe(false);
+  });
+
+  it("rejects uppercase hex", () => {
+    expect(isValidLaunchpadClientId("AABBCCDD00112233445566778899AABBCCDDEEFF")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTokenManager — fallback
+// ---------------------------------------------------------------------------
+
+describe("createTokenManager fallback", () => {
+  beforeEach(() => {
+    clearTokenManagers();
+    vi.mocked(TokenManager).mockClear();
+    vi.mocked(FileTokenStore).mockClear();
+  });
+
+  it("uses built-in default when oauthClientId is missing", () => {
+    const account = makeAccount({ oauthClientId: undefined, oauthClientSecret: undefined });
+    createTokenManager(account);
+    expect(TokenManager).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef",
+        clientSecret: undefined,
+      }),
+    );
+  });
+
+  it("uses built-in default when oauthClientId is invalid (discards stale secret)", () => {
+    const account = makeAccount({ oauthClientId: "dcr-id", oauthClientSecret: "stale" });
+    createTokenManager(account);
+    expect(TokenManager).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef",
+        clientSecret: undefined,
+      }),
+    );
+  });
+
+  it("prefers env vars over built-in default", () => {
+    const envId = "ff00112233445566778899aabbccddeeff001122";
+    process.env.LAUNCHPAD_CLIENT_ID = envId;
+    process.env.LAUNCHPAD_CLIENT_SECRET = "env-secret";
+    try {
+      const account = makeAccount({ oauthClientId: undefined, oauthClientSecret: undefined });
+      createTokenManager(account);
+      expect(TokenManager).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientId: envId,
+          clientSecret: "env-secret",
+        }),
+      );
+    } finally {
+      delete process.env.LAUNCHPAD_CLIENT_ID;
+      delete process.env.LAUNCHPAD_CLIENT_SECRET;
+    }
   });
 });

--- a/tests/oauth-credentials.test.ts
+++ b/tests/oauth-credentials.test.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock @37signals/basecamp OAuth exports (these are being built in parallel)
 vi.mock("@37signals/basecamp/oauth", () => {

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -75,6 +75,7 @@ const mockResolveTokenFilePath = vi.fn();
 vi.mock("../src/oauth-credentials.js", () => ({
   interactiveLogin: (...args: any[]) => mockInteractiveLogin(...args),
   resolveTokenFilePath: (...args: any[]) => mockResolveTokenFilePath(...args),
+  isValidLaunchpadClientId: (id: string | undefined) => !!id && /^[0-9a-f]{40}$/.test(id),
 }));
 
 // ---------------------------------------------------------------------------
@@ -325,7 +326,7 @@ describe("basecampOnboardingAdapter", () => {
       });
 
       const existingCfg = cfg({
-        oauth: { clientId: "existing-client", clientSecret: "existing-secret" },
+        oauth: { clientId: "aabbccdd00112233445566778899aabbccddeeff", clientSecret: "existing-secret" },
       });
 
       const result = await basecampOnboardingAdapter.configure({
@@ -368,7 +369,7 @@ describe("basecampOnboardingAdapter", () => {
           work: {
             personId: "42",
             oauthTokenFile: "/tmp/tokens/work.json",
-            oauthClientId: "per-account-client",
+            oauthClientId: "1122334455667788990011223344556677889900",
             oauthClientSecret: "per-account-secret",
           },
         },
@@ -385,7 +386,7 @@ describe("basecampOnboardingAdapter", () => {
 
       const account = result.cfg.channels.basecamp.accounts.work;
       // Per-account credentials must survive — TokenManager needs them for refresh
-      expect(account.oauthClientId).toBe("per-account-client");
+      expect(account.oauthClientId).toBe("1122334455667788990011223344556677889900");
       expect(account.oauthClientSecret).toBe("per-account-secret");
     });
   });
@@ -408,7 +409,7 @@ describe("basecampOnboardingAdapter", () => {
         accessToken: "cli-access-token",
         refreshToken: "cli-refresh-token",
         expiresAt: 1770188269,
-        clientId: "cli-client-id",
+        clientId: "aabbccddee00112233445566778899aabbccddee",
         clientSecret: "",
       });
 
@@ -436,7 +437,7 @@ describe("basecampOnboardingAdapter", () => {
       expect(account.basecampAccountId).toBe("100");
       expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
       // CLI-imported client creds go per-account, not channel-level
-      expect(account.oauthClientId).toBe("cli-client-id");
+      expect(account.oauthClientId).toBe("aabbccddee00112233445566778899aabbccddee");
       // Should import CLI credentials, not run interactiveLogin
       expect(mockInteractiveLogin).not.toHaveBeenCalled();
       expect(mockFileTokenStoreSave).toHaveBeenCalledWith(
@@ -544,7 +545,7 @@ describe("basecampOnboardingAdapter", () => {
         accessToken: "cli-token",
         refreshToken: "cli-refresh",
         expiresAt: 1770188269,
-        clientId: "cli-client-id",
+        clientId: "aabbccddee00112233445566778899aabbccddee",
         clientSecret: "",
       });
 
@@ -625,13 +626,13 @@ describe("basecampOnboardingAdapter", () => {
         accessToken: "cli-token",
         refreshToken: "cli-refresh",
         expiresAt: 1770188269,
-        clientId: "cli-client-id",
+        clientId: "aabbccddee00112233445566778899aabbccddee",
         clientSecret: "",
       });
 
       // Start with OAuth-configured account
       const existingCfg = cfg({
-        oauth: { clientId: "existing-client", clientSecret: "existing-secret" },
+        oauth: { clientId: "aabbccdd00112233445566778899aabbccddeeff", clientSecret: "existing-secret" },
       });
 
       // Select: auth method → "cli", profile → "dev" (auto-selected for single), "done"
@@ -652,10 +653,10 @@ describe("basecampOnboardingAdapter", () => {
       expect(account.cliProfile).toBe("dev");
       expect(account.oauthTokenFile).toBe("/tmp/tokens/default.json");
       // CLI-imported creds are per-account, not channel-level
-      expect(account.oauthClientId).toBe("cli-client-id");
+      expect(account.oauthClientId).toBe("aabbccddee00112233445566778899aabbccddee");
       // Existing channel-level OAuth must be preserved
       expect(result.cfg.channels.basecamp.oauth).toEqual({
-        clientId: "existing-client",
+        clientId: "aabbccdd00112233445566778899aabbccddeeff",
         clientSecret: "existing-secret",
       });
       expect(mockInteractiveLogin).not.toHaveBeenCalled();

--- a/tests/webhook-project-scoping.test.ts
+++ b/tests/webhook-project-scoping.test.ts
@@ -8,7 +8,7 @@ vi.mock("openclaw/plugin-sdk", () => ({
   },
 }));
 
-import { listBasecampAccountIds, resolveAccountForBucket, scopeWebhookProjects } from "../src/config.js";
+import { scopeWebhookProjects } from "../src/config.js";
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

- `openclaw channels login` sent `client_id=dcr-id` to Launchpad because the CLI credential import path blindly accepted a DCR-generated placeholder from `~/.config/basecamp/client.json`, and no downstream validation caught it before building the authorization URL.

- Four layers of fix, each guarding a different entry point:
  - **Import guard** (`basecamp-cli.ts`): `exportCliCredentials` rejects `client_id` values that aren't 40-char hex
  - **Config resolution** (`config.ts`): invalid per-account `oauthClientId` no longer shadows a valid channel-level `oauth.clientId`; client ID and secret travel as a pair (no cross-client secret inheritance)
  - **OAuth client resolution** (`oauth-credentials.ts`): new `resolveOAuthClient` with four-tier fallback — valid overrides → valid account config → env vars → built-in public client ID (PKCE, no secret required)
  - **Prompt validation** (`onboarding.ts`, `hatch.ts`): all OAuth client ID prompts enforce 40-char hex format

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1150 passed, 0 failed
- [x] `npm run lint` — 0 errors
- [ ] Manual: `openclaw channels login` with `oauthClientId: "dcr-id"` in config → auth URL uses built-in default client
- [ ] Manual: hatch wizard with no configured client → prompts and validates format