### PR TITLE
Upgrade @37signals/basecamp SDK to v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@37signals/openclaw-basecamp",
       "version": "0.1.0",
       "dependencies": {
-        "@37signals/basecamp": "git+https://github.com/basecamp/basecamp-sdk.git#b0939b8fd8f38023dd3ee1975daf6a761bf3d83c",
+        "@37signals/basecamp": "git+https://github.com/basecamp/basecamp-sdk.git#92026d65a1561dcc220b9bd4e9e8460e08a92045",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@37signals/basecamp": {
-      "version": "0.2.2",
-      "resolved": "git+ssh://git@github.com/basecamp/basecamp-sdk.git#b0939b8fd8f38023dd3ee1975daf6a761bf3d83c",
-      "integrity": "sha512-KUaxVVUvrJQd66XM+ejfiDFW9nBiUQU+WdNqyguWjhgnR3q7J+2sSgWiJF8/xtXcqq3N58+sg9CNmTd7WBPRJQ==",
+      "version": "0.4.0",
+      "resolved": "git+ssh://git@github.com/basecamp/basecamp-sdk.git#92026d65a1561dcc220b9bd4e9e8460e08a92045",
+      "integrity": "sha512-jbX35kqbHJTiGKSdynElw+petURHntgQeJGowGHOPMKmIH5vv1nQBcE+yssCRLZS3+jHin6L48HBviRiSL9CIg==",
       "dependencies": {
         "openapi-fetch": "^0.17.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,6 +1143,15 @@
         "scripts/actions/documentation"
       ]
     },
