### PR TITLE
fix: Ping (DM) delivery fails via readings poller

### DIFF
--- a/src/inbound/normalize.ts
+++ b/src/inbound/normalize.ts
@@ -140,6 +140,7 @@ function resolveRecordableType(kind: string, recordingType?: string): BasecampRe
 
 const READINGS_TYPE_MAP: Record<string, BasecampRecordableType> = {
   Card: "Kanban::Card",
+  Chat: "Chat::Transcript",
   ChatLine: "Chat::Line",
   Ping: "Chat::Transcript",
   Message: "Message",
@@ -208,10 +209,21 @@ export function parseRecordingIdFromUrl(url: string): string | undefined {
   return match ? match[1] : undefined;
 }
 
-/** Extract recording ID from a readable_identifier (e.g., "Comment/123"). */
+/** Extract recording ID from a readable_identifier (e.g., "Comment/123" or base64-encoded GID). */
 export function parseRecordingIdFromIdentifier(identifier: string): string | undefined {
-  const match = /\/(\d+)$/.exec(identifier);
-  return match ? match[1] : undefined;
+  // Try matching directly first (plain GID like "Recording/123")
+  let match = /\/(\d+)$/.exec(identifier);
+  if (match) return match[1];
+
+  // Try base64-decoding — readings use base64-encoded GIDs
+  // (e.g., "Z2lkOi8vYmMzL1JlY29yZGluZy85NzI5MjgxMDg3" → "gid://bc3/Recording/9729281087")
+  try {
+    const decoded = Buffer.from(identifier, "base64").toString("utf-8");
+    match = /Recording\/(\d+)/.exec(decoded);
+    if (match) return match[1];
+  } catch { /* not base64 — fall through */ }
+
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -466,7 +478,7 @@ export function normalizeReadingsEvent(
     return null;
   }
 
-  const isPing = raw.type === "Ping";
+  const isPing = raw.type === "Ping" || raw.app_url?.includes("/circles/") === true;
   // readings participants uses other_circle_people() which excludes the caller — add 1.
   const participantCount = raw.participants ? raw.participants.length + 1 : undefined;
 

--- a/src/outbound/send.ts
+++ b/src/outbound/send.ts
@@ -241,7 +241,12 @@ export async function postReplyToEvent(params: {
 
   // Pings: resolve the transcript ID from the circle's bucket ID
   if (parsed.prefix === "ping") {
-    const transcriptId = await resolvePingTranscriptCached(bucketId, account);
+    let transcriptId = await resolvePingTranscriptCached(bucketId, account);
+    // Fallback: when the Circle API returns 204 (e.g., single-account setups),
+    // use the inbound recordingId as the transcript ID.
+    if (!transcriptId && recordingId) {
+      transcriptId = recordingId;
+    }
     if (!transcriptId) {
       return { ok: false, message: `Could not resolve Ping transcript for circle bucket=${bucketId}` };
     }


### PR DESCRIPTION
## Problem

Ping (DM) messages received via the readings poller are dispatched but delivery always fails with `Not Found` or `Could not resolve Ping transcript`.

Three separate bugs compound to prevent DM delivery:

### 1. Readings API returns `type: "Chat"` for Pings

The Basecamp readings API returns `type: "Chat"` for Ping conversations, not `type: "Ping"`. This type was not in `READINGS_TYPE_MAP`, causing events to be dropped as unknown kind.

Additionally, `isPing` was only checking `raw.type === "Ping"`, missing the Chat-typed Pings. Extended to also check `app_url` for `/circles/` (consistent with the activity normalizer on line 382).

### 2. `parseRecordingIdFromIdentifier` doesn't decode base64

The readings `readable_identifier` field is a base64-encoded GID:
```
Z2lkOi8vYmMzL1JlY29yZGluZy85NzI5MjgxMDg3 → gid://bc3/Recording/9729281087
```

The regex `/\/([0-9]+)$/` was applied to the raw base64 string, which never matches. The function fell through to `String(raw.id)` — the readings *entry* ID, not the recording (transcript) ID. This caused the outbound to POST to a non-existent transcript.

### 3. Circle API returns 204 No Content

`resolveCircleInfoCached` calls `GET /circles/{bucketId}.json` to discover the transcript ID via `room_url`. In observed setups, this endpoint returns HTTP 204 with no body, so transcript resolution fails.

Added a fallback in `postReplyToEvent`: when the circle lookup returns nothing, use the inbound `recordingId` (now correctly resolved via fix #2) as the transcript ID.

## Changes

- **`src/inbound/normalize.ts`**: Added `Chat` to `READINGS_TYPE_MAP`, extended `isPing` to check `app_url`, and added base64 decoding to `parseRecordingIdFromIdentifier`
- **`src/outbound/send.ts`**: Added `recordingId` fallback when circle transcript lookup fails

## Testing

All 1155 existing tests pass (65 suites, 0 failures). Verified end-to-end: Ping DM → readings poll → dispatch → reply delivered to Basecamp.