### PR TITLE
Require configured OAuth client — no hardcoded fallback

### DIFF
--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -19,7 +19,12 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { normalizeAccountId } from "openclaw/plugin-sdk";
 import { cliMe, cliProfileList } from "../basecamp-cli.js";
 import { listBasecampAccountIds } from "../config.js";
-import { interactiveLogin, isValidLaunchpadClientId, resolveTokenFilePath } from "../oauth-credentials.js";
+import {
+  interactiveLogin,
+  isValidLaunchpadClientId,
+  OAUTH_SETUP_GUIDANCE,
+  resolveTokenFilePath,
+} from "../oauth-credentials.js";
 import type { BasecampChannelConfig, ResolvedBasecampAccount } from "../types.js";
 
 type WizardPrompter = {
@@ -84,6 +89,7 @@ async function discoverViaBrowser(
   let clientId = isValidLaunchpadClientId(section?.oauth?.clientId) ? section!.oauth!.clientId : undefined;
   let promptedClientId = false;
   if (!clientId) {
+    await prompter.note(OAUTH_SETUP_GUIDANCE, "OAuth setup");
     clientId = await prompter.text({
       message: "OAuth client ID",
       validate: (v) => (isValidLaunchpadClientId(v?.trim()) ? undefined : "Must be a 40-character hex string"),
@@ -322,6 +328,7 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
     let cliClientId = isValidLaunchpadClientId(cliSection?.oauth?.clientId) ? cliSection!.oauth!.clientId : undefined;
     let cliPromptedClientId = false;
     if (!cliClientId) {
+      await prompter.note(OAUTH_SETUP_GUIDANCE, "OAuth setup");
       cliClientId = await prompter.text({
         message: "OAuth client ID",
         validate: (v) => (isValidLaunchpadClientId(v?.trim()) ? undefined : "Must be a 40-character hex string"),

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -22,7 +22,7 @@ import {
   extractCliBootstrapToken,
 } from "../basecamp-cli.js";
 import { listBasecampAccountIds, resolveBasecampAccount, resolveDefaultBasecampAccountId } from "../config.js";
-import { isValidLaunchpadClientId } from "../oauth-credentials.js";
+import { isValidLaunchpadClientId, OAUTH_SETUP_GUIDANCE } from "../oauth-credentials.js";
 import type { BasecampChannelConfig } from "../types.js";
 
 const channel = "basecamp" as const;
@@ -53,14 +53,7 @@ async function runOAuthLogin(params: { cfg: OpenClawConfig; accountId: string; p
     // Discard paired secret when client ID is invalid (e.g. DCR placeholder)
     clientId = undefined;
     clientSecret = undefined;
-    await prompter.note(
-      "You'll need a Basecamp OAuth app. Register one at:\n" +
-        "https://launchpad.37signals.com/integrations\n\n" +
-        "When creating the app, set the redirect URI to:\n" +
-        "http://localhost:14923/callback\n\n" +
-        "You can leave the other fields as defaults.",
-      "OAuth setup",
-    );
+    await prompter.note(OAUTH_SETUP_GUIDANCE, "OAuth setup");
     const enteredId = await prompter.text({
       message: "Enter your Basecamp OAuth app Client ID",
       validate: (value: string) =>

--- a/src/oauth-credentials.ts
+++ b/src/oauth-credentials.ts
@@ -23,14 +23,13 @@ import type { ResolvedBasecampAccount } from "./types.js";
 
 const LAUNCHPAD_TOKEN_ENDPOINT = "https://launchpad.37signals.com/authorization/token";
 
-/**
- * Built-in Launchpad OAuth client ID for the OpenClaw Basecamp plugin.
- *
- * This is a public identifier (like Basecamp CLI's launchpadClientID) — it
- * identifies the app to Launchpad but is not a secret. The SDK negotiates
- * PKCE automatically, so a client secret is optional.
- */
-const DEFAULT_LAUNCHPAD_CLIENT_ID = "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef";
+/** Guidance note shown before prompting for OAuth client credentials. */
+export const OAUTH_SETUP_GUIDANCE =
+  "You'll need a Basecamp OAuth app. Register one at:\n" +
+  "https://launchpad.37signals.com/integrations\n\n" +
+  "When creating the app, set the redirect URI to:\n" +
+  "http://localhost:14923/callback\n\n" +
+  "You can leave the other fields as defaults.";
 
 /** Valid Launchpad OAuth client IDs are 40-character lowercase hex (SHA-1). */
 export function isValidLaunchpadClientId(id: string | undefined): id is string {
@@ -40,7 +39,7 @@ export function isValidLaunchpadClientId(id: string | undefined): id is string {
 /**
  * Resolve a valid OAuth client ID/secret pair.
  *
- * Priority: valid overrides → valid account config → env vars → built-in default.
+ * Priority: valid overrides → valid account config → env vars → throws.
  * Client ID and secret are treated as a pair — if a source's client ID is
  * invalid (e.g. DCR placeholder "dcr-id"), both are discarded and the next
  * source is tried.
@@ -65,7 +64,11 @@ function resolveOAuthClient(
     return { clientId: envClientId, clientSecret: envClientSecret };
   }
 
-  return { clientId: DEFAULT_LAUNCHPAD_CLIENT_ID, clientSecret: undefined };
+  throw new Error(
+    "No OAuth client configured for Basecamp. " +
+      "Run `openclaw channels add` and select Basecamp to set up credentials, " +
+      "or set the LAUNCHPAD_CLIENT_ID and LAUNCHPAD_CLIENT_SECRET environment variables.",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -41,6 +41,7 @@ vi.mock("../src/oauth-credentials.js", () => ({
   resolveTokenFilePath: (...args: any[]) => mockResolveTokenFilePath(...args),
   createTokenManager: (...args: any[]) => mockCreateTokenManager(...args),
   isValidLaunchpadClientId: (id: string | undefined) => !!id && /^[0-9a-f]{40}$/.test(id),
+  OAUTH_SETUP_GUIDANCE: "test guidance",
 }));
 
 // ---------------------------------------------------------------------------

--- a/tests/oauth-credentials.test.ts
+++ b/tests/oauth-credentials.test.ts
@@ -181,32 +181,20 @@ describe("interactiveLogin", () => {
     );
   });
 
-  it("uses built-in default when clientId is missing", async () => {
+  it("throws when no client configured", async () => {
     const account = makeAccount({
       oauthClientId: undefined,
       oauthClientSecret: undefined,
     });
-    await interactiveLogin(account);
-    expect(performInteractiveLogin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        clientId: "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef",
-        clientSecret: undefined,
-      }),
-    );
+    await expect(interactiveLogin(account)).rejects.toThrow(/No OAuth client configured/);
   });
 
-  it("uses built-in default when clientId is invalid (DCR placeholder), discards stale secret", async () => {
+  it("throws when clientId is invalid (DCR placeholder)", async () => {
     const account = makeAccount({
       oauthClientId: "dcr-id",
       oauthClientSecret: "stale-secret",
     });
-    await interactiveLogin(account);
-    expect(performInteractiveLogin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        clientId: "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef",
-        clientSecret: undefined,
-      }),
-    );
+    await expect(interactiveLogin(account)).rejects.toThrow(/No OAuth client configured/);
   });
 
   it("validates override clientId — invalid override falls through to account", async () => {
@@ -220,7 +208,7 @@ describe("interactiveLogin", () => {
     );
   });
 
-  it("prefers env vars over built-in default", async () => {
+  it("uses env vars when account has no client configured", async () => {
     const envId = "ff00112233445566778899aabbccddeeff001122";
     process.env.LAUNCHPAD_CLIENT_ID = envId;
     process.env.LAUNCHPAD_CLIENT_SECRET = "env-secret";
@@ -273,29 +261,17 @@ describe("createTokenManager fallback", () => {
     vi.mocked(FileTokenStore).mockClear();
   });
 
-  it("uses built-in default when oauthClientId is missing", () => {
+  it("throws when oauthClientId is missing", () => {
     const account = makeAccount({ oauthClientId: undefined, oauthClientSecret: undefined });
-    createTokenManager(account);
-    expect(TokenManager).toHaveBeenCalledWith(
-      expect.objectContaining({
-        clientId: "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef",
-        clientSecret: undefined,
-      }),
-    );
+    expect(() => createTokenManager(account)).toThrow(/No OAuth client configured/);
   });
 
-  it("uses built-in default when oauthClientId is invalid (discards stale secret)", () => {
+  it("throws when oauthClientId is invalid (DCR placeholder)", () => {
     const account = makeAccount({ oauthClientId: "dcr-id", oauthClientSecret: "stale" });
-    createTokenManager(account);
-    expect(TokenManager).toHaveBeenCalledWith(
-      expect.objectContaining({
-        clientId: "37275cfbf73bb6a1140c9f255eefd9f6ac9be2ef",
-        clientSecret: undefined,
-      }),
-    );
+    expect(() => createTokenManager(account)).toThrow(/No OAuth client configured/);
   });
 
-  it("prefers env vars over built-in default", () => {
+  it("uses env vars when account has no client configured", () => {
     const envId = "ff00112233445566778899aabbccddeeff001122";
     process.env.LAUNCHPAD_CLIENT_ID = envId;
     process.env.LAUNCHPAD_CLIENT_SECRET = "env-secret";

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -76,6 +76,7 @@ vi.mock("../src/oauth-credentials.js", () => ({
   interactiveLogin: (...args: any[]) => mockInteractiveLogin(...args),
   resolveTokenFilePath: (...args: any[]) => mockResolveTokenFilePath(...args),
   isValidLaunchpadClientId: (id: string | undefined) => !!id && /^[0-9a-f]{40}$/.test(id),
+  OAUTH_SETUP_GUIDANCE: "test guidance",
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Remove the built-in `DEFAULT_LAUNCHPAD_CLIENT_ID` constant. Launchpad's discovery endpoint doesn't advertise PKCE support, so the default client (with no secret) always fails token exchange with `Missing client_secret query parameter`.
- `resolveOAuthClient` now throws a clear error directing users to `openclaw channels add` or the `LAUNCHPAD_CLIENT_ID` env var when no valid client is found after checking overrides → account config → env vars.
- Both hatch wizard paths (browser OAuth and CLI-chains-into-OAuth) now show Launchpad registration guidance before prompting for the client ID, matching the existing onboarding flow.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1151 passed
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] Manual: `openclaw channels login --account default` with no client → clear error message
- [x] Manual: `openclaw channels add` → wizard shows Launchpad URL, prompts for client ID/secret, login succeeds