### PR TITLE
Bump @37signals/basecamp SDK to v0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@37signals/openclaw-basecamp",
       "version": "0.1.0",
       "dependencies": {
-        "@37signals/basecamp": "git+https://github.com/basecamp/basecamp-sdk.git#7e55f2e3da9de49a3f92d2b721695605ab39480e",
+        "@37signals/basecamp": "0.7.2",
         "@sinclair/typebox": "^0.34.0",
         "zod": "^4.3.6"
       },
@@ -24,14 +24,18 @@
       }
     },
     "node_modules/@37signals/basecamp": {
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/basecamp/basecamp-sdk.git#7e55f2e3da9de49a3f92d2b721695605ab39480e",
-      "integrity": "sha512-p08Ph0uYauUhnj2qTBmsKQWIu6z5Uc3JhB1TCxxPMGk9fldvgaqQBJmBDZU+Jfcqnt7rXFUDUlQ3WiMFld9U4g==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@37signals/basecamp/-/basecamp-0.7.2.tgz",
+      "integrity": "sha512-Nko1Yl+3A6zSp5qs6+oSNVvPbKq3i+/U50gI+W9E9tqx6UgRZG4DM76uQvlQ2KM22p2lLmsaAPy99dWr1D7AMQ==",
+      "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.17.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -2294,6 +2298,7 @@
       "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2345,6 +2350,7 @@
       "integrity": "sha512-lkg23ge+rgyhgUwXmlbkPEhuhHq/hUi/gXKH+4I7vO+lJrbNfEYcQdJLIGjKyXLQzgFiiyDAwh5vAe/tITAE+w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "e2e/*"
       ],
@@ -5152,6 +5158,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5954,6 +5961,7 @@
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7427,6 +7435,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8619,8 +8628,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8720,6 +8729,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8798,6 +8808,7 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -9099,6 +9110,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@37signals/basecamp": "git+https://github.com/basecamp/basecamp-sdk.git#7e55f2e3da9de49a3f92d2b721695605ab39480e",
+    "@37signals/basecamp": "0.7.2",
     "@sinclair/typebox": "^0.34.0",
     "zod": "^4.3.6"
   },

--- a/src/adapters/actions.ts
+++ b/src/adapters/actions.ts
@@ -179,7 +179,7 @@ async function handleReact(ctx: ChannelMessageActionContext) {
   try {
     const client = getClient(account);
     const result = await client.boosts.createForRecording(numId("recording", recordingId), { content: emoji });
-    return jsonResult({ ok: true, target: "boost", boostId: (result as any)?.id });
+    return jsonResult({ ok: true, target: "boost", boostId: result.id });
   } catch (err) {
     console.error(`[basecamp:${accountId}] react error: bucket=${bucketId} recording=${recordingId}`, err);
     return jsonResult({ ok: false, error: String(err) });

--- a/src/adapters/agent-tools.ts
+++ b/src/adapters/agent-tools.ts
@@ -194,7 +194,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
             dueOn: params.dueOn,
             startsOn: params.startsOn,
           });
-          return toolOk({ todoId: (result as any)?.id, title: (result as any)?.title });
+          return toolOk({ todoId: result.id, title: result.title });
         } catch (err) {
           return toolErr(String(err));
         }
@@ -283,7 +283,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         const content = params.content || "👍";
         try {
           const result = await client.boosts.createForRecording(numId("recording", params.recordingId), { content });
-          return toolOk({ boostId: (result as any)?.id });
+          return toolOk({ boostId: result.id });
         } catch (err) {
           return toolErr(String(err));
         }
@@ -318,7 +318,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         const { messageBoardId, subject, content, categoryId } = rawParams as PostMessageInput;
         try {
           const result = await client.messages.create(numId("board", messageBoardId), { subject, content, categoryId });
-          return toolOk({ messageId: (result as any)?.id, subject: (result as any)?.subject });
+          return toolOk({ messageId: result.id, subject: result.subject });
         } catch (err) {
           return toolErr(String(err));
         }
@@ -334,7 +334,7 @@ function buildTools(client: BasecampClient): ChannelAgentTool[] {
         const { questionId, content } = rawParams as AnswerCheckinInput;
         try {
           const result = await client.checkins.createAnswer(numId("question", questionId), { content });
-          return toolOk({ answerId: (result as any)?.id });
+          return toolOk({ answerId: result.id });
         } catch (err) {
           return toolErr(String(err));
         }

--- a/src/adapters/directory.ts
+++ b/src/adapters/directory.ts
@@ -9,7 +9,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { ChannelDirectoryAdapter, ChannelDirectoryEntry } from "openclaw/plugin-sdk/channel-runtime";
 import { getClient, numId } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
-import type { BasecampChannelConfig, BasecampPerson, BasecampProject, ResolvedBasecampAccount } from "../types.js";
+import type { BasecampChannelConfig } from "../types.js";
 
 function getBasecampSection(cfg: OpenClawConfig): BasecampChannelConfig | undefined {
   return cfg.channels?.basecamp as BasecampChannelConfig | undefined;
@@ -67,20 +67,18 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
   listPeersLive: async ({ cfg, accountId, query }) => {
     const account = resolveBasecampAccount(cfg, accountId);
 
-    let people: Array<{ id: number; name: string; email_address: string; avatar_url?: string }>;
+    let people;
     try {
       const client = getClient(account);
-      people = (await client.people.list()) as any;
+      people = await client.people.list();
     } catch {
       return [];
     }
 
-    if (!Array.isArray(people)) return [];
-
-    let filtered = people;
+    let filtered = [...people];
     if (query) {
       const q = query.toLowerCase();
-      filtered = people.filter((p) => p.name.toLowerCase().includes(q) || p.email_address.toLowerCase().includes(q));
+      filtered = filtered.filter((p) => p.name.toLowerCase().includes(q) || p.email_address?.toLowerCase().includes(q));
     }
 
     return filtered.map((p) => ({
@@ -114,20 +112,18 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
   listGroupsLive: async ({ cfg, accountId, query }) => {
     const account = resolveBasecampAccount(cfg, accountId);
 
-    let projects: Array<{ id: number; name: string }>;
+    let projects;
     try {
       const client = getClient(account);
-      projects = (await client.projects.list()) as any;
+      projects = await client.projects.list();
     } catch {
       return [];
     }
 
-    if (!Array.isArray(projects)) return [];
-
-    let filtered = projects;
+    let filtered = [...projects];
     if (query) {
       const q = query.toLowerCase();
-      filtered = projects.filter((p) => p.name.toLowerCase().includes(q));
+      filtered = filtered.filter((p) => p.name.toLowerCase().includes(q));
     }
 
     return filtered.map((p) => ({
@@ -144,15 +140,13 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
     const projectId = numId("project", bucketMatch[1]);
     const account = resolveBasecampAccount(cfg, accountId);
 
-    let people: Array<{ id: number; name: string; email_address: string; avatar_url?: string }>;
+    let people;
     try {
       const client = getClient(account);
-      people = (await client.people.listForProject(projectId)) as any;
+      people = await client.people.listForProject(projectId);
     } catch {
       return [];
     }
-
-    if (!Array.isArray(people)) return [];
 
     return people.map((p) => ({
       kind: "user" as const,

--- a/src/adapters/directory.ts
+++ b/src/adapters/directory.ts
@@ -5,6 +5,7 @@
  * agent targeting, and people/project lookup via the Basecamp API.
  */
 
+import type { Person, Project } from "@37signals/basecamp";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { ChannelDirectoryAdapter, ChannelDirectoryEntry } from "openclaw/plugin-sdk/channel-runtime";
 import { getClient, numId } from "../basecamp-client.js";
@@ -67,7 +68,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
   listPeersLive: async ({ cfg, accountId, query }) => {
     const account = resolveBasecampAccount(cfg, accountId);
 
-    let people;
+    let people: Person[];
     try {
       const client = getClient(account);
       people = await client.people.list();
@@ -75,7 +76,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
       return [];
     }
 
-    let filtered = [...people];
+    let filtered = people;
     if (query) {
       const q = query.toLowerCase();
       filtered = filtered.filter((p) => p.name.toLowerCase().includes(q) || p.email_address?.toLowerCase().includes(q));
@@ -112,7 +113,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
   listGroupsLive: async ({ cfg, accountId, query }) => {
     const account = resolveBasecampAccount(cfg, accountId);
 
-    let projects;
+    let projects: Project[];
     try {
       const client = getClient(account);
       projects = await client.projects.list();
@@ -120,7 +121,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
       return [];
     }
 
-    let filtered = [...projects];
+    let filtered = projects;
     if (query) {
       const q = query.toLowerCase();
       filtered = filtered.filter((p) => p.name.toLowerCase().includes(q));
@@ -140,7 +141,7 @@ export const basecampDirectoryAdapter: ChannelDirectoryAdapter = {
     const projectId = numId("project", bucketMatch[1]);
     const account = resolveBasecampAccount(cfg, accountId);
 
-    let people;
+    let people: Person[];
     try {
       const client = getClient(account);
       people = await client.people.listForProject(projectId);

--- a/src/adapters/resolver.ts
+++ b/src/adapters/resolver.ts
@@ -6,12 +6,13 @@
  * exact name (case-insensitive), partial name, or email prefix.
  */
 
+import type { Person } from "@37signals/basecamp";
 import type { ChannelResolveResult, ChannelResolverAdapter } from "openclaw/plugin-sdk/channel-runtime";
 import { getClient } from "../basecamp-client.js";
 import { resolveBasecampAccount } from "../config.js";
-import type { BasecampPerson, BasecampProject } from "../types.js";
+import type { BasecampProject } from "../types.js";
 
-function matchPerson(input: string, people: BasecampPerson[]): BasecampPerson | undefined {
+function matchPerson(input: string, people: Person[]): Person | undefined {
   const lower = input.toLowerCase();
 
   // Exact ID match
@@ -27,7 +28,7 @@ function matchPerson(input: string, people: BasecampPerson[]): BasecampPerson | 
   if (byPartial) return byPartial;
 
   // Email prefix match
-  const byEmail = people.find((p) => p.email_address.toLowerCase().startsWith(lower));
+  const byEmail = people.find((p) => p.email_address?.toLowerCase().startsWith(lower));
   if (byEmail) return byEmail;
 
   return undefined;
@@ -57,10 +58,10 @@ export const basecampResolverAdapter: ChannelResolverAdapter = {
     const account = resolveBasecampAccount(cfg, accountId);
 
     if (kind === "user") {
-      let people: BasecampPerson[];
+      let people: Person[];
       try {
         const client = getClient(account);
-        people = (await client.people.list()) as any;
+        people = await client.people.list();
       } catch {
         return inputs.map((input) => ({
           input,
@@ -91,7 +92,7 @@ export const basecampResolverAdapter: ChannelResolverAdapter = {
       let projects: BasecampProject[];
       try {
         const client = getClient(account);
-        projects = (await client.projects.list()) as any;
+        projects = await client.projects.list();
       } catch {
         return inputs.map((input) => ({
           input,

--- a/src/basecamp-client.ts
+++ b/src/basecamp-client.ts
@@ -164,7 +164,7 @@ export async function resolvePersonId(
     enableCache: false,
   });
   const profile = await client.people.me();
-  return { id: String(profile.id), name: (profile as any).name ?? "" };
+  return { id: String(profile.id), name: profile.name };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -148,7 +148,7 @@ export async function postCampfireLine(params: {
       `[basecamp:outbound] sent ok — ` +
         `type=campfire recording=${transcriptId} account=${accountId} correlation=${correlationId ?? "none"}`,
     );
-    return { ok: true, recordingId: String((result as any)?.id ?? "") };
+    return { ok: true, recordingId: String(result.id) };
   } catch (err) {
     const retryable = isRetryableError(err);
     console.warn(
@@ -192,7 +192,7 @@ export async function postComment(params: {
       `[basecamp:outbound] sent ok — ` +
         `type=comment recording=${recordingId} account=${accountId} correlation=${correlationId ?? "none"}`,
     );
-    return { ok: true, commentId: String((result as any)?.id ?? "") };
+    return { ok: true, commentId: String(result.id) };
   } catch (err) {
     const retryable = isRetryableError(err);
     console.warn(


### PR DESCRIPTION
## Summary

- Bump `@37signals/basecamp` from v0.6.0 (pinned git hash) to v0.7.2 (npm registry)
- Remove 17 `as any` casts across six files now that the SDK's types cover the accessed properties
- Use SDK's `Person` type in the resolver adapter instead of the plugin-local `BasecampPerson`

v0.7.x brings API spec sync, `Person.Id` type fix, and `CardStep.assignees` → `assignee_ids` rename (no impact — plugin uses `Card`, not `CardStep`).

## What's NOT adopted

- WebhookReceiver / verifyWebhookSignature — different security model (plugin uses Stripe-style with replay protection)
- WebhookEventKind constants — plugin covers more event kinds than the SDK
- parseEventKind / isErrorCode — plugin's versions do semantic mapping the SDK doesn't

## Test plan

- [x] `tsc --noEmit` passes clean
- [x] `biome check` passes (no new warnings introduced)
- [x] All 1155 tests pass across 65 test files