### PR TITLE
Default Basecamp dmPolicy to allowlist instead of pairing

### DIFF
--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -114,7 +114,7 @@ const dmPolicy: ChannelSetupDmPolicy = {
   channel,
   policyKey: "channels.basecamp.dmPolicy",
   allowFromKey: "channels.basecamp.allowFrom",
-  getCurrent: (cfg) => (getBasecampSection(cfg)?.dmPolicy as DmPolicy) ?? "pairing",
+  getCurrent: (cfg) => (getBasecampSection(cfg)?.dmPolicy as DmPolicy) ?? "allowlist",
   setPolicy: (cfg, policy) => setBasecampDmPolicy(cfg, policy),
   promptAllowFrom: async ({ cfg, prompter }) => {
     const section = getBasecampSection(cfg) ?? {};

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -453,6 +453,21 @@ export const basecampSetupWizard: ChannelSetupWizard = {
       }
     }
 
+    // Normalize DM policy: the generic setup host may have written "pairing"
+    // as the default, but Basecamp has no pairing challenge flow — pairing and
+    // allowlist are identical. Rewrite to "allowlist" so the config label
+    // accurately reflects behavior.
+    const finalSection = getBasecampSection(next);
+    if (finalSection?.dmPolicy === "pairing") {
+      next = {
+        ...next,
+        channels: {
+          ...next.channels,
+          basecamp: { ...finalSection, dmPolicy: "allowlist" },
+        },
+      };
+    }
+
     return { cfg: next };
   },
 

--- a/src/adapters/onboarding.ts
+++ b/src/adapters/onboarding.ts
@@ -18,7 +18,7 @@ import {
   exportCliCredentials,
   extractCliBootstrapToken,
 } from "../basecamp-cli.js";
-import { listBasecampAccountIds, resolveBasecampAccount } from "../config.js";
+import { listBasecampAccountIds, resolveBasecampAccount, resolveBasecampDmPolicy } from "../config.js";
 import { isValidLaunchpadClientId, OAUTH_SETUP_GUIDANCE } from "../oauth-credentials.js";
 import type { BasecampChannelConfig } from "../types.js";
 
