### PR TITLE
Fix onboarding wizard writing Launchpad identity instead of Basecamp person ID

### DIFF
--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -73,6 +73,7 @@ async function chooseAuthMethod(prompter: WizardPrompter, cliAvailable: boolean)
 
 type OAuthDiscoveryResult = {
   info?: AuthorizationInfo;
+  accessToken: string;
   clientId: string;
   clientSecret?: string;
   tempTokenFile: string;
@@ -136,7 +137,7 @@ async function discoverViaBrowser(
 
   const tempTokenFile = resolveTokenFilePath(tempKey);
 
-  return { info, clientId, clientSecret, tempTokenFile, promptedClientId, promptedClientSecret };
+  return { info, accessToken: token.accessToken, clientId, clientSecret, tempTokenFile, promptedClientId, promptedClientSecret };
 }
 
 // ---------------------------------------------------------------------------
@@ -269,7 +270,6 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
       "Detected identity",
     );
 
-    personId = String(info.identity.id);
     displayName = `${info.identity.firstName} ${info.identity.lastName}`;
 
     // Select Basecamp account from discovered accounts
@@ -277,6 +277,17 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
       info.accounts as Array<{ id: number; name: string; product?: string }>,
       prompter,
     );
+
+    // Resolve per-account person ID — never use the Launchpad identity ID,
+    // which would silently break self-message filtering.
+    if (basecampAccountId) {
+      try {
+        const { resolvePersonId } = await import("../basecamp-client.js");
+        personId = await resolvePersonId(basecampAccountId, browserResult.accessToken);
+      } catch {
+        // Will fall through to manual entry at step 4
+      }
+    }
   } else {
     const cliResult = await discoverViaCli(profileNames, prompter);
 
@@ -367,20 +378,22 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
 
     const cliOauthToken = await interactiveLogin(tempAccount, { clientId: cliClientId, clientSecret: cliClientSecret });
 
-    // Verify OAuth identity matches CLI-discovered identity
-    try {
-      const oauthInfo = await discoverIdentity(cliOauthToken.accessToken);
-      const oauthPersonId = String(oauthInfo.identity.id);
-      if (oauthPersonId !== personId) {
-        personId = oauthPersonId;
-        displayName = `${oauthInfo.identity.firstName} ${oauthInfo.identity.lastName}`;
-        attachableSgid = undefined; // CLI SGID invalid for different identity
+    // Resolve per-account person ID (CLI identity may be Launchpad-scoped)
+    if (basecampAccountId) {
+      try {
+        const { resolvePersonId } = await import("../basecamp-client.js");
+        const resolvedId = await resolvePersonId(basecampAccountId, cliOauthToken.accessToken);
+        if (resolvedId !== personId) {
+          personId = resolvedId;
+          attachableSgid = undefined; // CLI SGID may not match different person
+        }
+      } catch {
+        // Non-fatal: proceed with CLI-discovered identity
       }
-    } catch {
-      // Non-fatal: proceed with CLI-discovered identity
     }
 
     oauthResult = {
+      accessToken: cliOauthToken.accessToken,
       clientId: cliClientId,
       clientSecret: cliClientSecret,
       tempTokenFile: resolveTokenFilePath(tempKey),

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -137,7 +137,15 @@ async function discoverViaBrowser(
 
   const tempTokenFile = resolveTokenFilePath(tempKey);
 
-  return { info, accessToken: token.accessToken, clientId, clientSecret, tempTokenFile, promptedClientId, promptedClientSecret };
+  return {
+    info,
+    accessToken: token.accessToken,
+    clientId,
+    clientSecret,
+    tempTokenFile,
+    promptedClientId,
+    promptedClientSecret,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -405,7 +405,7 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
     };
   }
 
-  // Step 5: Resolve personId — prompt if not set by resolvePersonId or browser discovery
+  // Step 5: Resolve personId — prompt if not set by resolvePersonId
   if (!personId) {
     const entered = await prompter.text({
       message: "Basecamp person ID for this identity",

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -398,6 +398,11 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
       } catch {
         // Non-fatal: proceed with CLI-discovered identity
       }
+    } else {
+      // No Basecamp account selected — CLI-discovered personId may be Launchpad-scoped.
+      // Clear it so step 4 prompts for manual entry.
+      personId = undefined;
+      attachableSgid = undefined;
     }
 
     oauthResult = {
@@ -516,5 +521,5 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
     },
   };
 
-  return { cfg: next, accountId, personId, personaMapping };
+  return { cfg: next, accountId, personId: personId!, personaMapping };
 }

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -291,7 +291,9 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
     if (basecampAccountId) {
       try {
         const { resolvePersonId } = await import("../basecamp-client.js");
-        personId = await resolvePersonId(basecampAccountId, browserResult.accessToken);
+        const resolved = await resolvePersonId(basecampAccountId, browserResult.accessToken);
+        personId = resolved.id;
+        if (resolved.name) displayName = resolved.name;
       } catch {
         // Will fall through to manual entry at step 5
       }
@@ -383,7 +385,9 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
     if (basecampAccountId) {
       try {
         const { resolvePersonId } = await import("../basecamp-client.js");
-        personId = await resolvePersonId(basecampAccountId, cliOauthToken.accessToken);
+        const resolved = await resolvePersonId(basecampAccountId, cliOauthToken.accessToken);
+        personId = resolved.id;
+        if (resolved.name) displayName = resolved.name;
         attachableSgid = undefined; // CLI SGID does not apply to per-account person
       } catch {
         // Non-fatal: fall through to step 5 manual prompt

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -293,7 +293,7 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
         const { resolvePersonId } = await import("../basecamp-client.js");
         personId = await resolvePersonId(basecampAccountId, browserResult.accessToken);
       } catch {
-        // Will fall through to manual entry at step 4
+        // Will fall through to manual entry at step 5
       }
     }
   } else {
@@ -306,7 +306,7 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
       );
 
       // Don't set personId from CLI — it's the Launchpad identity ID, not the
-      // per-account person ID. resolvePersonId in the CLI OAuth chain (or step 4
+      // per-account person ID. resolvePersonId in the CLI OAuth chain (or step 5
       // manual prompt) will set the correct value.
       displayName = cliResult.identity.name;
       attachableSgid = cliResult.identity.attachable_sgid;
@@ -379,20 +379,17 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
 
     const cliOauthToken = await interactiveLogin(tempAccount, { clientId: cliClientId, clientSecret: cliClientSecret });
 
-    // Resolve per-account person ID (CLI identity may be Launchpad-scoped)
+    // Resolve per-account person ID (CLI identity is Launchpad-scoped, not per-account)
     if (basecampAccountId) {
       try {
         const { resolvePersonId } = await import("../basecamp-client.js");
-        const resolvedId = await resolvePersonId(basecampAccountId, cliOauthToken.accessToken);
-        if (resolvedId !== personId) {
-          personId = resolvedId;
-          attachableSgid = undefined; // CLI SGID may not match different person
-        }
+        personId = await resolvePersonId(basecampAccountId, cliOauthToken.accessToken);
+        attachableSgid = undefined; // CLI SGID does not apply to per-account person
       } catch {
-        // Non-fatal: fall through to step 4 manual prompt
+        // Non-fatal: fall through to step 5 manual prompt
       }
     }
-    // When basecampAccountId is absent, personId stays unset — step 4 prompts.
+    // When basecampAccountId is absent, personId stays unset — step 5 prompts.
 
     oauthResult = {
       accessToken: cliOauthToken.accessToken,

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -305,7 +305,9 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
         "Detected identity",
       );
 
-      personId = String(cliResult.identity.id);
+      // Don't set personId from CLI — it's the Launchpad identity ID, not the
+      // per-account person ID. resolvePersonId in the CLI OAuth chain (or step 4
+      // manual prompt) will set the correct value.
       displayName = cliResult.identity.name;
       attachableSgid = cliResult.identity.attachable_sgid;
       cliProfile = cliResult.profile;
@@ -318,16 +320,7 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
     }
   }
 
-  // Step 4: Resolve personId — confirm or prompt for manual entry
-  if (!personId) {
-    personId = await prompter.text({
-      message: "Basecamp person ID for this identity",
-      validate: (v) => (v?.trim() ? undefined : "Required"),
-    });
-    personId = personId.trim();
-  }
-
-  // Step 5: Prompt for unique accountId key
+  // Step 4: Prompt for unique accountId key
   const existingIds = new Set(listBasecampAccountIds(cfg));
   const accountId = normalizeAccountId(
     await prompter.text({
@@ -396,14 +389,10 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
           attachableSgid = undefined; // CLI SGID may not match different person
         }
       } catch {
-        // Non-fatal: proceed with CLI-discovered identity
+        // Non-fatal: fall through to step 4 manual prompt
       }
-    } else {
-      // No Basecamp account selected — CLI-discovered personId may be Launchpad-scoped.
-      // Clear it so step 4 prompts for manual entry.
-      personId = undefined;
-      attachableSgid = undefined;
     }
+    // When basecampAccountId is absent, personId stays unset — step 4 prompts.
 
     oauthResult = {
       accessToken: cliOauthToken.accessToken,
@@ -414,6 +403,16 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
       promptedClientSecret: cliPromptedClientSecret,
     };
   }
