### PR TITLE
Drop resolveRecipients from heartbeat adapter

### DIFF
--- a/src/adapters/heartbeat.ts
+++ b/src/adapters/heartbeat.ts
@@ -1,8 +1,7 @@
 /**
  * Basecamp heartbeat adapter — delivery health checks.
  *
- * Implements ChannelHeartbeatAdapter for verifying auth readiness
- * and resolving heartbeat message recipients.
+ * Implements ChannelHeartbeatAdapter for verifying auth readiness.
  *
  * For all token sources, uses the SDK client to verify the access token
  * is valid (auto-refreshing for OAuth accounts).
@@ -27,21 +26,5 @@ export const basecampHeartbeatAdapter: ChannelHeartbeatAdapter = {
     } catch (err) {
       return { ok: false, reason: `Auth check failed: ${String(err)}` };
     }
-  },
-
-  resolveRecipients: ({ cfg, opts }) => {
-    // Explicit recipients from opts
-    if (opts?.to) {
-      return {
-        recipients: [opts.to],
-        source: "explicit",
-      };
-    }
-
-    // allowFrom contains person IDs, but ping peer IDs require circle bucket
-    // IDs (not person IDs). We cannot map person IDs to ping targets without
-    // an API call to discover the circle. Return empty — heartbeat delivery
-    // for Basecamp requires an explicit --to flag with a valid peer ID.
-    return { recipients: [], source: "none" };
   },
 };

--- a/tests/heartbeat.test.ts
+++ b/tests/heartbeat.test.ts
@@ -124,37 +124,3 @@ describe("heartbeat.checkReady", () => {
     expect(result.reason).toContain("Auth check failed");
   });
 });
-
-// ---------------------------------------------------------------------------
-// resolveRecipients
-// ---------------------------------------------------------------------------
-
-describe("heartbeat.resolveRecipients", () => {
-  it("returns explicit recipient", () => {
-    const result = basecampHeartbeatAdapter.resolveRecipients!({
-      cfg: cfg({}),
-      opts: { to: "ping:42" },
-    });
-
-    expect(result.recipients).toEqual(["ping:42"]);
-    expect(result.source).toBe("explicit");
-  });
-
-  it("returns empty when only allowFrom is available (person IDs cannot be mapped to ping peers)", () => {
-    const result = basecampHeartbeatAdapter.resolveRecipients!({
-      cfg: cfg({ allowFrom: ["100", "200"] }),
-    });
-
-    expect(result.recipients).toEqual([]);
-    expect(result.source).toBe("none");
-  });
-
-  it("returns empty when no recipients available", () => {
-    const result = basecampHeartbeatAdapter.resolveRecipients!({
-      cfg: cfg({}),
-    });
-
-    expect(result.recipients).toEqual([]);
-    expect(result.source).toBe("none");
-  });
-});


### PR DESCRIPTION
openclaw 2026.6.11 removed `resolveRecipients` from `ChannelHeartbeatAdapter` (recipient resolution moved out of the plugin surface entirely), so main no longer typechecks — this landed silently via the auto-merged dependabot bumps in #139/#140, whose CI results arrived after the merge.

The Basecamp implementation was a no-op anyway: it returned no recipients unless an explicit `--to` was given, which the runtime now handles itself. Deleting the slot and its tests loses nothing.

Verified locally against openclaw 2026.6.11: `tsc --noEmit` clean, 1152 tests pass, biome clean.