### PR TITLE
Persist dmPolicy and engage defaults in onboarding wizard

### DIFF
--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -51,6 +51,7 @@ import {
 import { listBasecampAccountIds, resolveBasecampAccount, resolveDefaultBasecampAccountId } from "../config.js";
 import { isValidLaunchpadClientId, OAUTH_SETUP_GUIDANCE } from "../oauth-credentials.js";
 import type { BasecampChannelConfig } from "../types.js";
+import { DEFAULT_ENGAGE } from "../types.js";
 
 const channel = "basecamp" as const;
 
@@ -405,6 +406,8 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
         basecamp: {
           ...section,
           enabled: true,
+          dmPolicy: (section as any)?.dmPolicy ?? "pairing",
+          engage: (section as any)?.engage ?? DEFAULT_ENGAGE,
           ...(channelOauth ? { oauth: channelOauth } : {}),
           accounts: {
             ...accounts,


### PR DESCRIPTION
## Summary
- `dmPolicy` was never written to config by the wizard. Runtime default is `"pairing"` so behavior was correct, but the absence confused users inspecting their setup.
- `engage` (engagement types that trigger agent response) was `optional()` with no `.default()` and never prompted for. Runtime falls back to `DEFAULT_ENGAGE` in `dispatch.ts`, but config was silent.
- Both are now written to the channel config in step 7 with their runtime defaults, making the active policy visible.

## Test plan
- [x] Fresh onboarding produces config with `dmPolicy: "pairing"` and `engage: ["dm", "mention", "assignment", "checkin"]`
- [x] Re-running onboarding with existing dmPolicy/engage preserves the existing values