+    "node_modules/@buape/carbon/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@buape/carbon/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
@@ -1259,6 +1268,15 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
+    },
+    "node_modules/@discordjs/voice/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@37signals/basecamp": "git+https://github.com/basecamp/basecamp-sdk.git#b0939b8fd8f38023dd3ee1975daf6a761bf3d83c",
+    "@37signals/basecamp": "git+https://github.com/basecamp/basecamp-sdk.git#92026d65a1561dcc220b9bd4e9e8460e08a92045",
     "zod": "^4.3.6"
   },
   "overrides": {

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -243,6 +243,10 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         const { bucketId, recordingId, type, limit } = rawParams as ReadHistoryInput;
         const effectiveLimit = Math.min(limit ?? DEFAULT_HISTORY_LIMIT, 50);
 
+        // Use raw GET for a single page — the API returns oldest-first, and
+        // .slice(-N) gives the most recent N from whatever page we get.
+        // Typed list methods auto-paginate with maxItems truncating from the
+        // front, which would return the oldest N instead.
         const path =
           type === "campfire"
             ? `/buckets/${bucketId}/chats/${recordingId}/lines.json`

--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -7,10 +7,17 @@
 
 import { homedir } from "node:os";
 import { resolve as pathResolve } from "node:path";
-import { type BasecampClient, BasecampError, createBasecampClient, errorFromResponse } from "@37signals/basecamp";
+import {
+  type BasecampClient,
+  type BasecampHooks,
+  BasecampError,
+  createBasecampClient,
+  errorFromResponse,
+  isBasecampError,
+} from "@37signals/basecamp";
 import type { ResolvedBasecampAccount } from "./types.js";
 
-export { BasecampError };
+export { BasecampError, isBasecampError };
 export type { BasecampClient };
 
 // ---------------------------------------------------------------------------
@@ -31,11 +38,21 @@ export function getClient(account: ResolvedBasecampAccount): BasecampClient {
   const basecampAccountId = resolveNumericAccountId(account);
   const tokenProvider = resolveTokenProvider(account);
 
+  const hooks: BasecampHooks = {
+    onRetry(info, _attempt, error, delayMs) {
+      console.warn(
+        `[basecamp:sdk:${cacheKey}] retry #${info.attempt} ${info.method} ${info.url} ` +
+          `(${error.message}, backoff ${delayMs}ms)`,
+      );
+    },
+  };
+
   const client = createBasecampClient({
     accountId: basecampAccountId,
     accessToken: tokenProvider,
     enableRetry: true,
     enableCache: false,
+    hooks,
   });
 
   clientCache.set(cacheKey, client);

--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -9,8 +9,8 @@ import { homedir } from "node:os";
 import { resolve as pathResolve } from "node:path";
 import {
   type BasecampClient,
-  type BasecampHooks,
   BasecampError,
+  type BasecampHooks,
   createBasecampClient,
   errorFromResponse,
   isBasecampError,

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -13,7 +13,7 @@
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { BASECAMP_TEXT_CHUNK_LIMIT, chunkMarkdownText } from "./adapters/outbound.js";
-import { BasecampError } from "./basecamp-client.js";
+import { isBasecampError } from "./basecamp-client.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
 import {
   resolveBasecampAccount,
@@ -362,7 +362,7 @@ function resolveEngagePolicy(cfg: OpenClawConfig, bucketId: string): BasecampEng
  */
 function classifyDispatchError(err: unknown): string {
   // SDK errors carry a structured code
-  if (err instanceof BasecampError) {
+  if (isBasecampError(err)) {
     switch (err.code) {
       case "auth_required":
       case "forbidden":

--- a/src/inbound/activity.ts
+++ b/src/inbound/activity.ts
@@ -43,6 +43,8 @@ export async function pollActivityFeed(opts: ActivityPollerOptions): Promise<Act
 
   const fetchTimeline = async () => {
     const client = getClient(account);
+    // SDK returns TimelineEvent[] (generated type with all-optional fields).
+    // Cast to our richer hand-rolled type which matches the actual API shape.
     return client.reports.progress() as Promise<BasecampActivityEvent[]>;
   };
 

--- a/src/inbound/reconciliation.ts
+++ b/src/inbound/reconciliation.ts
@@ -12,6 +12,7 @@
  *   - 24h TTL on promotions
  */
 
+import type { BasecampClient } from "../basecamp-client.js";
 import type { BasecampActivityEvent, BasecampRecordableType, ResolvedBasecampAccount } from "../types.js";
 import { EventDedup } from "./dedup.js";
 import { isNormalizableKind, recordableTypeForKind, resolveEventKind } from "./normalize.js";
@@ -58,6 +59,8 @@ export interface ReconciliationResult {
   gapsByType: Record<string, number>;
   /** Currently promoted types after applying promotion logic. */
   promotions: PromotionEntry[];
+  /** True when results were capped by maxItems — gap counts are sampled, not exhaustive. */
+  sampled: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,7 +69,7 @@ export interface ReconciliationResult {
 
 export interface ReconciliationOptions {
   account: ResolvedBasecampAccount;
-  client: any;
+  client: BasecampClient;
   dedup: EventDedup;
   maxItems?: number;
   windowMs?: number;
@@ -81,6 +84,8 @@ export interface ReconciliationOptions {
 }
 
 export async function runReconciliation(opts: ReconciliationOptions): Promise<ReconciliationResult> {
+  // maxItems caps SDK pagination (v0.4.0+). 250 covers a typical 24h window
+  // while preventing runaway pagination on high-activity accounts.
   const { account, client, dedup, log, maxItems = 250, windowMs = 24 * 60 * 60 * 1000, gapThreshold = 3 } = opts;
 
   const cutoff = new Date(Date.now() - windowMs).toISOString();
@@ -97,7 +102,17 @@ export async function runReconciliation(opts: ReconciliationOptions): Promise<Re
       unseen: 0,
       gapsByType: {},
       promotions: opts.promotionState?.promotions ?? [],
+      sampled: false,
     };
+  }
+
+  // Detect truncation: if we got exactly maxItems results, the feed was
+  // likely capped by pagination. Gap counts are sampled, not exhaustive.
+  const sampled = rawEvents.length >= maxItems;
+  if (sampled) {
+    log?.warn?.(
+      `[${account.accountId}] reconciliation: results capped at ${maxItems} events — gap detection is sampled`,
+    );
   }
 
   let replayed = 0;
@@ -135,10 +150,11 @@ export async function runReconciliation(opts: ReconciliationOptions): Promise<Re
   });
 
   log?.info?.(
-    `[${account.accountId}] reconciliation: replayed=${replayed} unseen=${unseen} promoted=${promotions.length}`,
+    `[${account.accountId}] reconciliation: replayed=${replayed} unseen=${unseen} promoted=${promotions.length}` +
+      (sampled ? " sampled=true" : ""),
   );
 
-  return { replayed, unseen, gapsByType, promotions };
+  return { replayed, unseen, gapsByType, promotions, sampled };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/inbound/reconciliation.ts
+++ b/src/inbound/reconciliation.ts
@@ -106,7 +106,7 @@ export async function runReconciliation(opts: ReconciliationOptions): Promise<Re
     };
   }
 
-  // Detect truncation: if we got exactly maxItems results, the feed was
+  // Detect truncation: if we got at least maxItems results, the feed was
   // likely capped by pagination. Gap counts are sampled, not exhaustive.
   const sampled = rawEvents.length >= maxItems;
   if (sampled) {

--- a/src/inbound/safety-net.ts
+++ b/src/inbound/safety-net.ts
@@ -14,7 +14,7 @@
  */
 
 import crypto from "node:crypto";
-import { BasecampError } from "../basecamp-client.js";
+import { isBasecampError } from "../basecamp-client.js";
 import type {
   BasecampEventKind,
   BasecampInboundMessage,
@@ -26,7 +26,7 @@ import { EventDedup } from "./dedup.js";
 import { invalidateDockCache, resolveDockToolIds } from "./dock-cache.js";
 
 function isStaleResourceError(err: unknown): boolean {
-  if (err instanceof BasecampError) {
+  if (isBasecampError(err)) {
     return err.httpStatus === 404 || err.httpStatus === 410 || err.code === "not_found";
   }
   return false;

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -444,6 +444,52 @@ describe("reconciliation", () => {
     expect(result.promotions).toEqual([entry]);
   });
 
+  // ---- sampled flag ----
+
+  it("sampled=false when event count is below maxItems", async () => {
+    const client = makeClient([
+      activityEvent({ id: 1, kind: "todo_created" }),
+      activityEvent({ id: 2, kind: "todo_completed" }),
+    ]);
+    const result = await runReconciliation({
+      account,
+      client,
+      dedup,
+      maxItems: 10,
+      log,
+    });
+    expect(result.sampled).toBe(false);
+  });
+
+  it("sampled=true when event count equals maxItems", async () => {
+    const events = Array.from({ length: 5 }, (_, i) =>
+      activityEvent({ id: i + 1, kind: "todo_created" }),
+    );
+    const client = makeClient(events);
+    const result = await runReconciliation({
+      account,
+      client,
+      dedup,
+      maxItems: 5,
+      log,
+    });
+    expect(result.sampled).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("capped at 5 events"),
+    );
+  });
+
+  it("sampled=false on fetch error", async () => {
+    const client = makeClient(new Error("boom"));
+    const result = await runReconciliation({
+      account,
+      client,
+      dedup,
+      log,
+    });
+    expect(result.sampled).toBe(false);
+  });
+
   it("secondary key matching detects cross-source dedup", async () => {
     // Register an event via secondary key (as if it came through webhooks)
     const recordingId = "12345";

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -462,9 +462,7 @@ describe("reconciliation", () => {
   });
 
   it("sampled=true when event count equals maxItems", async () => {
-    const events = Array.from({ length: 5 }, (_, i) =>
-      activityEvent({ id: i + 1, kind: "todo_created" }),
-    );
+    const events = Array.from({ length: 5 }, (_, i) => activityEvent({ id: i + 1, kind: "todo_created" }));
     const client = makeClient(events);
     const result = await runReconciliation({
       account,
@@ -474,9 +472,7 @@ describe("reconciliation", () => {
       log,
     });
     expect(result.sampled).toBe(true);
-    expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("capped at 5 events"),
-    );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("capped at 5 events"));
   });
 
   it("sampled=false on fetch error", async () => {

--- a/tests/safety-net.test.ts
+++ b/tests/safety-net.test.ts
@@ -32,7 +32,10 @@ vi.mock("../src/basecamp-client.js", () => {
       this.retryable = false;
     }
   }
-  return { BasecampError };
+  return {
+    BasecampError,
+    isBasecampError: (err: unknown): err is InstanceType<typeof BasecampError> => err instanceof BasecampError,
+  };
 });
 
 import { invalidateDockCache, resolveDockToolIds } from "../src/inbound/dock-cache.js";


### PR DESCRIPTION
## Summary

- Bump `@37signals/basecamp` from v0.2.2 (`b0939b8f`) to v0.4.0 (`92026d65`), pinned to exact commit SHA
- Wire `BasecampHooks.onRetry` for SDK retry visibility (429/503 retries now logged with account context)
- Replace `instanceof BasecampError` with `isBasecampError()` guard in dispatch and safety-net (module-instance safe)
- Type the reconciliation `client` parameter (`any` → `BasecampClient`)
- Surface pagination truncation in reconciliation via new `sampled` flag on `ReconciliationResult`
- Document `maxItems` behavioral change (now enforced by SDK, was previously ignored)

### Intentionally unchanged

- **read_history**: kept raw GET — typed list methods truncate from the front (`maxItems` gives oldest N), breaking the single-page/tail contract that returns the most recent N
- **Webhook signature verification**: SDK's `verifyWebhookSignature` uses a different wire format; plugin's Stripe-style protocol with replay protection is correct for Basecamp's actual format
- **retry.ts**: plugin's transport-layer retry for `TypeError` is orthogonal to SDK's 429/503 retry
- **rawOrThrow**: still needed for `client.raw.GET` calls with no typed service equivalent

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1156 passed, 10 skipped (smoke tests), 0 failed
- [x] Lockfile, manifest, and installed package all resolve to v0.4.0 at `92026d65`
- [ ] Run smoke tests against a live Basecamp account before release