### PR TITLE
Improve DM policy and readings polling observability

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -144,13 +144,13 @@ export async function dispatchBasecampEvent(msg: BasecampInboundMessage, options
   if (engagement === "dm") {
     const dmPolicy = resolveBasecampDmPolicy(cfg);
     if (dmPolicy === "disabled") {
-      slog.debug("dm_policy_dropped", { correlationId, sender: msg.sender.id, policy: "disabled" });
+      slog.info("dm_policy_dropped", { correlationId, sender: msg.sender.id, policy: "disabled" });
       return false;
     }
     if (dmPolicy === "pairing" || dmPolicy === "allowlist") {
       const allowFrom = resolveBasecampAllowFrom(cfg);
       if (!allowFrom.includes(msg.sender.id)) {
-        slog.debug("dm_policy_dropped", {
+        slog.info("dm_policy_dropped", {
           correlationId,
           sender: msg.sender.id,
           policy: dmPolicy,

--- a/src/inbound/readings.ts
+++ b/src/inbound/readings.ts
@@ -55,8 +55,14 @@ export async function pollReadings(opts: ReadingsPollerOptions): Promise<Reading
     ? await withCircuitBreaker(opts.circuitBreaker.instance, opts.circuitBreaker.key, fetchReadings)
     : await fetchReadings();
 
+  if (data === undefined || data === null) {
+    log?.info?.(`[${account.accountId}] readings returned no body (HTTP 204)`);
+    return { events: [], newestAt: undefined, processedSgids: [] };
+  }
+
   const unreads = data?.unreads;
   if (!Array.isArray(unreads) || unreads.length === 0) {
+    log?.debug?.(`[${account.accountId}] readings returned empty unreads array`);
     return { events: [], newestAt: undefined, processedSgids: [] };
   }
 

--- a/src/inbound/readings.ts
+++ b/src/inbound/readings.ts
@@ -56,12 +56,16 @@ export async function pollReadings(opts: ReadingsPollerOptions): Promise<Reading
     : await fetchReadings();
 
   if (data === undefined || data === null) {
-    log?.info?.(`[${account.accountId}] readings returned no body (HTTP 204)`);
+    log?.info?.(`[${account.accountId}] readings returned no response body`);
     return { events: [], newestAt: undefined, processedSgids: [] };
   }
 
   const unreads = data?.unreads;
-  if (!Array.isArray(unreads) || unreads.length === 0) {
+  if (!Array.isArray(unreads)) {
+    log?.warn?.(`[${account.accountId}] readings returned unexpected unreads type: ${typeof unreads}`);
+    return { events: [], newestAt: undefined, processedSgids: [] };
+  }
+  if (unreads.length === 0) {
     log?.debug?.(`[${account.accountId}] readings returned empty unreads array`);
     return { events: [], newestAt: undefined, processedSgids: [] };
   }


### PR DESCRIPTION
## Summary
- `dm_policy_dropped` in dispatch.ts promoted from `debug` to `info` level. This is the #1 signal operators need when Pings aren't arriving — `debug` is often disabled in production, making DM policy drops invisible.
- Readings poller now distinguishes HTTP 204 (no body — API returned nothing) from an empty unreads array (inbox is empty), logging at `info` vs `debug` respectively. Operators can now tell "API returned nothing" from "inbox is empty."

## Test plan
- [x] Verify `dm_policy_dropped` appears at info level in logs
- [x] Verify readings 204 response logs distinctly from empty unreads array
- [x] All existing tests pass