### PR TITLE
Fix openclaw 2026.3.23 SDK compatibility

### DIFF
--- a/src/adapters/actions.ts
+++ b/src/adapters/actions.ts
@@ -13,8 +13,8 @@ import type {
   ChannelMessageActionContext,
   ChannelMessageActionName,
 } from "openclaw/plugin-sdk";
-import type { ChannelToolSend } from "openclaw/plugin-sdk/tool-send";
 import { readStringParam } from "openclaw/plugin-sdk/param-readers";
+import type { ChannelToolSend } from "openclaw/plugin-sdk/tool-send";
 import { getClient, numId } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
 import { markdownToBasecampHtml } from "../outbound/format.js";

--- a/src/adapters/actions.ts
+++ b/src/adapters/actions.ts
@@ -12,13 +12,25 @@ import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
   ChannelMessageActionName,
-  ChannelToolSend,
 } from "openclaw/plugin-sdk";
-import { jsonResult, readStringParam } from "openclaw/plugin-sdk";
+import type { ChannelToolSend } from "openclaw/plugin-sdk/tool-send";
+import { readStringParam } from "openclaw/plugin-sdk/param-readers";
 import { getClient, numId } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
 import { markdownToBasecampHtml } from "../outbound/format.js";
 import { postCampfireLine, postComment } from "../outbound/send.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Wrap a payload as a JSON agent tool result (inlined; removed from barrel export). */