@@ -114,7 +114,7 @@ const dmPolicy: ChannelSetupDmPolicy = {
   channel,
   policyKey: "channels.basecamp.dmPolicy",
   allowFromKey: "channels.basecamp.allowFrom",
-  getCurrent: (cfg) => (getBasecampSection(cfg)?.dmPolicy as DmPolicy) ?? "allowlist",
+  getCurrent: (cfg) => resolveBasecampDmPolicy(cfg) as DmPolicy,
   setPolicy: (cfg, policy) => setBasecampDmPolicy(cfg, policy),
   promptAllowFrom: async ({ cfg, prompter }) => {
     const section = getBasecampSection(cfg) ?? {};

--- a/src/adapters/security.ts
+++ b/src/adapters/security.ts
@@ -6,6 +6,7 @@
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { resolveBasecampDmPolicy } from "../config.js";
 import type { BasecampChannelConfig, ResolvedBasecampAccount } from "../types.js";
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
@@ -23,7 +24,7 @@ export const basecampSecurityAdapter = {
     account: ResolvedBasecampAccount;
   }) => {
     const section = getBasecampSection(cfg);
-    const dmPolicy = section?.dmPolicy ?? "allowlist";
+    const dmPolicy = resolveBasecampDmPolicy(cfg);
     const allowFrom = section?.allowFrom ?? [];
     // DM policy is channel-level (channels.basecamp.dmPolicy), not per-account.
     const basePath = "channels.basecamp.";

--- a/src/adapters/security.ts
+++ b/src/adapters/security.ts
@@ -23,7 +23,7 @@ export const basecampSecurityAdapter = {
     account: ResolvedBasecampAccount;
   }) => {
     const section = getBasecampSection(cfg);
-    const dmPolicy = section?.dmPolicy ?? "pairing";
+    const dmPolicy = section?.dmPolicy ?? "allowlist";
     const allowFrom = section?.allowFrom ?? [];
     // DM policy is channel-level (channels.basecamp.dmPolicy), not per-account.
     const basePath = "channels.basecamp.";

--- a/src/config.ts
+++ b/src/config.ts
@@ -351,10 +351,10 @@ export function resolveCircuitBreakerConfig(cfg: OpenClawConfig): { threshold: n
   };
 }
 
-/** Get the DM policy for Basecamp Pings. Defaults to "pairing". */
+/** Get the DM policy for Basecamp Pings. Defaults to "allowlist". */
 export function resolveBasecampDmPolicy(cfg: OpenClawConfig) {
   const section = getBasecampSection(cfg);
-  return section?.dmPolicy ?? "pairing";
+  return section?.dmPolicy ?? "allowlist";
 }
 
 /** Get the allow-from list. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -455,13 +455,13 @@ export type BasecampChannelConfig = {
   /**
    * DM policy for Ping conversations.
    * Uses the SDK's standard vocabulary:
-   *   pairing  — DMs allowed through the pairing flow (default)
-   *   allowlist — DMs allowed only from sender IDs in allowFrom
+   *   allowlist — DMs allowed only from sender IDs in allowFrom (default)
+   *   pairing  — alias for allowlist (Basecamp has no pairing challenge flow)
    *   open     — DMs allowed from anyone
    *   disabled — DMs completely blocked
    */
   dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
-  /** Allowed sender person IDs for DM/pairing. */
+  /** Allowed sender person IDs for DM allowlist. */
   allowFrom?: Array<string | number>;
   /** Per-bucket behavior overrides. Key is bucket ID or "*" for wildcard. */
   buckets?: Record<string, BasecampBucketConfig>;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -453,12 +453,12 @@ describe("resolvePollingIntervals", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveBasecampDmPolicy", () => {
-  it("defaults to 'pairing' when config is empty", () => {
-    expect(resolveBasecampDmPolicy({} as any)).toBe("pairing");
+  it("defaults to 'allowlist' when config is empty", () => {
+    expect(resolveBasecampDmPolicy({} as any)).toBe("allowlist");
   });
 
-  it("defaults to 'pairing' when dmPolicy is not set", () => {
-    expect(resolveBasecampDmPolicy(cfg({}))).toBe("pairing");
+  it("defaults to 'allowlist' when dmPolicy is not set", () => {
+    expect(resolveBasecampDmPolicy(cfg({}))).toBe("allowlist");
   });
 
   it("returns 'disabled' when configured", () => {

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -197,6 +197,10 @@ vi.mock("../src/config.js", () => ({
       config: acct,
     };
   },
+  resolveBasecampDmPolicy: (cfg: any) => {
+    const section = cfg?.channels?.basecamp;
+    return section?.dmPolicy ?? "allowlist";
+  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -603,8 +603,8 @@ describe("basecampSetupWizard", () => {
       expect(dp.allowFromKey).toBe("channels.basecamp.allowFrom");
     });
 
-    it("getCurrent returns 'pairing' by default", () => {
-      expect(basecampSetupWizard.dmPolicy!.getCurrent({} as any)).toBe("pairing");
+    it("getCurrent returns 'allowlist' by default", () => {
+      expect(basecampSetupWizard.dmPolicy!.getCurrent({} as any)).toBe("allowlist");
     });
 
     it("getCurrent returns configured policy", () => {

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -599,6 +599,66 @@ describe("basecampSetupWizard", () => {
     });
   });
 
+  describe("finalize — DM policy normalization", () => {
+    it("rewrites pairing to allowlist in finalize output", async () => {
+      mockCliProfileListFull.mockRejectedValue(new Error("not installed"));
+      mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
+      mockInteractiveLogin.mockResolvedValue({ accessToken: "tok", refreshToken: "ref", tokenType: "Bearer" });
+      mockDiscoverIdentity.mockResolvedValue({
+        identity: { id: 1, firstName: "Bot", lastName: "", emailAddress: "b@t.com" },
+        accounts: [{ id: 100, name: "Co", product: "bc3" }],
+      });
+
+      const prompter = createPrompter({
+        textAnswers: ["client-id", ""],
+        selectAnswers: ["done"],
+      });
+
+      // Simulate the generic setup host having written dmPolicy: "pairing"
+      const inputCfg = cfg({ dmPolicy: "pairing" });
+
+      const result = await basecampSetupWizard.finalize!({
+        cfg: inputCfg,
+        accountId: "default",
+        credentialValues: {},
+        runtime: {} as any,
+        prompter,
+        forceAllowFrom: false,
+      });
+
+      // finalize should have rewritten pairing → allowlist
+      expect(result!.cfg!.channels.basecamp.dmPolicy).toBe("allowlist");
+    });
+
+    it("preserves explicit open policy", async () => {
+      mockCliProfileListFull.mockRejectedValue(new Error("not installed"));
+      mockResolveTokenFilePath.mockReturnValue("/tmp/tokens/default.json");
+      mockInteractiveLogin.mockResolvedValue({ accessToken: "tok", refreshToken: "ref", tokenType: "Bearer" });
+      mockDiscoverIdentity.mockResolvedValue({
+        identity: { id: 1, firstName: "Bot", lastName: "", emailAddress: "b@t.com" },
+        accounts: [{ id: 100, name: "Co", product: "bc3" }],
+      });
+
+      const prompter = createPrompter({
+        textAnswers: ["client-id", ""],
+        selectAnswers: ["done"],
+      });
+
+      const inputCfg = cfg({ dmPolicy: "open" });
+
+      const result = await basecampSetupWizard.finalize!({
+        cfg: inputCfg,
+        accountId: "default",
+        credentialValues: {},
+        runtime: {} as any,
+        prompter,
+        forceAllowFrom: false,
+      });
+
+      expect(result!.cfg!.channels.basecamp.dmPolicy).toBe("open");
+    });
+  });
+
   describe("dmPolicy", () => {
     it("has correct channel and keys", () => {
       const dp = basecampSetupWizard.dmPolicy!;

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -8,6 +8,13 @@ vi.mock("openclaw/plugin-sdk", () => ({
   },
 }));
 
+vi.mock("../src/config.js", () => ({
+  resolveBasecampDmPolicy: (cfg: any) => {
+    const section = cfg?.channels?.basecamp;
+    return section?.dmPolicy ?? "allowlist";
+  },
+}));
+
 import { basecampSecurityAdapter } from "../src/adapters/security.js";
 
 function cfg(basecamp?: Record<string, unknown>) {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -22,9 +22,9 @@ const stubAccount = { accountId: "test", personId: "42" } as any;
 // ---------------------------------------------------------------------------
 
 describe("security.resolveDmPolicy", () => {
-  it("defaults to pairing when no dmPolicy is set", () => {
+  it("defaults to allowlist when no dmPolicy is set", () => {
     const result = basecampSecurityAdapter.resolveDmPolicy({ cfg: cfg({}), account: stubAccount });
-    expect(result.policy).toBe("pairing");
+    expect(result.policy).toBe("allowlist");
   });
 
   it("returns configured dmPolicy", () => {


### PR DESCRIPTION
## Summary

- Changes the default `dmPolicy` from `"pairing"` to `"allowlist"` in config resolution, security adapter, and setup wizard
- Basecamp has no pairing challenge flow — both `pairing` and `allowlist` gate identically on `allowFrom` in `dispatch.ts:150`
- The `"pairing"` label misled the setup host into presenting a pairing option that doesn't exist for this channel
- Combined with `promptAllowFrom` from #85, setup now produces a working allowlist config instead of silently dropping all DMs

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] `npm test` — 1153 passed, 0 failed
- [x] Default assertions updated in config, security, and onboarding tests