### PR TITLE
Add bootstrap guards for activity/readings pollers

### DIFF
--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -263,6 +263,20 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
       : { mode: "primary" }),
   });
 
+  /** Mark processed readings as read via the Basecamp API. */
+  async function markReadingsRead(sgids: string[]): Promise<void> {
+    if (sgids.length === 0) return;
+    const markRead = async () => {
+      const client = getClient(account);
+      await rawOrThrow(
+        await client.raw.PUT("/my/unreads.json" as any, {
+          body: { readables: sgids } as any,
+        }),
+      );
+    };
+    await withCircuitBreaker(cb, "readings:mark-read", markRead);
+  }
+
   while (!abortSignal?.aborted) {
     const now = Date.now();
     const activityDue = now - lastActivityPoll >= activityIntervalMs + activityBackoff;
@@ -285,9 +299,11 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
           if (result.newestAt) {
             cursors.setActivitySince(result.newestAt);
             await saveCursorsWithRetry(cursors, slog);
+            activityBootstrapped = true;
+            slog.info("poll_bootstrap", { feed: "activity", fetched: result.events.length, cursor: result.newestAt });
+          } else {
+            slog.info("poll_bootstrap_empty", { feed: "activity", fetched: result.events.length });
           }
-          activityBootstrapped = true;
-          slog.info("poll_bootstrap", { feed: "activity", fetched: result.events.length, cursor: result.newestAt ?? "none" });
           recordPollSuccess(account.accountId, "activity", 0, 0);
         } else {
           let dispatched = 0;
@@ -354,27 +370,19 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
 
         if (!readingsBootstrapped) {
           // First run / cleared cursor: advance cursor and mark-read without emitting events
-          if (result.processedSgids.length > 0) {
-            try {
-              const markRead = async () => {
-                const client = getClient(account);
-                await rawOrThrow(
-                  await client.raw.PUT("/my/unreads.json" as any, {
-                    body: { readables: result.processedSgids } as any,
-                  }),
-                );
-              };
-              await withCircuitBreaker(cb, "readings:mark-read", markRead);
-            } catch (err) {
-              slog.warn("readings_mark_read_failed", { error: String(err) });
-            }
+          try {
+            await markReadingsRead(result.processedSgids);
+          } catch (err) {
+            slog.warn("readings_mark_read_failed", { error: String(err) });
           }
           if (result.newestAt) {
             cursors.setReadingsSince(result.newestAt);
             await saveCursorsWithRetry(cursors, slog);
+            readingsBootstrapped = true;
+            slog.info("poll_bootstrap", { feed: "readings", fetched: result.events.length, cursor: result.newestAt });
+          } else {
+            slog.info("poll_bootstrap_empty", { feed: "readings", fetched: result.events.length });
           }
-          readingsBootstrapped = true;
-          slog.info("poll_bootstrap", { feed: "readings", fetched: result.events.length, cursor: result.newestAt ?? "none" });
           recordPollSuccess(account.accountId, "readings", 0, 0);
         } else {
           let dispatched = 0;
@@ -401,21 +409,11 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
           }
 
           // Mark processed readings as read so they don't reappear
-          if (result.processedSgids.length > 0) {
-            try {
-              const markRead = async () => {
-                const client = getClient(account);
-                await rawOrThrow(
-                  await client.raw.PUT("/my/unreads.json" as any, {
-                    body: { readables: result.processedSgids } as any,
-                  }),
-                );
-              };
-              await withCircuitBreaker(cb, "readings:mark-read", markRead);
-              slog.debug("readings_marked_read", { count: result.processedSgids.length });
-            } catch (err) {
-              slog.warn("readings_mark_read_failed", { error: String(err) });
-            }
+          try {
+            await markReadingsRead(result.processedSgids);
+            slog.debug("readings_marked_read", { count: result.processedSgids.length });
+          } catch (err) {
+            slog.warn("readings_mark_read_failed", { error: String(err) });
           }
 
           if (result.newestAt) {

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -314,7 +314,10 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
               ? EventDedup.secondaryKey(event.meta.recordingId, event.meta.eventKind, event.createdAt)
               : undefined;
 
-            if (dedup.isDuplicate(event.dedupKey, secondaryKey)) { deduped++; continue; }
+            if (dedup.isDuplicate(event.dedupKey, secondaryKey)) {
+              deduped++;
+              continue;
+            }
             if (isSelfMessage(event.sender.id, account)) continue;
 
             try {
@@ -393,7 +396,10 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
               ? EventDedup.secondaryKey(event.meta.recordingId, event.meta.eventKind, event.createdAt)
               : undefined;
 
-            if (dedup.isDuplicate(event.dedupKey, secondaryKey)) { deduped++; continue; }
+            if (dedup.isDuplicate(event.dedupKey, secondaryKey)) {
+              deduped++;
+              continue;
+            }
             if (isSelfMessage(event.sender.id, account)) continue;
 
             try {
@@ -461,7 +467,10 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
         let dropped = 0;
         let deduped = 0;
         for (const event of result.events) {
-          if (dedup.isDuplicate(event.dedupKey)) { deduped++; continue; }
+          if (dedup.isDuplicate(event.dedupKey)) {
+            deduped++;
+            continue;
+          }
           if (isSelfMessage(event.sender.id, account)) continue;
 
           try {

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -159,6 +159,12 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
     slog.warn("cursors_load_failed", { error: String(err) });
   }
 
+  // Bootstrap flags for activity and readings: when cursors are absent
+  // (first run or cleared state), the first poll records the cursor
+  // without emitting events — same pattern as assignmentsBootstrapped.
+  let activityBootstrapped = cursors.get().activitySince !== undefined;
+  let readingsBootstrapped = cursors.get().readingsSince !== undefined;
+
   // Circuit breaker: fail fast when Basecamp API is persistently down.
   // One CB instance per account; separate keys per polling source.
   const cbConfig = resolveCircuitBreakerConfig(cfg as any);
@@ -274,38 +280,51 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
           log,
         });
 
-        let dispatched = 0;
-        let dropped = 0;
-        for (const event of result.events) {
-          const secondaryKey = event.meta.recordingId
-            ? EventDedup.secondaryKey(event.meta.recordingId, event.meta.eventKind, event.createdAt)
-            : undefined;
-
-          if (dedup.isDuplicate(event.dedupKey, secondaryKey)) continue;
-          if (isSelfMessage(event.sender.id, account)) continue;
-
-          try {
-            const delivered = await onEvent(event);
-            if (delivered) {
-              dispatched++;
-            } else {
-              dropped++;
-            }
-          } catch (err) {
-            slog.error("dispatch_error", { feed: "activity", key: event.dedupKey, error: String(err) });
+        if (!activityBootstrapped) {
+          // First run / cleared cursor: record cursor without emitting events
+          if (result.newestAt) {
+            cursors.setActivitySince(result.newestAt);
+            await saveCursorsWithRetry(cursors, slog);
           }
+          activityBootstrapped = true;
+          slog.info("poll_bootstrap", { feed: "activity", fetched: result.events.length, cursor: result.newestAt ?? "none" });
+          recordPollSuccess(account.accountId, "activity", 0, 0);
+        } else {
+          let dispatched = 0;
+          let dropped = 0;
+          let deduped = 0;
+          for (const event of result.events) {
+            const secondaryKey = event.meta.recordingId
+              ? EventDedup.secondaryKey(event.meta.recordingId, event.meta.eventKind, event.createdAt)
+              : undefined;
+
+            if (dedup.isDuplicate(event.dedupKey, secondaryKey)) { deduped++; continue; }
+            if (isSelfMessage(event.sender.id, account)) continue;
+
+            try {
+              const delivered = await onEvent(event);
+              if (delivered) {
+                dispatched++;
+              } else {
+                dropped++;
+              }
+            } catch (err) {
+              slog.error("dispatch_error", { feed: "activity", key: event.dedupKey, error: String(err) });
+            }
+          }
+
+          if (result.newestAt) {
+            cursors.setActivitySince(result.newestAt);
+            await saveCursorsWithRetry(cursors, slog);
+          }
+
+          if (result.events.length > 0) {
+            slog.info("poll_cycle", { feed: "activity", fetched: result.events.length, dispatched, dropped, deduped });
+          }
+
+          recordPollSuccess(account.accountId, "activity", dispatched, dropped);
         }
 
-        if (result.newestAt) {
-          cursors.setActivitySince(result.newestAt);
-          await saveCursorsWithRetry(cursors, slog);
-        }
-
-        if (dispatched > 0 || dropped > 0) {
-          slog.info("poll_dispatched", { feed: "activity", total: result.events.length, dispatched, dropped });
-        }
-
-        recordPollSuccess(account.accountId, "activity", dispatched, dropped);
         recordDedupSize(account.accountId, dedup.size);
         syncCircuitBreakerMetrics("activity");
         activityBackoff = 0;
@@ -333,56 +352,84 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
           log,
         });
 
-        let dispatched = 0;
-        let dropped = 0;
-        for (const event of result.events) {
-          const secondaryKey = event.meta.recordingId
-            ? EventDedup.secondaryKey(event.meta.recordingId, event.meta.eventKind, event.createdAt)
-            : undefined;
-
-          if (dedup.isDuplicate(event.dedupKey, secondaryKey)) continue;
-          if (isSelfMessage(event.sender.id, account)) continue;
-
-          try {
-            const delivered = await onEvent(event);
-            if (delivered) {
-              dispatched++;
-            } else {
-              dropped++;
+        if (!readingsBootstrapped) {
+          // First run / cleared cursor: advance cursor and mark-read without emitting events
+          if (result.processedSgids.length > 0) {
+            try {
+              const markRead = async () => {
+                const client = getClient(account);
+                await rawOrThrow(
+                  await client.raw.PUT("/my/unreads.json" as any, {
+                    body: { readables: result.processedSgids } as any,
+                  }),
+                );
+              };
+              await withCircuitBreaker(cb, "readings:mark-read", markRead);
+            } catch (err) {
+              slog.warn("readings_mark_read_failed", { error: String(err) });
             }
-          } catch (err) {
-            slog.error("dispatch_error", { feed: "readings", key: event.dedupKey, error: String(err) });
           }
-        }
-
-        // Mark processed readings as read so they don't reappear
-        if (result.processedSgids.length > 0) {
-          try {
-            const markRead = async () => {
-              const client = getClient(account);
-              await rawOrThrow(
-                await client.raw.PUT("/my/unreads.json" as any, {
-                  body: { readables: result.processedSgids } as any,
-                }),
-              );
-            };
-            await withCircuitBreaker(cb, "readings:mark-read", markRead);
-            slog.debug("readings_marked_read", { count: result.processedSgids.length });
-          } catch (err) {
-            slog.warn("readings_mark_read_failed", { error: String(err) });
+          if (result.newestAt) {
+            cursors.setReadingsSince(result.newestAt);
+            await saveCursorsWithRetry(cursors, slog);
           }
+          readingsBootstrapped = true;
+          slog.info("poll_bootstrap", { feed: "readings", fetched: result.events.length, cursor: result.newestAt ?? "none" });
+          recordPollSuccess(account.accountId, "readings", 0, 0);
+        } else {
+          let dispatched = 0;
+          let dropped = 0;
+          let deduped = 0;
+          for (const event of result.events) {
+            const secondaryKey = event.meta.recordingId
+              ? EventDedup.secondaryKey(event.meta.recordingId, event.meta.eventKind, event.createdAt)
+              : undefined;
+
+            if (dedup.isDuplicate(event.dedupKey, secondaryKey)) { deduped++; continue; }
+            if (isSelfMessage(event.sender.id, account)) continue;
+
+            try {
+              const delivered = await onEvent(event);
+              if (delivered) {
+                dispatched++;
+              } else {
+                dropped++;
+              }
+            } catch (err) {
+              slog.error("dispatch_error", { feed: "readings", key: event.dedupKey, error: String(err) });
+            }
+          }
+
+          // Mark processed readings as read so they don't reappear
+          if (result.processedSgids.length > 0) {
+            try {
+              const markRead = async () => {
+                const client = getClient(account);
+                await rawOrThrow(
+                  await client.raw.PUT("/my/unreads.json" as any, {
+                    body: { readables: result.processedSgids } as any,
+                  }),
+                );
+              };
+              await withCircuitBreaker(cb, "readings:mark-read", markRead);
+              slog.debug("readings_marked_read", { count: result.processedSgids.length });
+            } catch (err) {
+              slog.warn("readings_mark_read_failed", { error: String(err) });
+            }
+          }
+
+          if (result.newestAt) {
+            cursors.setReadingsSince(result.newestAt);
+            await saveCursorsWithRetry(cursors, slog);
+          }
+
+          if (result.events.length > 0) {
+            slog.info("poll_cycle", { feed: "readings", fetched: result.events.length, dispatched, dropped, deduped });
+          }
+
+          recordPollSuccess(account.accountId, "readings", dispatched, dropped);
         }
 
-        if (result.newestAt) {
-          cursors.setReadingsSince(result.newestAt);
-          await saveCursorsWithRetry(cursors, slog);
-        }
-
-        if (dispatched > 0 || dropped > 0) {
-          slog.info("poll_dispatched", { feed: "readings", total: result.events.length, dispatched, dropped });
-        }
-
-        recordPollSuccess(account.accountId, "readings", dispatched, dropped);
         recordDedupSize(account.accountId, dedup.size);
         syncCircuitBreakerMetrics("readings");
         readingsBackoff = 0;
@@ -414,8 +461,9 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
 
         let dispatched = 0;
         let dropped = 0;
+        let deduped = 0;
         for (const event of result.events) {
-          if (dedup.isDuplicate(event.dedupKey)) continue;
+          if (dedup.isDuplicate(event.dedupKey)) { deduped++; continue; }
           if (isSelfMessage(event.sender.id, account)) continue;
 
           try {
@@ -436,8 +484,8 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
         cursors.setCustom("assignmentIds", JSON.stringify([...result.knownIds]));
         await saveCursorsWithRetry(cursors, slog);
 
-        if (dispatched > 0 || dropped > 0) {
-          slog.info("poll_dispatched", { feed: "assignments", total: result.events.length, dispatched, dropped });
+        if (result.events.length > 0) {
+          slog.info("poll_cycle", { feed: "assignments", fetched: result.events.length, dispatched, dropped, deduped });
         }
 
         recordPollSuccess(account.accountId, "assignments", dispatched, dropped);

--- a/src/inbound/poller.ts
+++ b/src/inbound/poller.ts
@@ -415,11 +415,13 @@ export async function startCompositePoller(opts: CompositePollerOptions): Promis
           }
 
           // Mark processed readings as read so they don't reappear
-          try {
-            await markReadingsRead(result.processedSgids);
-            slog.debug("readings_marked_read", { count: result.processedSgids.length });
-          } catch (err) {
-            slog.warn("readings_mark_read_failed", { error: String(err) });
+          if (result.processedSgids.length > 0) {
+            try {
+              await markReadingsRead(result.processedSgids);
+              slog.debug("readings_marked_read", { count: result.processedSgids.length });
+            } catch (err) {
+              slog.warn("readings_mark_read_failed", { error: String(err) });
+            }
           }
 
           if (result.newestAt) {

--- a/tests/poller-dispatch.test.ts
+++ b/tests/poller-dispatch.test.ts
@@ -184,6 +184,11 @@ describe("poller dispatch flow", () => {
   });
 
   it("dispatches activity events and advances cursor", async () => {
+    // Pre-seed activity cursor so poller is past bootstrap phase
+    const cursors = new CursorStore(tmpDir, baseAccount.accountId);
+    cursors.setActivitySince("2025-06-01T11:00:00Z");
+    await cursors.save();
+
     const ev = makeEvent("act", { createdAt: "2025-06-01T12:00:00Z" });
     activityEvents = [ev];
 
@@ -211,6 +216,11 @@ describe("poller dispatch flow", () => {
   });
 
   it("dispatches readings events and triggers mark-read", async () => {
+    // Pre-seed readings cursor so poller is past bootstrap phase
+    const cursors = new CursorStore(tmpDir, baseAccount.accountId);
+    cursors.setReadingsSince("2025-06-01T11:00:00Z");
+    await cursors.save();
+
     const ev = makeEvent("read");
     readingsEvents = [ev];
     readingsSgids = ["sgid://bc3/Recording/1"];
@@ -239,6 +249,11 @@ describe("poller dispatch flow", () => {
   });
 
   it("dedup filters duplicate dedupKeys", async () => {
+    // Pre-seed activity cursor so poller is past bootstrap phase
+    const cursors = new CursorStore(tmpDir, baseAccount.accountId);
+    cursors.setActivitySince("2025-06-01T11:00:00Z");
+    await cursors.save();
+
     // Same event object returned on every poll cycle — same dedupKey
     const ev = makeEvent("dup");
     activityEvents = [ev];
@@ -268,6 +283,11 @@ describe("poller dispatch flow", () => {
   });
 
   it("self-message filtering: sender.id === account.personId → not dispatched", async () => {
+    // Pre-seed activity cursor so poller is past bootstrap phase
+    const cursors = new CursorStore(tmpDir, baseAccount.accountId);
+    cursors.setActivitySince("2025-06-01T11:00:00Z");
+    await cursors.save();
+
     const ev = makeEvent("self", { senderId: "99" }); // matches account.personId
     activityEvents = [ev];
 


### PR DESCRIPTION
## Summary
- **Bootstrap guards:** When activity/readings cursors are absent (first run or cleared state), the first poll cycle now records the cursor without emitting events — same pattern as the existing `assignmentsBootstrapped` guard. Prevents historical event flood when dedup/cursor state is cleared.
- **Poll cycle logging:** All three polling loops (activity, readings, assignments) now log a `poll_cycle` event whenever events were fetched, including a `deduped` counter. Previously only logged when `dispatched > 0 || dropped > 0`, meaning a poll fetching 20 events that are all deduped produced zero log output.
- Existing tests updated to pre-seed cursors so they test dispatch behavior, not bootstrap behavior.

## Test plan
- [x] Start poller with no stored cursors → first cycle logs `poll_bootstrap`, emits zero events, advances cursor
- [x] Second cycle processes events normally
- [x] Poll cycle with all events deduped produces a `poll_cycle` log line with `deduped` count
- [x] All existing poller tests pass