+function jsonResult(payload: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+    details: payload,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Supported action set
@@ -32,13 +44,9 @@ const SUPPORTED_ACTIONS: ChannelMessageActionName[] = ["send", "react"];
 // ---------------------------------------------------------------------------
 
 export const basecampActionsAdapter: ChannelMessageActionAdapter = {
-  listActions: () => SUPPORTED_ACTIONS,
+  describeMessageTool: () => ({ actions: SUPPORTED_ACTIONS }),
 
   supportsAction: ({ action }) => SUPPORTED_ACTIONS.includes(action),
-
-  supportsButtons: () => false,
-
-  supportsCards: () => false,
 
   extractToolSend: ({ args }) => {
     const to = args.to;
@@ -58,10 +66,6 @@ export const basecampActionsAdapter: ChannelMessageActionAdapter = {
     }
   },
 };
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // send — post a campfire line or comment

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -206,7 +206,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
       description: "Mark a Basecamp to-do as complete. Requires the project (bucket) ID and to-do ID.",
       parameters: CompleteTodoParams,
       execute: async (_toolCallId: string, rawParams: unknown) => {
-        const { bucketId, todoId } = rawParams as CompleteTodoInput;
+        const { todoId } = rawParams as CompleteTodoInput;
         try {
           await client.todos.complete(numId("todo", todoId));
           return toolOk({ todoId });
@@ -222,7 +222,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         "Reopen a completed Basecamp to-do (mark as incomplete). Requires the project (bucket) ID and to-do ID.",
       parameters: ReopenTodoParams,
       execute: async (_toolCallId: string, rawParams: unknown) => {
-        const { bucketId, todoId } = rawParams as ReopenTodoInput;
+        const { todoId } = rawParams as ReopenTodoInput;
         try {
           await client.todos.uncomplete(numId("todo", todoId));
           return toolOk({ todoId });
@@ -297,7 +297,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         "Requires the project (bucket) ID, card recording ID, and target column ID.",
       parameters: MoveCardParams,
       execute: async (_toolCallId: string, rawParams: unknown) => {
-        const { bucketId, cardId, columnId } = rawParams as MoveCardInput;
+        const { cardId, columnId } = rawParams as MoveCardInput;
         try {
           await client.cards.move(numId("card", cardId), { columnId });
           return toolOk({ cardId, columnId });
@@ -315,7 +315,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         "Optionally include body content and a message category/type ID.",
       parameters: PostMessageParams,
       execute: async (_toolCallId: string, rawParams: unknown) => {
-        const { bucketId, messageBoardId, subject, content, categoryId } = rawParams as PostMessageInput;
+        const { messageBoardId, subject, content, categoryId } = rawParams as PostMessageInput;
         try {
           const result = await client.messages.create(numId("board", messageBoardId), { subject, content, categoryId });
           return toolOk({ messageId: (result as any)?.id, subject: (result as any)?.subject });
@@ -331,7 +331,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         "Answer a Basecamp check-in question. " + "Requires the project (bucket) ID, question ID, and answer content.",
       parameters: AnswerCheckinParams,
       execute: async (_toolCallId: string, rawParams: unknown) => {
-        const { bucketId, questionId, content } = rawParams as AnswerCheckinInput;
+        const { questionId, content } = rawParams as AnswerCheckinInput;
         try {
           const result = await client.checkins.createAnswer(numId("question", questionId), { content });
           return toolOk({ answerId: (result as any)?.id });

--- a/src/adapters/directory.ts
+++ b/src/adapters/directory.ts
@@ -5,7 +5,8 @@
  * agent targeting, and people/project lookup via the Basecamp API.
  */
 
-import type { ChannelDirectoryAdapter, ChannelDirectoryEntry, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ChannelDirectoryAdapter, ChannelDirectoryEntry } from "openclaw/plugin-sdk/channel-runtime";
 import { getClient, numId } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
 import type { BasecampChannelConfig, BasecampPerson, BasecampProject, ResolvedBasecampAccount } from "../types.js";

--- a/src/adapters/groups.ts
+++ b/src/adapters/groups.ts
@@ -5,7 +5,7 @@
  * and group intro hints on a per-project (bucket) basis.
  */
 
-import type { ChannelGroupAdapter, ChannelGroupContext } from "openclaw/plugin-sdk";
+import type { ChannelGroupAdapter, ChannelGroupContext } from "openclaw/plugin-sdk/channel-runtime";
 import type { BasecampBucketConfig, BasecampChannelConfig } from "../types.js";
 
 function getBasecampSection(cfg: Record<string, unknown>): BasecampChannelConfig | undefined {

--- a/src/adapters/hatch.ts
+++ b/src/adapters/hatch.ts
@@ -16,7 +16,7 @@
 import type { AuthorizationInfo } from "@37signals/basecamp";
 import { discoverIdentity } from "@37signals/basecamp/oauth";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { normalizeAccountId } from "openclaw/plugin-sdk";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { cliMe, cliProfileList } from "../basecamp-cli.js";
 import { listBasecampAccountIds } from "../config.js";
 import {

--- a/src/adapters/heartbeat.ts
+++ b/src/adapters/heartbeat.ts
@@ -8,7 +8,7 @@
  * is valid (auto-refreshing for OAuth accounts).
  */
 
-import type { ChannelHeartbeatAdapter } from "openclaw/plugin-sdk";
+import type { ChannelHeartbeatAdapter } from "openclaw/plugin-sdk/channel-runtime";
 import { getClient } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
 

--- a/src/adapters/mentions.ts
+++ b/src/adapters/mentions.ts
@@ -8,7 +8,8 @@
  * at the start of a message.
  */
 
-import type { ChannelMentionAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ChannelMentionAdapter } from "openclaw/plugin-sdk/channel-runtime";
 import type { BasecampChannelConfig } from "../types.js";
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {

--- a/src/adapters/messaging.ts
+++ b/src/adapters/messaging.ts
@@ -5,7 +5,7 @@
  * (recording:<id>, bucket:<id>, ping:<id>) and formatting them for display.
  */
 
-import type { ChannelMessagingAdapter } from "openclaw/plugin-sdk";
+import type { ChannelMessagingAdapter } from "openclaw/plugin-sdk/channel-runtime";
 
 const PEER_PATTERN = /^(recording|bucket|ping):\d+$/;
 

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -8,13 +8,39 @@
  * Both paths converge on discoverIdentity() for account/person resolution.
  */
 
-import type {
-  ChannelOnboardingAdapter,
-  ChannelOnboardingDmPolicy,
-  DmPolicy,
-  OpenClawConfig,
-} from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import type { DmPolicy } from "openclaw/plugin-sdk/setup";
+
+/** Local type for onboarding DM policy (removed from SDK barrel). */
+type ChannelOnboardingDmPolicy = {
+  label: string;
+  channel: string;
+  policyKey: string;
+  allowFromKey: string;
+  getCurrent: (cfg: OpenClawConfig) => DmPolicy;
+  setPolicy: (cfg: OpenClawConfig, policy: DmPolicy) => OpenClawConfig;
+};
+
+/** Local type for onboarding adapter (removed from SDK barrel). */
+type ChannelOnboardingAdapter = {
+  channel: string;
+  getStatus: (params: { cfg: OpenClawConfig }) => Promise<{
+    channel: string;
+    configured: boolean;
+    statusLines: string[];
+    selectionHint: string;
+    quickstartScore: number;
+  }>;
+  configure: (params: {
+    cfg: OpenClawConfig;
+    prompter: any;
+    accountOverrides: Record<string, string | undefined>;
+    shouldPromptAccountIds: boolean;
+  }) => Promise<{ cfg: OpenClawConfig; accountId: string }>;
+  dmPolicy: ChannelOnboardingDmPolicy;
+  disable: (cfg: OpenClawConfig) => OpenClawConfig;
+};
 import {
   type CliProfile,
   cliProfileListFull,
@@ -169,7 +195,7 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
       if (choice === "__new__") {
         const entered = await prompter.text({
           message: "New account ID",
-          validate: (value) => (value?.trim() ? undefined : "Required"),
+          validate: (value: string | undefined) => (value?.trim() ? undefined : "Required"),
         });
         accountId = normalizeAccountId(String(entered));
       } else {
@@ -324,7 +350,7 @@ export const basecampOnboardingAdapter: ChannelOnboardingAdapter = {
     if (!personId) {
       const entered = await prompter.text({
         message: "Basecamp person ID (your service account's person ID)",
-        validate: (value) => (value?.trim() ? undefined : "Required"),
+        validate: (value: string | undefined) => (value?.trim() ? undefined : "Required"),
       });
       personId = String(entered).trim();
     } else {

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -41,6 +41,7 @@ type ChannelOnboardingAdapter = {
   dmPolicy: ChannelOnboardingDmPolicy;
   disable: (cfg: OpenClawConfig) => OpenClawConfig;
 };
+
 import {
   type CliProfile,
   cliProfileListFull,

--- a/src/adapters/pairing.ts
+++ b/src/adapters/pairing.ts
@@ -6,8 +6,9 @@
  * Pairing approval sends a Ping message to the user via the Basecamp API.
  */
 
-import type { ChannelPairingAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
-import { PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ChannelPairingAdapter } from "openclaw/plugin-sdk/channel-runtime";
+import { PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk/channel-status";
 import { getClient, rawOrThrow } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
 

--- a/src/adapters/resolver.ts
+++ b/src/adapters/resolver.ts
@@ -6,7 +6,7 @@
  * exact name (case-insensitive), partial name, or email prefix.
  */
 
-import type { ChannelResolveResult, ChannelResolverAdapter } from "openclaw/plugin-sdk";
+import type { ChannelResolveResult, ChannelResolverAdapter } from "openclaw/plugin-sdk/channel-runtime";
 import { getClient } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
 import type { BasecampPerson, BasecampProject } from "../types.js";

--- a/src/adapters/security.ts
+++ b/src/adapters/security.ts
@@ -6,7 +6,6 @@
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import type { BasecampChannelConfig, ResolvedBasecampAccount } from "../types.js";
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {

--- a/src/adapters/security.ts
+++ b/src/adapters/security.ts
@@ -6,7 +6,7 @@
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import type { BasecampChannelConfig, ResolvedBasecampAccount } from "../types.js";
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {

--- a/src/adapters/setup.ts
+++ b/src/adapters/setup.ts
@@ -6,7 +6,8 @@
  */
 
 import type { ChannelSetupAdapter, ChannelSetupInput, OpenClawConfig } from "openclaw/plugin-sdk";
-import { applyAccountNameToChannelSection, DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { applyAccountNameToChannelSection } from "openclaw/plugin-sdk/setup";
 import type { BasecampChannelConfig } from "../types.js";
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {

--- a/src/adapters/setup.ts
+++ b/src/adapters/setup.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ChannelSetupAdapter, ChannelSetupInput, OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { applyAccountNameToChannelSection } from "openclaw/plugin-sdk/setup";
 import type { BasecampChannelConfig } from "../types.js";
 

--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -11,8 +11,8 @@
  */
 
 import type { ChannelAccountSnapshot, OpenClawConfig } from "openclaw/plugin-sdk";
-import type { ChannelStatusAdapter } from "openclaw/plugin-sdk/channel-runtime";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import type { ChannelStatusAdapter } from "openclaw/plugin-sdk/channel-runtime";
 import { getClient, numId } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
 import type { AccountMetrics, PollerSourceMetrics } from "../metrics.js";

--- a/src/adapters/status.ts
+++ b/src/adapters/status.ts
@@ -10,8 +10,9 @@
  * and status issue collection.
  */
 
-import type { ChannelAccountSnapshot, ChannelStatusAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import type { ChannelAccountSnapshot, OpenClawConfig } from "openclaw/plugin-sdk";
+import type { ChannelStatusAdapter } from "openclaw/plugin-sdk/channel-runtime";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { getClient, numId } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
 import type { AccountMetrics, PollerSourceMetrics } from "../metrics.js";

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,5 +1,4 @@
 import type { ChannelPlugin } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { deleteAccountFromConfigSection, setAccountEnabledInConfigSection } from "openclaw/plugin-sdk/core";
 import { basecampActionsAdapter } from "./adapters/actions.js";

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,10 +1,7 @@
 import type { ChannelPlugin } from "openclaw/plugin-sdk";
-import {
-  buildChannelConfigSchema,
-  DEFAULT_ACCOUNT_ID,
-  deleteAccountFromConfigSection,
-  setAccountEnabledInConfigSection,
-} from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import { deleteAccountFromConfigSection, setAccountEnabledInConfigSection } from "openclaw/plugin-sdk/core";
 import { basecampActionsAdapter } from "./adapters/actions.js";
 import { basecampAgentPromptAdapter } from "./adapters/agent-prompt.js";
 import { basecampAgentTools } from "./adapters/agent-tools.js";
@@ -13,7 +10,6 @@ import { basecampGroupAdapter } from "./adapters/groups.js";
 import { basecampHeartbeatAdapter } from "./adapters/heartbeat.js";
 import { basecampMentionAdapter } from "./adapters/mentions.js";
 import { basecampMessagingAdapter } from "./adapters/messaging.js";
-import { basecampOnboardingAdapter } from "./adapters/onboarding.js";
 import { BASECAMP_TEXT_CHUNK_LIMIT, chunkMarkdownText, resolveOutboundTarget } from "./adapters/outbound.js";
 import { basecampPairingAdapter } from "./adapters/pairing.js";
 import { basecampResolverAdapter } from "./adapters/resolver.js";
@@ -74,8 +70,6 @@ export const basecampChannel: ChannelPlugin<ResolvedBasecampAccount, BasecampPro
     nativeCommands: false,
     blockStreaming: false,
   },
-
-  onboarding: basecampOnboardingAdapter,
 
   pairing: basecampPairingAdapter,
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { z } from "zod";
 import { isValidLaunchpadClientId } from "./oauth-credentials.js";
 import type {

--- a/src/inbound/webhooks.ts
+++ b/src/inbound/webhooks.ts
@@ -142,7 +142,7 @@ export function verifyWebhookSignature(params: {
 
   // Replay protection: reject if timestamp is too old
   const ts = parseInt(timestamp, 10);
-  if (isNaN(ts)) return false;
+  if (Number.isNaN(ts)) return false;
   const age = Math.abs(Math.floor(Date.now() / 1000) - ts);
   if (age > MAX_TIMESTAMP_AGE_S) return false;
 

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -129,7 +129,7 @@ export async function postCampfireLine(params: {
   circuitBreaker?: { instance: CircuitBreaker; key: string };
   correlationId?: string;
 }): Promise<OutboundResult> {
-  const { bucketId, transcriptId, content, account, retries, circuitBreaker, correlationId } = params;
+  const { transcriptId, content, account, retries, circuitBreaker, correlationId } = params;
   const { accountId } = account;
 
   const doPost = async () => {
@@ -173,7 +173,7 @@ export async function postComment(params: {
   circuitBreaker?: { instance: CircuitBreaker; key: string };
   correlationId?: string;
 }): Promise<OutboundResult> {
-  const { bucketId, recordingId, content, account, retries, circuitBreaker, correlationId } = params;
+  const { recordingId, content, account, retries, circuitBreaker, correlationId } = params;
   const { accountId } = account;
 
   const doPost = async () => {

--- a/tests/actions.test.ts
+++ b/tests/actions.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
   normalizeAccountId: (v: string | undefined | null) => (v ?? "").trim() || "default",
-  jsonResult: (payload: unknown) => ({ ok: true, result: payload }),
+}));
+
+vi.mock("openclaw/plugin-sdk/param-readers", () => ({
   readStringParam: (params: Record<string, unknown>, key: string, opts?: { required?: boolean; label?: string }) => {
     const val = params[key];
     if (opts?.required && (val === undefined || val === null || val === "")) {
@@ -72,13 +74,21 @@ function actionCtx(overrides: Record<string, unknown> = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// listActions
+// Helper: extract payload from AgentToolResult shape
 // ---------------------------------------------------------------------------
 
-describe("actions.listActions", () => {
+function resultPayload(result: unknown): unknown {
+  return (result as { details: unknown }).details;
+}
+
+// ---------------------------------------------------------------------------
+// describeMessageTool
+// ---------------------------------------------------------------------------
+
+describe("actions.describeMessageTool", () => {
   it("returns supported action names", () => {
-    const actions = basecampActionsAdapter.listActions!({ cfg: {} as any });
-    expect(actions).toEqual(["send", "react"]);
+    const discovery = basecampActionsAdapter.describeMessageTool!({ cfg: {} } as any);
+    expect(discovery?.actions).toEqual(["send", "react"]);
   });
 });
 
@@ -98,22 +108,6 @@ describe("actions.supportsAction", () => {
   it("returns false for unsupported actions", () => {
     expect(basecampActionsAdapter.supportsAction!({ action: "delete" })).toBe(false);
     expect(basecampActionsAdapter.supportsAction!({ action: "edit" })).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// supportsButtons / supportsCards
-// ---------------------------------------------------------------------------
-
-describe("actions.supportsButtons", () => {
-  it("returns false", () => {
-    expect(basecampActionsAdapter.supportsButtons!({ cfg: {} as any })).toBe(false);
-  });
-});
-
-describe("actions.supportsCards", () => {
-  it("returns false", () => {
-    expect(basecampActionsAdapter.supportsCards!({ cfg: {} as any })).toBe(false);
   });
 });
 
@@ -163,10 +157,7 @@ describe("actions.handleAction — send campfire line", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: { ok: true, target: "campfire", recordingId: "42" },
-    });
+    expect(resultPayload(result)).toEqual({ ok: true, target: "campfire", recordingId: "42" });
     expect(postCampfireLine).toHaveBeenCalledWith({
       bucketId: "1",
       transcriptId: "2",
@@ -198,10 +189,7 @@ describe("actions.handleAction — send campfire line", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: { ok: false, target: "campfire", error: "timeout" },
-    });
+    expect(resultPayload(result)).toEqual({ ok: false, target: "campfire", error: "timeout" });
   });
 });
 
@@ -219,10 +207,7 @@ describe("actions.handleAction — send comment", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: { ok: true, target: "comment", commentId: "77" },
-    });
+    expect(resultPayload(result)).toEqual({ ok: true, target: "comment", commentId: "77" });
     expect(postComment).toHaveBeenCalledWith({
       bucketId: "1",
       recordingId: "3",
@@ -244,10 +229,7 @@ describe("actions.handleAction — send comment", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: { ok: false, target: "comment", error: "403 Forbidden" },
-    });
+    expect(resultPayload(result)).toEqual({ ok: false, target: "comment", error: "403 Forbidden" });
   });
 });
 
@@ -271,10 +253,7 @@ describe("actions.handleAction — send validation", () => {
   it("returns error when neither transcriptId nor recordingId is provided", async () => {
     const result = await basecampActionsAdapter.handleAction!(actionCtx({ params: { bucketId: "1", text: "Hello" } }));
 
-    expect(result).toEqual({
-      ok: true,
-      result: { ok: false, error: expect.stringContaining("transcriptId") },
-    });
+    expect(resultPayload(result)).toEqual({ ok: false, error: expect.stringContaining("transcriptId") });
   });
 });
 
@@ -291,16 +270,15 @@ describe("actions.handleAction — send dryRun", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: expect.objectContaining({
+    expect(resultPayload(result)).toEqual(
+      expect.objectContaining({
         ok: true,
         dryRun: true,
         target: "campfire",
         bucketId: "1",
         transcriptId: "2",
       }),
-    });
+    );
     expect(postCampfireLine).not.toHaveBeenCalled();
     expect(postComment).not.toHaveBeenCalled();
   });
@@ -313,16 +291,15 @@ describe("actions.handleAction — send dryRun", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: expect.objectContaining({
+    expect(resultPayload(result)).toEqual(
+      expect.objectContaining({
         ok: true,
         dryRun: true,
         target: "comment",
         bucketId: "1",
         recordingId: "3",
       }),
-    });
+    );
   });
 });
 
@@ -334,10 +311,7 @@ describe("actions.handleAction — unsupported action", () => {
   it("returns error for unsupported action", async () => {
     const result = await basecampActionsAdapter.handleAction!(actionCtx({ action: "delete" }));
 
-    expect(result).toEqual({
-      ok: true,
-      result: { ok: false, error: "Unsupported action: delete" },
-    });
+    expect(resultPayload(result)).toEqual({ ok: false, error: "Unsupported action: delete" });
   });
 });
 
@@ -364,12 +338,9 @@ describe("actions.handleAction — bucket scoping", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: {
-        ok: false,
-        error: expect.stringContaining("scoped to bucket 42"),
-      },
+    expect(resultPayload(result)).toEqual({
+      ok: false,
+      error: expect.stringContaining("scoped to bucket 42"),
     });
     expect(postCampfireLine).not.toHaveBeenCalled();
   });
@@ -403,10 +374,7 @@ describe("actions.handleAction — react", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: { ok: true, target: "boost", boostId: 55 },
-    });
+    expect(resultPayload(result)).toEqual({ ok: true, target: "boost", boostId: 55 });
     expect(mockClient.boosts.createForRecording).toHaveBeenCalledWith(500, { content: "🎉" });
   });
 
@@ -433,10 +401,7 @@ describe("actions.handleAction — react", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: { ok: false, error: "Error: 503 Unavailable" },
-    });
+    expect(resultPayload(result)).toEqual({ ok: false, error: "Error: 503 Unavailable" });
   });
 
   it("throws on missing bucketId", async () => {
@@ -486,12 +451,9 @@ describe("actions.handleAction — react bucket scoping", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: {
-        ok: false,
-        error: expect.stringContaining("scoped to bucket 42"),
-      },
+    expect(resultPayload(result)).toEqual({
+      ok: false,
+      error: expect.stringContaining("scoped to bucket 42"),
     });
     expect(mockClient.boosts.createForRecording).not.toHaveBeenCalled();
   });
@@ -523,9 +485,8 @@ describe("actions.handleAction — react dryRun", () => {
       }),
     );
 
-    expect(result).toEqual({
-      ok: true,
-      result: expect.objectContaining({
+    expect(resultPayload(result)).toEqual(
+      expect.objectContaining({
         ok: true,
         dryRun: true,
         target: "boost",
@@ -533,7 +494,7 @@ describe("actions.handleAction — react dryRun", () => {
         recordingId: "500",
         emoji: "🎉",
       }),
-    });
+    );
     expect(mockClient.boosts.createForRecording).not.toHaveBeenCalled();
   });
 });

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -8,6 +8,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("openclaw/plugin-sdk", () => ({
   DEFAULT_ACCOUNT_ID: "default",
   normalizeAccountId: (v: string | undefined) => (v ?? "").trim() || "default",
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({}));
+
+vi.mock("openclaw/plugin-sdk/channel-status", () => ({
   PAIRING_APPROVED_MESSAGE: "You have been approved!",
 }));
 


### PR DESCRIPTION
## Summary
PR #83 bumped `openclaw` from 2026.3.13 to 2026.3.23 which removed/renamed several plugin SDK exports. This broke `tsc` on main. Updates call sites to match the new API surface.

## Changes
- **Barrel imports replaced with deep imports:** `DEFAULT_ACCOUNT_ID` and `normalizeAccountId` now from `openclaw/plugin-sdk/account-id`; `buildChannelConfigSchema` from `openclaw/plugin-sdk/channel-config-schema`; `deleteAccountFromConfigSection` and `setAccountEnabledInConfigSection` from `openclaw/plugin-sdk/core`; `applyAccountNameToChannelSection` from `openclaw/plugin-sdk/setup`; `PAIRING_APPROVED_MESSAGE` from `openclaw/plugin-sdk/channel-status`; `readStringParam` from `openclaw/plugin-sdk/param-readers`
- **Adapter types moved to deep imports:** `ChannelDirectoryAdapter`, `ChannelDirectoryEntry`, `ChannelGroupAdapter`, `ChannelGroupContext`, `ChannelHeartbeatAdapter`, `ChannelMentionAdapter`, `ChannelMessagingAdapter`, `ChannelPairingAdapter`, `ChannelResolveResult`, `ChannelResolverAdapter`, `ChannelStatusAdapter` now from `openclaw/plugin-sdk/channel-runtime`; `ChannelToolSend` from `openclaw/plugin-sdk/tool-send`
- **`jsonResult` inlined:** No longer exported from any generic SDK path; implemented as a local helper in `actions.ts`
- **`listActions` replaced with `describeMessageTool`:** Returns `{ actions: [...] }` discovery object instead of a flat array; `supportsButtons`/`supportsCards` methods removed (no longer on the adapter interface)
- **`onboarding` slot removed:** `ChannelOnboardingAdapter` / `ChannelOnboardingDmPolicy` / `DmPolicy` removed from SDK barrel and `onboarding` property removed from `ChannelPlugin`; adapter types inlined locally for backward compat
- **Tests updated:** `actions.test.ts` assertions updated for `AgentToolResult` shape (`details` instead of `result`); `pairing.test.ts` mocks updated for new import paths

## Test plan
- [x] `tsc --noEmit` passes
- [x] All tests pass (1154 passed, 10 skipped)