+
+  // Step 5: Resolve personId — prompt if not set by resolvePersonId or browser discovery
+  if (!personId) {
+    const entered = await prompter.text({
+      message: "Basecamp person ID for this identity",
+      validate: (v) => (v?.trim() ? undefined : "Required"),
+    });
+    personId = entered.trim();
+  }
+  const finalPersonId: string = personId;
 
   // Relocate OAuth temp token file (and companion client file) to final
   // {accountId}-based path. Try rename first; fall back to copy+unlink
@@ -483,7 +482,7 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
 
   // Build account entry — include auth-method fields, omit the other method's fields
   const accountEntry: Record<string, unknown> = {
-    personId,
+    personId: finalPersonId,
     enabled: true,
     ...(displayName ? { displayName } : {}),
     ...(attachableSgid ? { attachableSgid } : {}),
@@ -521,5 +520,5 @@ export async function hatchIdentity(cfg: OpenClawConfig, prompter: WizardPrompte
     },
   };
 
-  return { cfg: next, accountId, personId: personId!, personaMapping };
+  return { cfg: next, accountId, personId: finalPersonId, personaMapping };
 }

--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -154,7 +154,12 @@ async function readTokenFile(filePath: string): Promise<string> {
  * and is needed for self-message filtering.
  */
 export async function resolvePersonId(basecampAccountId: string, accessToken: string): Promise<string> {
-  const client = createBasecampClient({ accountId: basecampAccountId, accessToken });
+  const client = createBasecampClient({
+    accountId: basecampAccountId,
+    accessToken,
+    enableRetry: true,
+    enableCache: false,
+  });
   const profile = await client.people.me();
   return String(profile.id);
 }

--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -141,6 +141,25 @@ async function readTokenFile(filePath: string): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
+// Per-account person ID resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the per-account Basecamp person ID for the authenticated user.
+ * Creates a temporary client scoped to the given Basecamp account number.
+ *
+ * This returns the **per-account** person ID (e.g. 51190969), which differs
+ * from the global Launchpad identity ID (e.g. 28147435) returned by
+ * discoverIdentity(). The per-account ID is what appears in activity events
+ * and is needed for self-message filtering.
+ */
+export async function resolvePersonId(basecampAccountId: string, accessToken: string): Promise<string> {
+  const client = createBasecampClient({ accountId: basecampAccountId, accessToken });
+  const profile = await client.people.me();
+  return String(profile.id);
+}
+
+// ---------------------------------------------------------------------------
 // ID coercion helper
 // ---------------------------------------------------------------------------
 

--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -145,15 +145,18 @@ async function readTokenFile(filePath: string): Promise<string> {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the per-account Basecamp person ID for the authenticated user.
+ * Resolve the per-account Basecamp person profile for the authenticated user.
  * Creates a temporary client scoped to the given Basecamp account number.
  *
- * This returns the **per-account** person ID (e.g. 51190969), which differs
- * from the global Launchpad identity ID (e.g. 28147435) returned by
- * discoverIdentity(). The per-account ID is what appears in activity events
- * and is needed for self-message filtering.
+ * Returns the **per-account** person ID (e.g. 51190969) and display name,
+ * which differ from the global Launchpad identity returned by discoverIdentity().
+ * The per-account ID is what appears in activity events and is needed for
+ * self-message filtering; the name is used for mention stripping.
  */
-export async function resolvePersonId(basecampAccountId: string, accessToken: string): Promise<string> {
+export async function resolvePersonId(
+  basecampAccountId: string,
+  accessToken: string,
+): Promise<{ id: string; name: string }> {
   const client = createBasecampClient({
     accountId: basecampAccountId,
     accessToken,
@@ -161,7 +164,7 @@ export async function resolvePersonId(basecampAccountId: string, accessToken: st
     enableCache: false,
   });
   const profile = await client.people.me();
-  return String(profile.id);
+  return { id: String(profile.id), name: (profile as any).name ?? "" };
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -172,7 +172,8 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
     expect(accounts.security).toBeDefined();
     expect(accounts.security.personId).toBe("42");
     expect(accounts.security.displayName).toBe("Jeremy");
-    expect(accounts.security.attachableSgid).toBe("sgid://x");
+    // attachableSgid is cleared when resolvePersonId returns a different ID than CLI discovery
+    expect(accounts.security.attachableSgid).toBeUndefined();
     expect(accounts.security.cliProfile).toBe("default");
     // CLI path chains into OAuth — oauthTokenFile should be set
     expect(accounts.security.oauthTokenFile).toBe("/tmp/tokens/security.json");

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -65,7 +65,7 @@ vi.mock("@37signals/basecamp", () => ({}));
 // Mock basecamp-client (resolvePersonId for per-account person ID resolution)
 // ---------------------------------------------------------------------------
 
-const mockResolvePersonId = vi.fn();
+const mockResolvePersonId = vi.fn((_, __) => Promise.resolve({ id: "1", name: "Resolved" }));
 
 vi.mock("../src/basecamp-client.js", () => ({
   resolvePersonId: (...args: any[]) => mockResolvePersonId(...args),
@@ -153,7 +153,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 42, firstName: "Jeremy", lastName: "", emailAddress: "j@example.com" },
       accounts: [{ id: 99, name: "Acme", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("42");
+    mockResolvePersonId.mockResolvedValue({ id: "42", name: "Person 42" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -171,7 +171,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
     const accounts = (result.cfg.channels as any).basecamp.accounts;
     expect(accounts.security).toBeDefined();
     expect(accounts.security.personId).toBe("42");
-    expect(accounts.security.displayName).toBe("Jeremy");
+    expect(accounts.security.displayName).toBe("Person 42");
     // attachableSgid is cleared because CLI SGID does not apply to the per-account person ID
     expect(accounts.security.attachableSgid).toBeUndefined();
     expect(accounts.security.cliProfile).toBe("default");
@@ -198,7 +198,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 10, firstName: "Bot", lastName: "", emailAddress: "bot@example.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("10");
+    mockResolvePersonId.mockResolvedValue({ id: "10", name: "Person 10" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -236,7 +236,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 1, firstName: "X", lastName: "", emailAddress: "x@x.com" },
       accounts: [],
     });
-    mockResolvePersonId.mockResolvedValue("1");
+    mockResolvePersonId.mockResolvedValue({ id: "1", name: "Person 1" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -286,7 +286,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 42, firstName: "Test", lastName: "", emailAddress: "t@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("42");
+    mockResolvePersonId.mockResolvedValue({ id: "42", name: "Person 42" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -328,7 +328,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 42, firstName: "Test", lastName: "", emailAddress: "t@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("42");
+    mockResolvePersonId.mockResolvedValue({ id: "42", name: "Person 42" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     // Config has an invalid client ID with a stale secret
@@ -365,7 +365,7 @@ describe("hatchIdentity — Browser/OAuth path", () => {
       identity: { id: 55, firstName: "OAuth", lastName: "Bot", emailAddress: "bot@test.com" },
       accounts: [{ id: 200, name: "OAuth Co", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("55");
+    mockResolvePersonId.mockResolvedValue({ id: "55", name: "Person 55" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -401,7 +401,7 @@ describe("hatchIdentity — Browser/OAuth path", () => {
       identity: { id: 10, firstName: "Bot", lastName: "", emailAddress: "b@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("10");
+    mockResolvePersonId.mockResolvedValue({ id: "10", name: "Person 10" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -439,7 +439,7 @@ describe("hatchIdentity — Browser/OAuth path", () => {
       identity: { id: 1, firstName: "A", lastName: "", emailAddress: "a@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("1");
+    mockResolvePersonId.mockResolvedValue({ id: "1", name: "Person 1" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter: p1 } = createMockPrompter({
@@ -524,7 +524,7 @@ describe("hatchIdentity — token file relocation", () => {
       identity: { id: 1, firstName: "A", lastName: "", emailAddress: "a@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("1");
+    mockResolvePersonId.mockResolvedValue({ id: "1", name: "Person 1" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
     // Both rename and copy fail
     mockRename.mockRejectedValue(new Error("EXDEV"));
@@ -555,7 +555,7 @@ describe("hatchIdentity — token file relocation", () => {
       identity: { id: 1, firstName: "A", lastName: "", emailAddress: "a@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
-    mockResolvePersonId.mockResolvedValue("1");
+    mockResolvePersonId.mockResolvedValue({ id: "1", name: "Person 1" });
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
     // rename fails, copy succeeds
     mockRename.mockRejectedValue(new Error("EXDEV"));

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -172,7 +172,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
     expect(accounts.security).toBeDefined();
     expect(accounts.security.personId).toBe("42");
     expect(accounts.security.displayName).toBe("Jeremy");
-    // attachableSgid is cleared when resolvePersonId returns a different ID than CLI discovery
+    // attachableSgid is cleared because CLI SGID does not apply to the per-account person ID
     expect(accounts.security.attachableSgid).toBeUndefined();
     expect(accounts.security.cliProfile).toBe("default");
     // CLI path chains into OAuth — oauthTokenFile should be set

--- a/tests/hatch.test.ts
+++ b/tests/hatch.test.ts
@@ -62,6 +62,16 @@ vi.mock("@37signals/basecamp/oauth", () => ({
 vi.mock("@37signals/basecamp", () => ({}));
 
 // ---------------------------------------------------------------------------
+// Mock basecamp-client (resolvePersonId for per-account person ID resolution)
+// ---------------------------------------------------------------------------
+
+const mockResolvePersonId = vi.fn();
+
+vi.mock("../src/basecamp-client.js", () => ({
+  resolvePersonId: (...args: any[]) => mockResolvePersonId(...args),
+}));
+
+// ---------------------------------------------------------------------------
 // Mock node:fs/promises (for token file relocation)
 // ---------------------------------------------------------------------------
 
@@ -143,6 +153,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 42, firstName: "Jeremy", lastName: "", emailAddress: "j@example.com" },
       accounts: [{ id: 99, name: "Acme", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("42");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -186,6 +197,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 10, firstName: "Bot", lastName: "", emailAddress: "bot@example.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("10");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -223,6 +235,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 1, firstName: "X", lastName: "", emailAddress: "x@x.com" },
       accounts: [],
     });
+    mockResolvePersonId.mockResolvedValue("1");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -272,6 +285,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 42, firstName: "Test", lastName: "", emailAddress: "t@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("42");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -313,6 +327,7 @@ describe("hatchIdentity — CLI path (chains into OAuth)", () => {
       identity: { id: 42, firstName: "Test", lastName: "", emailAddress: "t@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("42");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     // Config has an invalid client ID with a stale secret
@@ -349,6 +364,7 @@ describe("hatchIdentity — Browser/OAuth path", () => {
       identity: { id: 55, firstName: "OAuth", lastName: "Bot", emailAddress: "bot@test.com" },
       accounts: [{ id: 200, name: "OAuth Co", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("55");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -384,6 +400,7 @@ describe("hatchIdentity — Browser/OAuth path", () => {
       identity: { id: 10, firstName: "Bot", lastName: "", emailAddress: "b@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("10");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter } = createMockPrompter({
@@ -421,6 +438,7 @@ describe("hatchIdentity — Browser/OAuth path", () => {
       identity: { id: 1, firstName: "A", lastName: "", emailAddress: "a@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("1");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
 
     const { prompter: p1 } = createMockPrompter({
@@ -505,6 +523,7 @@ describe("hatchIdentity — token file relocation", () => {
       identity: { id: 1, firstName: "A", lastName: "", emailAddress: "a@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("1");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
     // Both rename and copy fail
     mockRename.mockRejectedValue(new Error("EXDEV"));
@@ -535,6 +554,7 @@ describe("hatchIdentity — token file relocation", () => {
       identity: { id: 1, firstName: "A", lastName: "", emailAddress: "a@t.com" },
       accounts: [{ id: 1, name: "Co", product: "bc3" }],
     });
+    mockResolvePersonId.mockResolvedValue("1");
     mockResolveTokenFilePath.mockImplementation((id: string) => `/tmp/tokens/${id}.json`);
     // rename fails, copy succeeds
     mockRename.mockRejectedValue(new Error("EXDEV"));


### PR DESCRIPTION
## Summary
- Both onboarding and hatch wizards called `discoverIdentity()` which returns the global Launchpad identity ID, not the per-account Basecamp person ID. These differ (e.g. identity 28147435 vs person 51190969). The `personId` in config is compared against `event.sender.id` in `isSelfMessage()` — activity events use the per-account ID, so the mismatch breaks self-message filtering (bot responds to its own messages) and can silently drop legitimate messages.
- After account selection, both wizards now call `client.people.me()` via the new `resolvePersonId()` helper to get the actual per-account ID. If resolution fails, falls through to manual entry — never falls back to the Launchpad identity.
- Removes the identity override in hatch.ts CLI→OAuth path that was replacing the CLI-discovered ID with the Launchpad identity.

## Test plan
- [x] Mock `discoverIdentity` to return identity ID 100; mock `resolvePersonId` to return 200; verify config writes 200
- [x] When `resolvePersonId` throws, wizard prompts for manual person ID entry
- [x] All existing onboarding + hatch tests pass with updated mocks